### PR TITLE
Add validation and edge-case handling across DSP modules

### DIFF
--- a/examples/basic_usage.rs
+++ b/examples/basic_usage.rs
@@ -134,7 +134,7 @@ fn main() {
     let target_freq = 1000.0;
     let signal = vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0];
 
-    let magnitude = goertzel_f32(&signal, sample_rate, target_freq);
+    let magnitude = goertzel_f32(&signal, sample_rate, target_freq).unwrap();
     println!("   Signal length: {}", signal.len());
     println!("   Sample rate: {} Hz", sample_rate);
     println!("   Target frequency: {} Hz", target_freq);
@@ -172,7 +172,7 @@ fn main() {
     // 9. Hilbert Transform
     println!("9. Hilbert Transform");
     let hilbert_input = vec![1.0, 0.0, -1.0, 0.0];
-    let hilbert_result = hilbert_analytic(&hilbert_input);
+    let hilbert_result = hilbert_analytic(&hilbert_input).unwrap();
     println!(
         "   Analytic signal: {:?}",
         hilbert_result
@@ -198,7 +198,7 @@ fn main() {
     // 11. Cepstrum Analysis
     println!("11. Cepstrum Analysis");
     let cep_input = vec![1.0, 2.0, 3.0, 4.0];
-    let cep_result = real_cepstrum(&cep_input);
+    let cep_result = real_cepstrum(&cep_input).unwrap();
     println!(
         "   Cepstrum: {:?}",
         cep_result

--- a/examples/embedded_example.rs
+++ b/examples/embedded_example.rs
@@ -54,7 +54,7 @@ fn main() {
     let dct_input: [f32; 8] = [1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0];
     let mut dct_output: [f32; 8] = [0.0; 8];
 
-    dct2_inplace_stack(&dct_input, &mut dct_output);
+    dct2_inplace_stack(&dct_input, &mut dct_output).unwrap();
     log!("   DCT-II completed");
 
     // 3. DST-II Example
@@ -62,7 +62,7 @@ fn main() {
     let dst_input: [f32; 8] = [1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0];
     let mut dst_output: [f32; 8] = [0.0; 8];
 
-    dst2_inplace_stack(&dst_input, &mut dst_output);
+    dst2_inplace_stack(&dst_input, &mut dst_output).unwrap();
     log!("   DST-II completed");
 
     // 4. Haar Wavelet Transform

--- a/src/cepstrum.rs
+++ b/src/cepstrum.rs
@@ -5,27 +5,34 @@
 extern crate alloc;
 use alloc::vec::Vec;
 use alloc::vec;
-use crate::fft::{ScalarFftImpl, Complex32, FftImpl};
+use crate::fft::{ScalarFftImpl, Complex32, FftImpl, FftError};
 use libm::{sqrtf, powf, floorf, logf, log10f};
 
 #[cfg(not(feature = "std"))]
 use libm::{sqrtf, logf, log10f, powf, floorf};
 
 /// Compute the real cepstrum of a real input signal
-pub fn real_cepstrum(input: &[f32]) -> Vec<f32> {
+pub fn real_cepstrum(input: &[f32]) -> Result<Vec<f32>, FftError> {
+    if input.is_empty() {
+        return Err(FftError::EmptyInput);
+    }
+    if !input.len().is_power_of_two() {
+        return Err(FftError::NonPowerOfTwoNoStd);
+    }
     let n = input.len();
     let mut freq = vec![Complex32::zero(); n];
     for (i, &x) in input.iter().enumerate() {
         freq[i] = Complex32::new(x, 0.0);
     }
-    ScalarFftImpl::<f32>::default().fft(&mut freq).unwrap();
+    let fft = ScalarFftImpl::<f32>::default();
+    fft.fft(&mut freq)?;
     for c in freq.iter_mut() {
         let mag = sqrtf(c.re * c.re + c.im * c.im);
         c.re = logf(mag + 1e-12); // avoid log(0)
         c.im = 0.0;
     }
-    ScalarFftImpl::<f32>::default().ifft(&mut freq).unwrap();
-    freq.iter().map(|c| c.re).collect()
+    fft.ifft(&mut freq)?;
+    Ok(freq.iter().map(|c| c.re).collect())
 }
 
 /// Compute Mel filterbank energies (triangular filters)
@@ -46,6 +53,9 @@ pub fn mel_filterbank(fft_mags: &[f32], sample_rate: f32, num_filters: usize) ->
     }
     let mut energies = vec![0.0; num_filters];
     for m in 1..=num_filters {
+        if bins[m] == bins[m - 1] || bins[m + 1] == bins[m] {
+            continue;
+        }
         for k in bins[m - 1]..bins[m] {
             if k < n_fft {
                 energies[m - 1] += (k - bins[m - 1]) as f32 / (bins[m] - bins[m - 1]) as f32 * fft_mags[k];
@@ -61,15 +71,32 @@ pub fn mel_filterbank(fft_mags: &[f32], sample_rate: f32, num_filters: usize) ->
 }
 
 /// Compute MFCCs from a power spectrum (fft_mags), sample rate, and number of coefficients
-pub fn mfcc(fft_mags: &[f32], sample_rate: f32, num_mel: usize, num_coeffs: usize) -> Vec<f32> {
+pub fn mfcc(
+    fft_mags: &[f32],
+    sample_rate: f32,
+    num_mel: usize,
+    num_coeffs: usize,
+) -> Result<Vec<f32>, FftError> {
     let mel_energies = mel_filterbank(fft_mags, sample_rate, num_mel);
+    if num_coeffs > mel_energies.len() {
+        return Err(FftError::InvalidValue);
+    }
     let log_mel: Vec<f32> = mel_energies.iter().map(|&x| logf(x + 1e-12)).collect();
-    crate::dct::dct2(&log_mel)[..num_coeffs].to_vec()
+    let dct = crate::dct::dct2(&log_mel);
+    Ok(dct[..num_coeffs].to_vec())
 }
 
 /// Batch MFCC computation
-pub fn mfcc_batch(batch: &[Vec<f32>], sample_rate: f32, num_mel: usize, num_coeffs: usize) -> Vec<Vec<f32>> {
-    batch.iter().map(|frame| mfcc(frame, sample_rate, num_mel, num_coeffs)).collect()
+pub fn mfcc_batch(
+    batch: &[Vec<f32>],
+    sample_rate: f32,
+    num_mel: usize,
+    num_coeffs: usize,
+) -> Result<Vec<Vec<f32>>, FftError> {
+    batch
+        .iter()
+        .map(|frame| mfcc(frame, sample_rate, num_mel, num_coeffs))
+        .collect()
 }
 
 #[cfg(test)]
@@ -78,8 +105,15 @@ mod tests {
     #[test]
     fn test_real_cepstrum() {
         let x = [1.0, 2.0, 3.0, 4.0];
-        let cep = real_cepstrum(&x);
+        let cep = real_cepstrum(&x).unwrap();
         assert_eq!(cep.len(), x.len());
+    }
+
+    #[test]
+    fn test_real_cepstrum_errors() {
+        assert_eq!(real_cepstrum(&[]).unwrap_err(), FftError::EmptyInput);
+        let x = [1.0, 2.0, 3.0];
+        assert_eq!(real_cepstrum(&x).unwrap_err(), FftError::NonPowerOfTwoNoStd);
     }
 }
 
@@ -89,8 +123,26 @@ mod mfcc_tests {
     #[test]
     fn test_mfcc_batch() {
         let frames = vec![vec![1.0; 32], vec![0.5; 32]];
-        let mfccs = mfcc_batch(&frames, 16000.0, 8, 4);
+        let mfccs = mfcc_batch(&frames, 16000.0, 8, 4).unwrap();
         assert_eq!(mfccs.len(), 2);
         assert_eq!(mfccs[0].len(), 4);
     }
-} 
+
+    #[test]
+    fn test_mfcc_error() {
+        let frame = vec![1.0; 32];
+        assert_eq!(mfcc(&frame, 16000.0, 8, 20).unwrap_err(), FftError::InvalidValue);
+    }
+}
+
+#[cfg(test)]
+mod mel_tests {
+    use super::*;
+    #[test]
+    fn test_mel_filterbank_zero_width() {
+        let mags = vec![1.0; 8];
+        let energies = mel_filterbank(&mags, 8000.0, 40);
+        assert_eq!(energies.len(), 40);
+        assert!(energies.iter().all(|e| e.is_finite()));
+    }
+}

--- a/src/czt.rs
+++ b/src/czt.rs
@@ -6,28 +6,49 @@ extern crate alloc;
 use alloc::vec::Vec;
 use alloc::vec;
 
-use libm::{cosf, sinf};
+// no additional libm functions needed
 
 /// Compute the CZT of a real signal at M output bins
 /// - `input`: real-valued signal
 /// - `m`: number of output bins
 /// - `w`: complex ratio between bins (e.g., exp(-j*2pi/M))
 /// - `a`: complex starting point (e.g., 1.0)
-pub fn czt_f32(input: &[f32], m: usize, _w: (f32, f32), _a: (f32, f32)) -> Vec<(f32, f32)> {
-    let n = input.len();
+pub fn czt_f32(input: &[f32], m: usize, w: (f32, f32), a: (f32, f32)) -> Vec<(f32, f32)> {
+    let (wr, wi) = w;
+    let (ar, ai) = a;
+    let denom = ar * ar + ai * ai;
+    let a_inv_r = if denom == 0.0 { 0.0 } else { ar / denom };
+    let a_inv_i = if denom == 0.0 { 0.0 } else { -ai / denom };
     let mut output = vec![(0.0, 0.0); m];
     for k in 0..m {
-        let mut sum_re = 0.0;
-        let mut sum_im = 0.0;
-        for i in 0..n {
-            // For DFT: angle = -2pi * i * k / n
-            let angle = -2.0 * core::f32::consts::PI * (i as f32) * (k as f32) / (n as f32);
-            let re = cosf(angle);
-            let im = sinf(angle);
-            sum_re += input[i] * re;
-            sum_im += input[i] * im;
+        // compute w^k
+        let mut w_k_r = 1.0;
+        let mut w_k_i = 0.0;
+        for _ in 0..k {
+            let tr = w_k_r * wr - w_k_i * wi;
+            let ti = w_k_r * wi + w_k_i * wr;
+            w_k_r = tr;
+            w_k_i = ti;
         }
-        output[k] = (sum_re, sum_im);
+        let mut wnk_r = 1.0;
+        let mut wnk_i = 0.0;
+        let mut a_pow_r = 1.0;
+        let mut a_pow_i = 0.0;
+        for &x in input {
+            let tr = a_pow_r * wnk_r - a_pow_i * wnk_i;
+            let ti = a_pow_r * wnk_i + a_pow_i * wnk_r;
+            output[k].0 += x * tr;
+            output[k].1 += x * ti;
+            // update powers
+            let wtr = wnk_r * w_k_r - wnk_i * w_k_i;
+            let wti = wnk_r * w_k_i + wnk_i * w_k_r;
+            wnk_r = wtr;
+            wnk_i = wti;
+            let atr = a_pow_r * a_inv_r - a_pow_i * a_inv_i;
+            let ati = a_pow_r * a_inv_i + a_pow_i * a_inv_r;
+            a_pow_r = atr;
+            a_pow_i = ati;
+        }
     }
     output
 }
@@ -45,4 +66,14 @@ mod tests {
         let y = czt_f32(&x, 4, w, a);
         assert!((y[0].0 - 1.0).abs() < 1e-5);
     }
-} 
+
+    #[test]
+    fn test_czt_non_unit_params() {
+        let x = [0.0, 1.0];
+        let w = (0.0, 1.0); // j
+        let a = (0.5, 0.0);
+        let y = czt_f32(&x, 2, w, a);
+        assert!((y[0].0 - 2.0).abs() < 1e-5 && y[0].1.abs() < 1e-5);
+        assert!((y[1].0).abs() < 1e-5 && (y[1].1 - 2.0).abs() < 1e-5);
+    }
+}

--- a/src/fft.rs
+++ b/src/fft.rs
@@ -52,6 +52,7 @@ pub enum FftError {
     MismatchedLengths,
     InvalidStride,
     InvalidHopSize,
+    InvalidValue,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/src/stft.rs
+++ b/src/stft.rs
@@ -107,6 +107,9 @@ impl<'a> StftStream<'a> {
     }
     pub fn next_frame(&mut self, out: &mut [Complex32]) -> Result<bool, FftError> {
         let win_len = self.window.len();
+        if out.len() != win_len {
+            return Err(FftError::MismatchedLengths);
+        }
         if self.pos >= self.signal.len() {
             return Ok(false);
         }
@@ -685,6 +688,15 @@ mod coverage_tests {
         let mut buf = vec![Complex32::new(0.0, 0.0); 4];
         assert!(stream.next_frame(&mut buf).unwrap());
         while stream.next_frame(&mut buf).unwrap() {}
+    }
+
+    #[test]
+    fn test_stream_buffer_mismatch() {
+        let signal = [1.0, 2.0, 3.0, 4.0];
+        let window = [1.0, 1.0, 1.0, 1.0];
+        let mut stream = StftStream::new(&signal, &window, 2).unwrap();
+        let mut buf = vec![Complex32::new(0.0, 0.0); 3];
+        assert_eq!(stream.next_frame(&mut buf).unwrap_err(), FftError::MismatchedLengths);
     }
 
     #[test]

--- a/src/window_more.rs
+++ b/src/window_more.rs
@@ -12,6 +12,7 @@ use crate::fft::Float;
 
 /// Tukey window (tapered cosine)
 pub fn tukey(len: usize, alpha: f32) -> Vec<f32> {
+    let alpha = alpha.clamp(0.0, 1.0);
     let mut w = vec![0.0; len];
     let edge = floorf(alpha * (len as f32 - 1.0) / 2.0) as usize;
     for n in 0..len {
@@ -76,4 +77,14 @@ mod tests {
         assert_eq!(w3.len(), 8);
         assert_eq!(w4.len(), 8);
     }
-} 
+
+    #[test]
+    fn test_tukey_alpha_clamp() {
+        let w_neg = tukey(8, -0.5);
+        let w_zero = tukey(8, 0.0);
+        assert_eq!(w_neg, w_zero);
+        let w_gt = tukey(8, 1.5);
+        let w_one = tukey(8, 1.0);
+        assert_eq!(w_gt, w_one);
+    }
+}


### PR DESCRIPTION
## Summary
- fix Goertzel coefficient and guard against empty input or invalid sample rates
- make Hilbert and cepstrum functions return `Result` with checks for empty or non-power-of-two inputs
- ensure STFT, windows, DCT/DST, and CZT handle invalid parameters safely and test degenerate paths

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_689dbe15082c832bb99bd1c96256bf9f