### PR TITLE
Add separate CI workflows for tests, lint, and coverage

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,0 +1,22 @@
+name: Coverage
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  coverage:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - name: Run Tarpaulin
+        uses: actions-rs/tarpaulin@v0.1
+        with:
+          version: '0.26.5'
+          args: '--out Xml'
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v4
+        with:
+          files: cobertura.xml

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,17 @@
+name: Lint
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: clippy
+      - name: Clippy
+        run: cargo clippy --all-targets

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,4 +1,4 @@
-name: CI
+name: Test
 
 on:
   push:
@@ -6,12 +6,10 @@ on:
   pull_request:
 
 jobs:
-  build:
+  test:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
-      - name: Build
-        run: cargo build --verbose
       - name: Test
         run: cargo test --all --verbose

--- a/README.md
+++ b/README.md
@@ -4,6 +4,9 @@
 [![Documentation](https://docs.rs/kofft/badge.svg)](https://docs.rs/kofft)
 [![License](https://img.shields.io/crates/l/kofft)](https://github.com/kianostad/kofft/blob/main/LICENSE)
 [![Rust Version](https://img.shields.io/badge/rust-1.70+-blue.svg)](https://www.rust-lang.org)
+[![Test](https://github.com/kianostad/kofft/actions/workflows/test.yml/badge.svg)](https://github.com/kianostad/kofft/actions/workflows/test.yml)
+[![Lint](https://github.com/kianostad/kofft/actions/workflows/lint.yml/badge.svg)](https://github.com/kianostad/kofft/actions/workflows/lint.yml)
+[![codecov](https://codecov.io/gh/kianostad/kofft/branch/main/graph/badge.svg)](https://codecov.io/gh/kianostad/kofft)
 
 High-performance, `no_std`, MCU-friendly DSP library featuring FFT, DCT, DST, Hartley, Wavelet, STFT, and more. Stack-only, SIMD-optimized, and batch transforms for embedded and scientific Rust applications.
 


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow for running tests
- add lint workflow using clippy
- generate coverage with tarpaulin and upload to Codecov
- show workflow and coverage badges in README

## Testing
- `cargo clippy --all-targets`
- `cargo test --all --verbose`
- `cargo tarpaulin --out Xml`


------
https://chatgpt.com/codex/tasks/task_e_689d0aa37380832bb3663a1674c0bebd