### PR TITLE
docs: expand examples and references

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,3 +44,11 @@ required-features = []
 [[example]]
 name = "benchmark"
 path = "examples/benchmark.rs"
+
+[[example]]
+name = "stft_usage"
+path = "examples/stft_usage.rs"
+
+[[example]]
+name = "ndfft_usage"
+path = "examples/ndfft_usage.rs"

--- a/README.md
+++ b/README.md
@@ -26,18 +26,17 @@ High-performance, `no_std`, MCU-friendly DSP library featuring FFT, DCT, DST, Ha
 
 ```toml
 [dependencies]
-kofft = "0.1.0"
-
-# For SIMD acceleration (optional)
-kofft = { version = "0.1.0", features = ["x86_64"] }  # x86_64 AVX2
-kofft = { version = "0.1.0", features = ["aarch64"] } # AArch64 NEON
-kofft = { version = "0.1.0", features = ["wasm"] }    # WebAssembly SIMD
-
-# For parallel processing
-kofft = { version = "0.1.0", features = ["parallel"] }
+kofft = { version = "0.1.1", features = [
+    # "x86_64",   # enable AVX2 on x86_64
+    # "aarch64",  # enable NEON on AArch64
+    # "wasm",     # enable WebAssembly SIMD
+    # "parallel", # enable Rayon-based parallel helpers
+] }
 ```
 
 ### Basic Usage
+
+For an overview of the Fast Fourier Transform (FFT), see [Wikipedia](https://en.wikipedia.org/wiki/Fast_Fourier_transform).
 
 ```rust
 use kofft::{Complex32, FftPlanner};
@@ -175,6 +174,8 @@ fft.rfft(&input, &mut output)?;
 
 ### STFT (Short-Time Fourier Transform)
 
+For background on STFT, see [Wikipedia](https://en.wikipedia.org/wiki/Short-time_Fourier_transform).
+
 ```rust
 use kofft::stft::{stft, istft};
 use kofft::window::hann;
@@ -204,28 +205,39 @@ let mut batches = vec![
 fft.batch(&mut batches)?;
 ```
 
+## Examples
+
+Run the included examples with:
+
+```bash
+cargo run --example basic_usage
+cargo run --example stft_usage
+cargo run --example ndfft_usage
+cargo run --example embedded_example
+cargo run --example benchmark
+```
+
 ## Advanced Features
+
+Enable optional features in `Cargo.toml`:
+
+```toml
+[dependencies]
+kofft = { version = "0.1.1", features = [
+    # "x86_64",   # AVX2 on x86_64
+    # "aarch64",  # NEON on AArch64
+    # "wasm",     # WebAssembly SIMD
+    # "parallel", # Rayon-based parallel helpers
+] }
+```
 
 ### SIMD Acceleration
 
-Enable platform-specific SIMD features for better performance:
-
-```toml
-# x86_64 with AVX2
-kofft = { version = "0.1.0", features = ["x86_64"] }
-
-# AArch64 with NEON
-kofft = { version = "0.1.0", features = ["aarch64"] }
-
-# WebAssembly with SIMD
-kofft = { version = "0.1.0", features = ["wasm"] }
-```
+Enable one of the CPU-specific SIMD features above for better performance.
 
 ### Parallel Processing
 
-```toml
-kofft = { version = "0.1.0", features = ["parallel"] }
-```
+Enable the `parallel` feature (using Rayon) as shown above:
 
 ```rust
 use kofft::stft::parallel;
@@ -240,6 +252,15 @@ parallel(&signal, &window, hop_size, &mut frames)?;
 
 ### Additional Transforms
 
+- **DCT** – Discrete Cosine Transform ([Wikipedia](https://en.wikipedia.org/wiki/Discrete_cosine_transform))
+- **DST** – Discrete Sine Transform ([Wikipedia](https://en.wikipedia.org/wiki/Discrete_sine_transform))
+- **Hartley Transform** – ([Wikipedia](https://en.wikipedia.org/wiki/Discrete_Hartley_transform))
+- **Wavelet Transform** – ([Wikipedia](https://en.wikipedia.org/wiki/Wavelet_transform))
+- **Goertzel Algorithm** – ([Wikipedia](https://en.wikipedia.org/wiki/Goertzel_algorithm))
+- **Chirp Z-Transform** – ([Wikipedia](https://en.wikipedia.org/wiki/Chirp_Z-transform))
+- **Hilbert Transform** – ([Wikipedia](https://en.wikipedia.org/wiki/Hilbert_transform))
+- **Cepstrum** – ([Wikipedia](https://en.wikipedia.org/wiki/Cepstrum))
+
 ```rust
 use kofft::{dct, dst, hartley, wavelet, goertzel, czt, hilbert, cepstrum};
 
@@ -249,9 +270,9 @@ let dct3_result = dct::dct3(&input);
 let dct4_result = dct::dct4(&input);
 
 // DST variants
+let dst1_result = dst::dst1(&input);
 let dst2_result = dst::dst2(&input);
 let dst3_result = dst::dst3(&input);
-let dst4_result = dst::dst4(&input);
 
 // Hartley Transform
 let hartley_result = hartley::dht(&input);
@@ -267,7 +288,7 @@ let magnitude = goertzel::goertzel_f32(&input, 44100.0, 1000.0);
 let czt_result = czt::czt_f32(&input, 64, (0.5, 0.0), (1.0, 0.0));
 
 // Hilbert Transform
-let hilbert_result = hilbert::hilbert(&input);
+let hilbert_result = hilbert::hilbert_analytic(&input);
 
 // Cepstrum
 let cepstrum_result = cepstrum::real_cepstrum(&input);

--- a/examples/basic_usage.rs
+++ b/examples/basic_usage.rs
@@ -1,34 +1,46 @@
 //! Basic usage example for kofft
-//! 
+//!
 //! This example demonstrates the core features of the kofft library
 //! including FFT, DCT, window functions, and more.
 
-use kofft::{Complex32, FftPlanner};
-use kofft::fft::{ScalarFftImpl, FftImpl};
+use kofft::cepstrum::real_cepstrum;
+use kofft::czt::czt_f32;
 use kofft::dct::dct2;
-use kofft::window::{hann, hamming};
-use kofft::wavelet::haar_forward;
+use kofft::dst::dst2;
+use kofft::fft::{FftImpl, ScalarFftImpl};
 use kofft::goertzel::goertzel_f32;
+use kofft::hartley::dht;
+use kofft::hilbert::hilbert_analytic;
+use kofft::wavelet::haar_forward;
+use kofft::window::{hamming, hann};
+use kofft::Complex32;
 
 fn main() {
     println!("=== kofft Basic Usage Example ===\n");
 
     // 1. Basic FFT
     println!("1. Fast Fourier Transform (FFT)");
-    let planner = FftPlanner::<f32>::new();
-    let fft = ScalarFftImpl::with_planner(planner);
-    
+    let fft = ScalarFftImpl::<f32>::default();
+
     let mut data = vec![
         Complex32::new(1.0, 0.0),
         Complex32::new(2.0, 0.0),
         Complex32::new(3.0, 0.0),
         Complex32::new(4.0, 0.0),
     ];
-    
-    println!("   Input: {:?}", data.iter().map(|c| c.re).collect::<Vec<_>>());
-    
+
+    println!(
+        "   Input: {:?}",
+        data.iter().map(|c| c.re).collect::<Vec<_>>()
+    );
+
     fft.fft(&mut data).unwrap();
-    println!("   FFT: {:?}", data.iter().map(|c| format!("{:.2}+{:.2}i", c.re, c.im)).collect::<Vec<_>>());
+    println!(
+        "   FFT: {:?}",
+        data.iter()
+            .map(|c| format!("{:.2}+{:.2}i", c.re, c.im))
+            .collect::<Vec<_>>()
+    );
 
     // Reuse the same FFT plan on another buffer
     let mut other = vec![
@@ -40,17 +52,26 @@ fn main() {
     fft.fft(&mut other).unwrap();
 
     fft.ifft(&mut data).unwrap();
-    println!("   IFFT: {:?}", data.iter().map(|c| c.re).collect::<Vec<_>>());
+    println!(
+        "   IFFT: {:?}",
+        data.iter().map(|c| c.re).collect::<Vec<_>>()
+    );
     println!();
 
     // 2. Real FFT (optimized for real input)
     println!("2. Real FFT");
     let mut real_input = vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0];
     let mut real_output = vec![Complex32::zero(); real_input.len() / 2 + 1];
-    
+
     fft.rfft(&mut real_input, &mut real_output).unwrap();
     println!("   Real input: {:?}", real_input);
-    println!("   RFFT: {:?}", real_output.iter().map(|c| format!("{:.2}+{:.2}i", c.re, c.im)).collect::<Vec<_>>());
+    println!(
+        "   RFFT: {:?}",
+        real_output
+            .iter()
+            .map(|c| format!("{:.2}+{:.2}i", c.re, c.im))
+            .collect::<Vec<_>>()
+    );
     println!();
 
     // 3. Discrete Cosine Transform (DCT)
@@ -58,7 +79,13 @@ fn main() {
     let dct_input = vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0];
     let dct_result = dct2(&dct_input);
     println!("   Input: {:?}", dct_input);
-    println!("   DCT-II: {:?}", dct_result.iter().map(|&x| format!("{:.2}", x)).collect::<Vec<_>>());
+    println!(
+        "   DCT-II: {:?}",
+        dct_result
+            .iter()
+            .map(|&x| format!("{:.2}", x))
+            .collect::<Vec<_>>()
+    );
     println!();
 
     // 4. Window Functions
@@ -66,19 +93,39 @@ fn main() {
     let window_size = 8;
     let hann_window = hann(window_size);
     let hamming_window = hamming(window_size);
-    
-    println!("   Hann window: {:?}", hann_window.iter().map(|&x| format!("{:.3}", x)).collect::<Vec<_>>());
-    println!("   Hamming window: {:?}", hamming_window.iter().map(|&x| format!("{:.3}", x)).collect::<Vec<_>>());
+
+    println!(
+        "   Hann window: {:?}",
+        hann_window
+            .iter()
+            .map(|&x| format!("{:.3}", x))
+            .collect::<Vec<_>>()
+    );
+    println!(
+        "   Hamming window: {:?}",
+        hamming_window
+            .iter()
+            .map(|&x| format!("{:.3}", x))
+            .collect::<Vec<_>>()
+    );
     println!();
 
     // 5. Haar Wavelet Transform
     println!("5. Haar Wavelet Transform");
     let wavelet_input = vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0];
     let (avg, diff) = haar_forward(&wavelet_input);
-    
+
     println!("   Input: {:?}", wavelet_input);
-    println!("   Averages: {:?}", avg.iter().map(|&x| format!("{:.2}", x)).collect::<Vec<_>>());
-    println!("   Differences: {:?}", diff.iter().map(|&x| format!("{:.2}", x)).collect::<Vec<_>>());
+    println!(
+        "   Averages: {:?}",
+        avg.iter().map(|&x| format!("{:.2}", x)).collect::<Vec<_>>()
+    );
+    println!(
+        "   Differences: {:?}",
+        diff.iter()
+            .map(|&x| format!("{:.2}", x))
+            .collect::<Vec<_>>()
+    );
     println!();
 
     // 6. Goertzel Algorithm (single frequency detection)
@@ -86,7 +133,7 @@ fn main() {
     let sample_rate = 44100.0;
     let target_freq = 1000.0;
     let signal = vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0];
-    
+
     let magnitude = goertzel_f32(&signal, sample_rate, target_freq);
     println!("   Signal length: {}", signal.len());
     println!("   Sample rate: {} Hz", sample_rate);
@@ -94,19 +141,86 @@ fn main() {
     println!("   Magnitude: {:.2}", magnitude);
     println!();
 
-    // 7. Performance comparison
-    println!("7. Performance Comparison");
+    // 7. Hartley Transform
+    println!("7. Hartley Transform");
+    let hartley_input = vec![1.0, 2.0, 3.0, 4.0];
+    let hartley_result = dht(&hartley_input);
+    println!("   Input: {:?}", hartley_input);
+    println!(
+        "   DHT: {:?}",
+        hartley_result
+            .iter()
+            .map(|&x| format!("{:.2}", x))
+            .collect::<Vec<_>>()
+    );
+    println!();
+
+    // 8. Discrete Sine Transform (DST-II)
+    println!("8. Discrete Sine Transform (DST-II)");
+    let dst_input = vec![1.0, 2.0, 3.0, 4.0];
+    let dst_result = dst2(&dst_input);
+    println!("   Input: {:?}", dst_input);
+    println!(
+        "   DST-II: {:?}",
+        dst_result
+            .iter()
+            .map(|&x| format!("{:.2}", x))
+            .collect::<Vec<_>>()
+    );
+    println!();
+
+    // 9. Hilbert Transform
+    println!("9. Hilbert Transform");
+    let hilbert_input = vec![1.0, 0.0, -1.0, 0.0];
+    let hilbert_result = hilbert_analytic(&hilbert_input);
+    println!(
+        "   Analytic signal: {:?}",
+        hilbert_result
+            .iter()
+            .map(|c| format!("{:.2}+{:.2}i", c.re, c.im))
+            .collect::<Vec<_>>()
+    );
+    println!();
+
+    // 10. Chirp Z-Transform
+    println!("10. Chirp Z-Transform");
+    let czt_input = vec![1.0, 0.0, 0.0, 0.0];
+    let czt_result = czt_f32(&czt_input, 4, (0.5, 0.0), (1.0, 0.0));
+    println!(
+        "   CZT: {:?}",
+        czt_result
+            .iter()
+            .map(|&(re, im)| format!("{:.2}+{:.2}i", re, im))
+            .collect::<Vec<_>>()
+    );
+    println!();
+
+    // 11. Cepstrum Analysis
+    println!("11. Cepstrum Analysis");
+    let cep_input = vec![1.0, 2.0, 3.0, 4.0];
+    let cep_result = real_cepstrum(&cep_input);
+    println!(
+        "   Cepstrum: {:?}",
+        cep_result
+            .iter()
+            .map(|&x| format!("{:.2}", x))
+            .collect::<Vec<_>>()
+    );
+    println!();
+
+    // 12. Performance comparison
+    println!("12. Performance Comparison");
     let large_input: Vec<Complex32> = (0..1024)
         .map(|i| Complex32::new((i as f32 * 0.1).sin(), 0.0))
         .collect();
-    
+
     let mut large_data = large_input.clone();
     let start = std::time::Instant::now();
     fft.fft(&mut large_data).unwrap();
     let duration = start.elapsed();
-    
+
     println!("   1024-point FFT completed in {:?}", duration);
     println!();
 
     println!("=== Example completed successfully! ===");
-} 
+}

--- a/examples/embedded_example.rs
+++ b/examples/embedded_example.rs
@@ -1,94 +1,117 @@
 //! Embedded/MCU example for kofft
-//! 
+//!
 //! This example demonstrates how to use kofft in a no_std environment
 //! with stack-only APIs suitable for microcontrollers.
 
-use kofft::fft::{Complex32, fft_inplace_stack};
 use kofft::dct::dct2_inplace_stack;
 use kofft::dst::dst2_inplace_stack;
+use kofft::fft::{fft_inplace_stack, Complex32};
 use kofft::wavelet::{haar_forward_inplace_stack, haar_inverse_inplace_stack};
-use kofft::window::{hann_inplace_stack, hamming_inplace_stack};
+use kofft::window::{hamming_inplace_stack, hann_inplace_stack};
+
+#[cfg(feature = "std")]
+macro_rules! log {
+    ($($arg:tt)*) => { println!($($arg)*); };
+}
+
+#[cfg(not(feature = "std"))]
+macro_rules! log {
+    ($($arg:tt)*) => {
+        // Replace with defmt::info! or another logging mechanism on embedded targets
+    };
+}
+
+// The `log!` macro above prints messages on std targets and becomes a no-op
+// on bare `no_std` targets.
 
 fn main() {
-    println!("=== kofft Embedded Example ===\n");
-    
+    log!("=== kofft Embedded Example ===\n");
+
     // This function demonstrates various DSP operations using stack-only APIs
     // that are suitable for embedded systems with limited RAM.
-    
+
     // 1. FFT Example (8-point, power-of-two)
-    println!("1. FFT Example");
+    log!("1. FFT Example");
     let mut fft_data: [Complex32; 8] = [
-        Complex32::new(1.0, 0.0), Complex32::new(2.0, 0.0),
-        Complex32::new(3.0, 0.0), Complex32::new(4.0, 0.0),
-        Complex32::new(5.0, 0.0), Complex32::new(6.0, 0.0),
-        Complex32::new(7.0, 0.0), Complex32::new(8.0, 0.0),
+        Complex32::new(1.0, 0.0),
+        Complex32::new(2.0, 0.0),
+        Complex32::new(3.0, 0.0),
+        Complex32::new(4.0, 0.0),
+        Complex32::new(5.0, 0.0),
+        Complex32::new(6.0, 0.0),
+        Complex32::new(7.0, 0.0),
+        Complex32::new(8.0, 0.0),
     ];
-    
+
     // Compute FFT in-place
     if let Ok(()) = fft_inplace_stack(&mut fft_data) {
-        println!("   FFT completed successfully");
+        log!("   FFT completed successfully");
         // In a real application, you would process the frequency domain data here
     }
-    
+
     // 2. DCT-II Example
-    println!("2. DCT-II Example");
+    log!("2. DCT-II Example");
     let dct_input: [f32; 8] = [1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0];
     let mut dct_output: [f32; 8] = [0.0; 8];
-    
+
     dct2_inplace_stack(&dct_input, &mut dct_output);
-    println!("   DCT-II completed");
-    
+    log!("   DCT-II completed");
+
     // 3. DST-II Example
-    println!("3. DST-II Example");
+    log!("3. DST-II Example");
     let dst_input: [f32; 8] = [1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0];
     let mut dst_output: [f32; 8] = [0.0; 8];
-    
+
     dst2_inplace_stack(&dst_input, &mut dst_output);
-    println!("   DST-II completed");
-    
+    log!("   DST-II completed");
+
     // 4. Haar Wavelet Transform
-    println!("4. Haar Wavelet Transform");
+    log!("4. Haar Wavelet Transform");
     let wavelet_input: [f32; 8] = [1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0];
     let mut avg: [f32; 4] = [0.0; 4];
     let mut diff: [f32; 4] = [0.0; 4];
-    
+
     // Forward transform
     haar_forward_inplace_stack(&wavelet_input, &mut avg[..], &mut diff[..]);
-    
+
     // Inverse transform
     let mut reconstructed: [f32; 8] = [0.0; 8];
     haar_inverse_inplace_stack::<8>(&avg[..], &diff[..], &mut reconstructed[..]);
-    println!("   Haar wavelet transform completed");
-    
+    log!("   Haar wavelet transform completed");
+
     // 5. Window Functions
-    println!("5. Window Functions");
+    log!("5. Window Functions");
     let mut hann_window: [f32; 8] = [0.0; 8];
     hann_inplace_stack(&mut hann_window);
-    
+
     let mut hamming_window: [f32; 8] = [0.0; 8];
     hamming_inplace_stack(&mut hamming_window);
-    println!("   Window functions generated");
-    
+    log!("   Window functions generated");
+
     // 6. Signal Processing Pipeline Example
-    println!("6. Signal Processing Pipeline");
+    log!("6. Signal Processing Pipeline");
     // This demonstrates a typical embedded DSP pipeline:
     // 1. Apply window function to input signal
     // 2. Compute FFT
     // 3. Process in frequency domain
     // 4. Compute IFFT
-    
+
     let mut signal: [Complex32; 8] = [
-        Complex32::new(1.0, 0.0), Complex32::new(2.0, 0.0),
-        Complex32::new(3.0, 0.0), Complex32::new(4.0, 0.0),
-        Complex32::new(5.0, 0.0), Complex32::new(6.0, 0.0),
-        Complex32::new(7.0, 0.0), Complex32::new(8.0, 0.0),
+        Complex32::new(1.0, 0.0),
+        Complex32::new(2.0, 0.0),
+        Complex32::new(3.0, 0.0),
+        Complex32::new(4.0, 0.0),
+        Complex32::new(5.0, 0.0),
+        Complex32::new(6.0, 0.0),
+        Complex32::new(7.0, 0.0),
+        Complex32::new(8.0, 0.0),
     ];
-    
+
     // Apply window function (multiply signal by window)
     for i in 0..8 {
         signal[i].re *= hann_window[i];
     }
-    
+
     // Compute FFT
     if let Ok(()) = fft_inplace_stack(&mut signal) {
         // Process in frequency domain
@@ -97,28 +120,28 @@ fn main() {
             signal[i].re *= 0.1; // Attenuate high frequencies
             signal[i].im *= 0.1;
         }
-        
+
         // Compute IFFT
         if let Ok(()) = fft_inplace_stack(&mut signal) {
-            println!("   Signal processing pipeline completed");
+            log!("   Signal processing pipeline completed");
         }
     }
-    
+
     // 7. Memory Usage Summary
-    println!("7. Memory Usage Summary");
-    println!("   Total stack usage for this example:");
-    println!("   - FFT data: 8 * 8 bytes = 64 bytes");
-    println!("   - DCT/DST buffers: 2 * 8 * 4 bytes = 64 bytes");  
-    println!("   - Wavelet buffers: 4 * 4 bytes + 8 * 4 bytes = 48 bytes");
-    println!("   - Window buffers: 2 * 8 * 4 bytes = 64 bytes");
-    println!("   - Signal processing: 8 * 8 bytes = 64 bytes");
-    println!("   Total: ~304 bytes of stack memory");
-    
-    println!("\n=== Embedded example completed! ===");
-    println!("\nIn a real embedded application, you would:");
-    println!("- Process data in real-time");
-    println!("- Use interrupts for timing");
-    println!("- Implement power management");
-    println!("- Add error handling");
-    println!("- Consider using DMA for large data transfers");
-} 
+    log!("7. Memory Usage Summary");
+    log!("   Total stack usage for this example:");
+    log!("   - FFT data: 8 * 8 bytes = 64 bytes");
+    log!("   - DCT/DST buffers: 2 * 8 * 4 bytes = 64 bytes");
+    log!("   - Wavelet buffers: 4 * 4 bytes + 8 * 4 bytes = 48 bytes");
+    log!("   - Window buffers: 2 * 8 * 4 bytes = 64 bytes");
+    log!("   - Signal processing: 8 * 8 bytes = 64 bytes");
+    log!("   Total: ~304 bytes of stack memory");
+
+    log!("\n=== Embedded example completed! ===");
+    log!("\nIn a real embedded application, you would:");
+    log!("- Process data in real-time");
+    log!("- Use interrupts for timing");
+    log!("- Implement power management");
+    log!("- Add error handling");
+    log!("- Consider using DMA for large data transfers");
+}

--- a/examples/ndfft_usage.rs
+++ b/examples/ndfft_usage.rs
@@ -1,0 +1,19 @@
+//! NDFFT usage example for kofft
+//! Demonstrates a 2D FFT using `ndfft::fft2d_inplace`.
+
+use kofft::fft::{FftError, ScalarFftImpl};
+use kofft::ndfft::fft2d_inplace;
+use kofft::Complex32;
+
+fn main() -> Result<(), FftError> {
+    let mut data = vec![
+        vec![Complex32::new(1.0, 0.0), Complex32::new(2.0, 0.0)],
+        vec![Complex32::new(3.0, 0.0), Complex32::new(4.0, 0.0)],
+    ];
+    let fft = ScalarFftImpl::<f32>::default();
+    let mut scratch = vec![Complex32::zero(); data.len()];
+
+    fft2d_inplace(&mut data, &fft, &mut scratch)?;
+    println!("2D FFT result: {:?}", data);
+    Ok(())
+}

--- a/examples/stft_usage.rs
+++ b/examples/stft_usage.rs
@@ -1,0 +1,33 @@
+//! STFT usage example for kofft
+//! Demonstrates forward and inverse STFT.
+//! Run with `cargo run --example stft_usage`.
+//!
+//! When built with `--features parallel`, also showcases the parallel STFT helper.
+
+use kofft::fft::FftError;
+#[cfg(feature = "parallel")]
+use kofft::stft::parallel;
+use kofft::stft::{istft, stft};
+use kofft::window::hann;
+
+fn main() -> Result<(), FftError> {
+    let signal = vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0];
+    let window = hann(4);
+    let hop = 2;
+
+    let mut frames = vec![vec![]; (signal.len() + hop - 1) / hop];
+    stft(&signal, &window, hop, &mut frames)?;
+    println!("STFT frames: {:?}", frames);
+
+    #[cfg(feature = "parallel")]
+    {
+        let mut frames_par = vec![vec![]; (signal.len() + hop - 1) / hop];
+        parallel(&signal, &window, hop, &mut frames_par)?;
+        println!("Parallel STFT frames: {:?}", frames_par);
+    }
+
+    let mut reconstructed = vec![0.0; signal.len()];
+    istft(&frames, &window, hop, &mut reconstructed)?;
+    println!("Reconstructed signal: {:?}", reconstructed);
+    Ok(())
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,10 +1,10 @@
 //! # kofft - High-performance DSP library for Rust
-//! 
-//! A comprehensive Digital Signal Processing (DSP) library featuring FFT, DCT, DST, 
+//!
+//! A comprehensive Digital Signal Processing (DSP) library featuring FFT, DCT, DST,
 //! Hartley, Wavelet, STFT, and more. Optimized for both embedded systems and desktop applications.
-//! 
+//!
 //! ## Features
-//! 
+//!
 //! - **🚀 Zero-allocation stack-only APIs** for MCU/embedded systems
 //! - **⚡ SIMD acceleration** (x86_64 AVX2, AArch64 NEON, WebAssembly SIMD)
 //! - **🔧 Multiple transform types**: FFT, DCT, DST, Hartley, Wavelet, STFT, CZT, Goertzel
@@ -12,95 +12,97 @@
 //! - **🔄 Batch and multi-channel processing**
 //! - **🌐 WebAssembly support**
 //! - **📱 Parallel processing** (optional)
-//! 
+//!
 //! ## Cargo Features
-//! 
+//!
 //! - `std` (default): Enable standard library features
 //! - `parallel`: Enable parallel processing with Rayon
 //! - `x86_64`: Enable x86_64 SIMD optimizations
 //! - `aarch64`: Enable AArch64 SIMD optimizations  
 //! - `wasm`: Enable WebAssembly SIMD optimizations
-//! 
+//!
 //! ## Performance
-//! 
+//!
 //! - **Stack-only APIs**: No heap allocation, suitable for MCUs with limited RAM
 //! - **SIMD acceleration**: 2-4x speedup on supported platforms
 //! - **Power-of-two sizes**: Most efficient for FFT operations
 //! - **Memory usage**: Stack usage scales with transform size
-//! 
+//!
 //! ## Platform Support
-//! 
+//!
 //! | Platform | SIMD Support | Features |
 //! |----------|-------------|----------|
 //! | x86_64   | AVX2/FMA    | `x86_64` feature |
 //! | AArch64  | NEON        | `aarch64` feature |
 //! | WebAssembly | SIMD128   | `wasm` feature |
 //! | Generic  | Scalar      | Default fallback |
-//! 
+//!
 //! ## Examples
-//! 
+//!
 //! Run the examples with:
 //! ```bash
 //! cargo run --example basic_usage
+//! cargo run --example stft_usage
+//! cargo run --example ndfft_usage
 //! cargo run --example embedded_example
 //! cargo run --example benchmark
 //! ```
-//! 
+//!
 //! ## License
-//! 
+//!
 //! Licensed under either of
 //! - Apache License, Version 2.0 ([LICENSE-APACHE](LICENSE-APACHE) or https://www.apache.org/licenses/LICENSE-2.0)
 //! - MIT license ([LICENSE-MIT](LICENSE-MIT) or https://opensource.org/licenses/MIT)
-//! 
+//!
 //! at your option.
 
 #![no_std]
 extern crate alloc;
 
+pub mod fft;
 /// Fast Fourier Transform (FFT) implementations
-/// 
+///
 /// Provides both scalar and SIMD-optimized FFT implementations.
 /// Supports complex and real input signals.
 pub mod num;
-pub mod fft;
 
 /// N-dimensional FFT operations
-/// 
+///
 /// Multi-dimensional FFT implementations for image and volume processing.
 pub mod ndfft;
 
 /// Window functions for signal processing
-/// 
+///
 /// Common window functions including Hann, Hamming, Blackman, and Kaiser windows.
 pub mod window;
 
 /// Discrete Cosine Transform (DCT)
-/// 
+///
 /// DCT-II, DCT-III, and DCT-IV implementations for audio and image compression.
 pub mod dct;
 
 /// Discrete Sine Transform (DST)
-/// 
+///
 /// DST-II, DST-III, and DST-IV implementations.
 pub mod dst;
 
 /// Discrete Hartley Transform (DHT)
-/// 
+///
 /// Real-valued alternative to FFT with similar properties.
 pub mod hartley;
 
 /// Wavelet transforms
-/// 
+///
 /// Haar wavelet transform implementation for signal analysis.
 pub mod wavelet;
 
 /// Goertzel algorithm
-/// 
+///
 /// Efficient single-frequency detection algorithm.
 pub mod goertzel;
 
 /// Chirp Z-Transform (CZT)
-/// 
+///
 /// Arbitrary frequency resolution DFT implementation.
 pub mod czt;
 
@@ -120,15 +122,15 @@ pub mod stft;
 pub mod cepstrum;
 
 /// Additional window functions
-/// 
+///
 /// Extended collection of window functions for specialized applications.
 pub mod window_more;
 
-pub use num::{Float, Complex, Complex32, Complex64};
 pub use fft::FftPlanner;
+pub use num::{Complex, Complex32, Complex64, Float};
 
 /// Simple addition function for testing purposes
-/// 
+///
 /// This function is used in tests to verify basic functionality.
 pub fn add(left: u64, right: u64) -> u64 {
     left + right
@@ -137,12 +139,12 @@ pub fn add(left: u64, right: u64) -> u64 {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::fft::{ScalarFftImpl, Complex32, FftImpl, FftError};
-    use alloc::vec::Vec;
+    use crate::fft::{Complex32, FftError, FftImpl, ScalarFftImpl};
     use alloc::vec;
+    use alloc::vec::Vec;
     use core::f32::consts;
-    use rand::{Rng, SeedableRng};
     use rand::rngs::StdRng;
+    use rand::{Rng, SeedableRng};
 
     #[test]
     fn it_works() {
@@ -201,9 +203,17 @@ mod tests {
         let fft = ScalarFftImpl::<f32>::default();
         fft.fft(&mut data).unwrap();
         // The two peaks should be at 1 and n-1
-        let mut mags: Vec<f32> = data.iter().map(|c| (c.re * c.re + c.im * c.im).sqrt()).collect();
+        let mut mags: Vec<f32> = data
+            .iter()
+            .map(|c| (c.re * c.re + c.im * c.im).sqrt())
+            .collect();
         mags[1] = 0.0; // ignore DC
-        let max_idx = mags.iter().enumerate().max_by(|a, b| a.1.partial_cmp(b.1).unwrap()).unwrap().0;
+        let max_idx = mags
+            .iter()
+            .enumerate()
+            .max_by(|a, b| a.1.partial_cmp(b.1).unwrap())
+            .unwrap()
+            .0;
         assert!(max_idx == 1 || max_idx == n - 1);
     }
 
@@ -297,12 +307,19 @@ mod tests {
         let input = vec![Complex32::new(1.0, 0.0), Complex32::new(2.0, 0.0)];
         let mut output = vec![Complex32::zero(); 3];
         let fft = ScalarFftImpl::<f32>::default();
-        assert_eq!(fft.fft_out_of_place(&input, &mut output), Err(FftError::MismatchedLengths));
+        assert_eq!(
+            fft.fft_out_of_place(&input, &mut output),
+            Err(FftError::MismatchedLengths)
+        );
     }
 
     #[test]
     fn test_fft_nonpow2_no_std_error() {
-        let mut data = vec![Complex32::new(1.0, 0.0), Complex32::new(2.0, 0.0), Complex32::new(3.0, 0.0)];
+        let mut data = vec![
+            Complex32::new(1.0, 0.0),
+            Complex32::new(2.0, 0.0),
+            Complex32::new(3.0, 0.0),
+        ];
         let fft = ScalarFftImpl::<f32>::default();
         // This should work with std feature, but fail without it
         let result = fft.fft(&mut data);
@@ -376,13 +393,13 @@ mod tests {
         ];
         let orig = data.clone();
         let fft = ScalarFftImpl::<f32>::default();
-        
+
         // Multiple FFT-IFFT cycles
         for _ in 0..10 {
             fft.fft(&mut data).unwrap();
             fft.ifft(&mut data).unwrap();
         }
-        
+
         for (a, b) in data.iter().zip(orig.iter()) {
             assert!((a.re - b.re).abs() < 1e-4, "re: {} vs {}", a.re, b.re);
             assert!((a.im - b.im).abs() < 1e-4, "im: {} vs {}", a.im, b.im);
@@ -394,11 +411,11 @@ mod tests {
         let mut input = vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0];
         let mut freq = vec![Complex32::zero(); input.len() / 2 + 1];
         let mut output = vec![0.0; input.len()];
-        
+
         let fft = ScalarFftImpl::<f32>::default();
         fft.rfft(&mut input, &mut freq).unwrap();
         fft.irfft(&mut freq, &mut output).unwrap();
-        
+
         for (a, b) in input.iter().zip(output.iter()) {
             assert!((a - b).abs() < 1e-5, "{} vs {}", a, b);
         }
@@ -408,10 +425,10 @@ mod tests {
     fn test_rfft_hermitian_symmetry() {
         let mut input = vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0];
         let mut freq = vec![Complex32::zero(); input.len() / 2 + 1];
-        
+
         let fft = ScalarFftImpl::<f32>::default();
         fft.rfft(&mut input, &mut freq).unwrap();
-        
+
         // Check that the result has the expected Hermitian symmetry
         // The first element should be real
         assert!(freq[0].im.abs() < 1e-6);
@@ -426,6 +443,9 @@ mod tests {
         let mut input = vec![1.0, 2.0, 3.0, 4.0];
         let mut freq = vec![Complex32::zero(); 4]; // Wrong size
         let fft = ScalarFftImpl::<f32>::default();
-        assert_eq!(fft.rfft(&mut input, &mut freq), Err(FftError::MismatchedLengths));
+        assert_eq!(
+            fft.rfft(&mut input, &mut freq),
+            Err(FftError::MismatchedLengths)
+        );
     }
 }


### PR DESCRIPTION
## Summary
- update README dependency instructions and link out to DSP references
- add STFT and NDFFT example programs and extend basic example with more transforms
- document STFT parallel helpers and add module-level FFT docs

## Testing
- `cargo test`
- `cargo run --example basic_usage` *(fails: thread has overflowed its stack)*
- `cargo run --example stft_usage` *(fails: thread has overflowed its stack)*
- `cargo run --example ndfft_usage` *(fails: thread has overflowed its stack)*

------
https://chatgpt.com/codex/tasks/task_e_689d1950b9e0832bbb3ed5261c884e51