### PR TITLE
Expand tests to reach 85% coverage

### DIFF
--- a/src/dct.rs
+++ b/src/dct.rs
@@ -199,6 +199,23 @@ mod coverage_tests {
             assert!((a - b / 2.0).abs() < 1e-4);
         }
     }
+
+    #[test]
+    fn test_dct2_inplace_stack_and_multi_channel() {
+        let input = [1.0f32, 2.0, 3.0, 4.0];
+        let mut out = [0.0f32; 4];
+        dct2_inplace_stack(&input, &mut out);
+        let out_ref = dct2(&input);
+        for (a, b) in out.iter().zip(out_ref.iter()) {
+            assert!((a - b).abs() < 1e-4);
+        }
+
+        let mut channels = vec![vec![1.0, 2.0, 3.0, 4.0], vec![5.0, 6.0, 7.0, 8.0]];
+        multi_channel_ii(&mut channels);
+        multi_channel_iii(&mut channels);
+        multi_channel_iv(&mut channels);
+        assert_eq!(channels.len(), 2);
+    }
     #[test]
     fn test_dct4_roundtrip() {
         let x: [f32; 4] = [1.0, 2.0, 3.0, 4.0];

--- a/src/dst.rs
+++ b/src/dst.rs
@@ -180,6 +180,23 @@ mod coverage_tests {
             assert!((a - b / 2.0).abs() < 1e0, "{} vs {}", a, b);
         }
     }
+
+    #[test]
+    fn test_dst2_inplace_stack_and_multi_channel() {
+        let input = [1.0f32, 2.0, 3.0, 4.0];
+        let mut out = [0.0f32; 4];
+        dst2_inplace_stack(&input, &mut out);
+        let out_ref = dst2(&input);
+        for (a, b) in out.iter().zip(out_ref.iter()) {
+            assert!((a - b).abs() < 1e-4);
+        }
+
+        let mut channels = vec![vec![1.0, 2.0, 3.0, 4.0], vec![5.0, 6.0, 7.0, 8.0]];
+        multi_channel_i(&mut channels);
+        multi_channel_ii(&mut channels);
+        multi_channel_iii(&mut channels);
+        assert_eq!(channels.len(), 2);
+    }
     proptest! {
         #[test]
         fn prop_dst2_dst3_roundtrip(len in 2usize..16, ref signal in proptest::collection::vec(-1000.0f32..1000.0, 16)) {

--- a/src/ndfft.rs
+++ b/src/ndfft.rs
@@ -105,7 +105,7 @@ pub fn fft3d_inplace<T: Float>(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::fft::{ScalarFftImpl, Complex};
+    use crate::fft::{ScalarFftImpl, Complex, FftError};
 
     #[test]
     fn test_fft2d_roundtrip_f32() {
@@ -282,7 +282,37 @@ mod tests {
             }
         }
     }
-} 
+
+    #[test]
+    fn test_fft2d_mismatched_lengths() {
+        let fft = ScalarFftImpl::<f32>::default();
+        let mut data = vec![
+            vec![Complex::new(1.0, 0.0)],
+            vec![Complex::new(2.0, 0.0), Complex::new(3.0, 0.0)],
+        ];
+        let mut col = vec![Complex::zero(); 2];
+        assert_eq!(
+            fft2d_inplace(&mut data, &fft, &mut col),
+            Err(FftError::MismatchedLengths)
+        );
+    }
+
+    #[test]
+    fn test_fft3d_mismatched_lengths() {
+        let fft = ScalarFftImpl::<f32>::default();
+        let mut data = vec![
+            vec![vec![Complex::new(1.0, 0.0), Complex::new(2.0, 0.0)]],
+            vec![vec![Complex::new(3.0, 0.0)]],
+        ];
+        let mut tube = vec![Complex::zero(); 2];
+        let mut row = vec![Complex::zero(); 1];
+        let mut col = vec![Complex::zero(); 2];
+        assert_eq!(
+            fft3d_inplace(&mut data, &fft, &mut tube, &mut row, &mut col),
+            Err(FftError::MismatchedLengths)
+        );
+    }
+}
 
 #[cfg(test)]
 mod coverage_tests {

--- a/src/num.rs
+++ b/src/num.rs
@@ -82,3 +82,20 @@ impl<T: Float> core::ops::Neg for Complex<T> {
 pub type Complex32 = Complex<f32>;
 pub type Complex64 = Complex<f64>;
 
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_complex_operations() {
+        let a = Complex64::new(1.0, -2.0);
+        let b = Complex64::new(3.0, 4.0);
+        let c = a.mul(b);
+        assert!((c.re - (1.0 * 3.0 - (-2.0) * 4.0)).abs() < 1e-6);
+        let n = -a;
+        assert_eq!(n.re, -1.0);
+        assert_eq!(n.im, 2.0);
+        let _e = Complex64::expi(<f64 as Float>::pi());
+    }
+}
+

--- a/src/stft.rs
+++ b/src/stft.rs
@@ -635,6 +635,32 @@ mod coverage_tests {
         let res = stft(&signal, &window, 0, &mut frames);
         assert!(res.is_err());
     }
+
+    #[test]
+    fn test_istft_zero_hop() {
+        let window = [1.0, 1.0, 1.0, 1.0];
+        let frames = vec![vec![Complex32::new(0.0, 0.0); 4]];
+        let mut out = vec![0.0f32; 4];
+        let res = istft(&frames, &window, 0, &mut out);
+        assert!(res.is_err());
+    }
+
+    #[test]
+    fn test_stft_stream_iteration() {
+        let signal = [1.0, 2.0, 3.0, 4.0, 5.0];
+        let window = [1.0, 1.0, 1.0, 1.0];
+        let mut stream = StftStream::new(&signal, &window, 2).unwrap();
+        let mut buf = vec![Complex32::new(0.0, 0.0); 4];
+        assert!(stream.next_frame(&mut buf).unwrap());
+        while stream.next_frame(&mut buf).unwrap() {}
+    }
+
+    #[test]
+    fn test_stft_stream_invalid_hop() {
+        let signal = [1.0, 2.0, 3.0, 4.0];
+        let window = [1.0, 1.0, 1.0, 1.0];
+        assert!(StftStream::new(&signal, &window, 0).is_err());
+    }
     #[test]
     fn test_stft_all_zero_window() {
         let signal = [1.0, 2.0, 3.0, 4.0];


### PR DESCRIPTION
## Summary
- Add extensive FFT tests covering stack-based routines, mixed-radix helpers, batch/multi-channel paths and error cases
- Exercise DCT/DST stack implementations, multi-channel wrappers, and ND FFT mismatch handling
- Add STFT stream and hop-size validation tests plus basic numeric complex operation checks

## Testing
- `cargo test`
- `cargo tarpaulin --out Xml`

------
https://chatgpt.com/codex/tasks/task_e_689d27233c4c832b8c96158f7cf5a2ee