### PR TITLE
Add CI and publish workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,17 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - name: Build
+        run: cargo build --verbose
+      - name: Test
+        run: cargo test --all --verbose

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,29 @@
+name: Publish
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - name: Ensure tag matches version
+        run: |
+          version=$(grep '^version = ' Cargo.toml | head -n 1 | cut -d '"' -f2)
+          tag=${GITHUB_REF_NAME}
+          if [ "v$version" != "$tag" ]; then
+            echo "Version mismatch: Cargo.toml has $version but tag is $tag"
+            exit 1
+          fi
+      - name: Build
+        run: cargo build --verbose
+      - name: Test
+        run: cargo test --all --verbose
+      - name: Publish to crates.io
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+        run: cargo publish --locked


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow for building and testing
- add publish workflow to deploy crate to crates.io on version tags with version validation

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_689cdde060a0832b820638e9938e01d9