### PR TITLE
Fix radix-4 FFT check, hardened ISTFT stream, and window normalization

### DIFF
--- a/src/window.rs
+++ b/src/window.rs
@@ -55,8 +55,7 @@ pub fn blackman(len: usize) -> alloc::vec::Vec<f32> {
 /// Generate a Kaiser window of length `len` and shape parameter `beta`.
 #[cfg(feature = "std")]
 pub fn kaiser(len: usize, beta: f32) -> alloc::vec::Vec<f32> {
-    use core::f32::consts::PI;
-    let denom = sqrtf(PI * beta);
+    let denom = bessel0(beta);
     let m = (len - 1) as f32 / 2.0;
     (0..len)
         .map(|i| {
@@ -68,8 +67,7 @@ pub fn kaiser(len: usize, beta: f32) -> alloc::vec::Vec<f32> {
 
 #[cfg(not(feature = "std"))]
 pub fn kaiser(len: usize, beta: f32) -> alloc::vec::Vec<f32> {
-    use core::f32::consts::PI;
-    let denom = sqrtf(PI * beta);
+    let denom = bessel0(beta);
     let m = (len - 1) as f32 / 2.0;
     (0..len)
         .map(|i| {
@@ -128,8 +126,14 @@ mod tests {
     }
     #[test]
     fn test_kaiser() {
-        let w = kaiser(8, 5.0);
-        assert_eq!(w.len(), 8);
+        let w = kaiser(9, 5.0);
+        assert_eq!(w.len(), 9);
+        // Peak amplitude at center
+        assert!((w[4] - 1.0).abs() < 1e-6);
+        // Symmetry
+        for i in 0..w.len() {
+            assert!((w[i] - w[w.len() - 1 - i]).abs() < 1e-6);
+        }
         assert!(w.iter().all(|&x| x.is_finite()));
     }
 


### PR DESCRIPTION
## Summary
- ensure radix-4 FFT only falls back when size is not a power of four
- reuse buffers and propagate errors in ISTFT stream, validating frame sizes
- correct Kaiser window normalization and add symmetry tests
- avoid sharing non-Sync FFT state in parallel STFT

## Testing
- `cargo test`
- `cargo test --features parallel`
- `cargo tarpaulin --features parallel`


------
https://chatgpt.com/codex/tasks/task_e_689d2ecbedf8832bb3f5356e2c6aabb2