### PR TITLE
Add real FFT module and examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,12 +162,26 @@ let result = fft.fft_vec(&data)?;
 
 ```rust
 use kofft::fft::{ScalarFftImpl, FftImpl};
+use kofft::rfft::RealFftImpl;
 
 let fft = ScalarFftImpl::<f32>::default();
-let input = vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0];
+let mut input = vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0];
 let mut output = vec![Complex32::zero(); input.len() / 2 + 1];
 
-fft.rfft(&input, &mut output)?;
+fft.rfft(&mut input, &mut output)?;
+```
+
+Stack-only helpers avoid heap allocation:
+
+```rust
+use kofft::rfft::{irfft_stack, rfft_stack};
+use kofft::Complex32;
+
+let input = [1.0f32, 2.0, 3.0, 4.0];
+let mut freq = [Complex32::new(0.0, 0.0); 3];
+rfft_stack(&input, &mut freq)?;
+let mut time = [0.0f32; 4];
+irfft_stack(&freq, &mut time)?;
 ```
 
 ### STFT (Short-Time Fourier Transform)
@@ -213,6 +227,7 @@ cargo run --example stft_usage
 cargo run --example ndfft_usage
 cargo run --example embedded_example
 cargo run --example benchmark
+cargo run --example rfft_usage
 ```
 
 ## Advanced Features

--- a/examples/basic_usage.rs
+++ b/examples/basic_usage.rs
@@ -8,6 +8,7 @@ use kofft::czt::czt_f32;
 use kofft::dct::dct2;
 use kofft::dst::dst2;
 use kofft::fft::{FftImpl, ScalarFftImpl};
+use kofft::rfft::RealFftImpl;
 use kofft::goertzel::goertzel_f32;
 use kofft::hartley::dht;
 use kofft::hilbert::hilbert_analytic;

--- a/examples/benchmark.rs
+++ b/examples/benchmark.rs
@@ -4,6 +4,7 @@
 //! and features of the kofft library.
 
 use kofft::fft::{Complex32, ScalarFftImpl, FftImpl};
+use kofft::rfft::RealFftImpl;
 use std::time::Instant;
 
 fn main() {

--- a/examples/rfft_usage.rs
+++ b/examples/rfft_usage.rs
@@ -1,0 +1,23 @@
+use kofft::fft::ScalarFftImpl;
+use kofft::rfft::{irfft_stack, rfft_stack, RealFftImpl};
+use kofft::Complex32;
+
+fn main() {
+    // Planner-based real FFT
+    let fft = ScalarFftImpl::<f32>::default();
+    let mut input = vec![1.0f32, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0];
+    let mut spectrum = vec![Complex32::new(0.0, 0.0); input.len() / 2 + 1];
+    fft.rfft(&mut input, &mut spectrum).unwrap();
+
+    let mut output = vec![0.0f32; input.len()];
+    fft.irfft(&mut spectrum, &mut output).unwrap();
+    println!("Input: {:?}\nReconstructed: {:?}", input, output);
+
+    // Stack-only helpers
+    let stack_input = [1.0f32, 2.0, 3.0, 4.0];
+    let mut stack_freq = [Complex32::new(0.0, 0.0); 3];
+    rfft_stack(&stack_input, &mut stack_freq).unwrap();
+    let mut stack_out = [0.0f32; 4];
+    irfft_stack(&stack_freq, &mut stack_out).unwrap();
+    println!("Stack input: {:?}\nStack output: {:?}", stack_input, stack_out);
+}

--- a/src/fft.rs
+++ b/src/fft.rs
@@ -492,51 +492,6 @@ fn factorize(mut n: usize) -> alloc::vec::Vec<usize> {
 }
 
 impl ScalarFftImpl<f32> {
-    /// Real-input FFT: input is real-valued, output is N/2+1 complex values (Hermitian symmetry)
-    pub fn rfft(&self, input: &mut [f32], output: &mut [Complex32]) -> Result<(), FftError> {
-        let n = input.len();
-        if n == 0 {
-            return Err(FftError::EmptyInput);
-        }
-        if output.len() != n / 2 + 1 {
-            return Err(FftError::MismatchedLengths);
-        }
-        // Copy real input into complex buffer
-        let mut buf = alloc::vec::Vec::with_capacity(n);
-        for &x in input.iter() {
-            buf.push(Complex32::new(x, 0.0));
-        }
-        self.fft(&mut buf)?;
-        // Output first N/2+1 values (Hermitian symmetry)
-        for k in 0..=n / 2 {
-            output[k] = buf[k];
-        }
-        Ok(())
-    }
-    /// Inverse real-input FFT: input is N/2+1 complex values, output is N real values
-    pub fn irfft(&self, input: &mut [Complex32], output: &mut [f32]) -> Result<(), FftError> {
-        let n = output.len();
-        if n == 0 {
-            return Err(FftError::EmptyInput);
-        }
-        if input.len() != n / 2 + 1 {
-            return Err(FftError::MismatchedLengths);
-        }
-        // Reconstruct full Hermitian-symmetric spectrum
-        let mut buf = alloc::vec::Vec::with_capacity(n);
-        for &c in input.iter() {
-            buf.push(c);
-        }
-        for k in (1..n / 2).rev() {
-            let conj = Complex32::new(input[k].re, -input[k].im);
-            buf.push(conj);
-        }
-        self.ifft(&mut buf)?;
-        for (i, c) in buf.iter().enumerate() {
-            output[i] = c.re;
-        }
-        Ok(())
-    }
     #[cfg(feature = "std")]
     pub fn fft_radix2_with_twiddles(
         &self,
@@ -1879,16 +1834,6 @@ mod coverage_tests {
         let tw6 = TwiddleFactorBuffer::new(6);
         fft.fft_mixed_radix_with_twiddles(&mut mix6, &tw6)
             .unwrap();
-    }
-
-    #[test]
-    fn test_rfft_irfft_empty() {
-        let fft = ScalarFftImpl::<f32>::default();
-        let mut input: [f32; 0] = [];
-        let mut freq = [Complex32::zero(); 1];
-        assert_eq!(fft.rfft(&mut input, &mut freq), Err(FftError::EmptyInput));
-        let mut out: [f32; 0] = [];
-        assert_eq!(fft.irfft(&mut freq, &mut out), Err(FftError::EmptyInput));
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -64,6 +64,9 @@ pub mod fft;
 ///
 /// Provides both scalar and SIMD-optimized FFT implementations.
 /// Supports complex and real input signals.
+pub mod rfft;
+/// Real-input FFT helpers built on top of complex FFT routines
+/// for converting between real and complex domains.
 pub mod num;
 
 /// N-dimensional FFT operations
@@ -140,6 +143,7 @@ pub fn add(left: u64, right: u64) -> u64 {
 mod tests {
     use super::*;
     use crate::fft::{Complex32, FftError, FftImpl, ScalarFftImpl};
+    use crate::rfft::RealFftImpl;
     use alloc::vec;
     use alloc::vec::Vec;
     use core::f32::consts;

--- a/src/rfft.rs
+++ b/src/rfft.rs
@@ -1,0 +1,143 @@
+//! Real FFT (RFFT) utilities built on top of complex FFT routines.
+//!
+//! This module provides real-to-complex (`rfft`) and complex-to-real (`irfft`)
+//! transforms by reusing the existing complex FFT implementations from
+//! [`crate::fft`]. It also exposes stack-only helpers analogous to
+//! [`crate::fft::fft_inplace_stack`] for embedded/`no_std` environments.
+
+use alloc::vec::Vec;
+
+use crate::fft::{ifft_inplace_stack, fft_inplace_stack, Complex, Complex32, FftError, FftImpl};
+use crate::num::Float;
+
+/// Trait providing real-valued FFT transforms built on top of [`FftImpl`].
+pub trait RealFftImpl<T: Float>: FftImpl<T> {
+    /// Compute the real-input FFT, producing `N/2 + 1` complex samples
+    /// representing the positive-frequency spectrum.
+    fn rfft(&self, input: &mut [T], output: &mut [Complex<T>]) -> Result<(), FftError> {
+        let n = input.len();
+        if n == 0 {
+            return Err(FftError::EmptyInput);
+        }
+        if output.len() != n / 2 + 1 {
+            return Err(FftError::MismatchedLengths);
+        }
+        let mut buf: Vec<Complex<T>> = input
+            .iter()
+            .map(|&x| Complex::<T>::new(x, T::zero()))
+            .collect();
+        self.fft(&mut buf)?;
+        for k in 0..=n / 2 {
+            output[k] = buf[k];
+        }
+        Ok(())
+    }
+
+    /// Compute the inverse real FFT, consuming `N/2 + 1` complex samples and
+    /// producing `N` real time-domain values.
+    fn irfft(&self, input: &mut [Complex<T>], output: &mut [T]) -> Result<(), FftError> {
+        let n = output.len();
+        if n == 0 {
+            return Err(FftError::EmptyInput);
+        }
+        if input.len() != n / 2 + 1 {
+            return Err(FftError::MismatchedLengths);
+        }
+        let mut buf: Vec<Complex<T>> = input.to_vec();
+        for k in (1..n / 2).rev() {
+            let c = input[k];
+            buf.push(Complex::new(c.re, -c.im));
+        }
+        self.ifft(&mut buf)?;
+        for (i, c) in buf.iter().enumerate() {
+            output[i] = c.re;
+        }
+        Ok(())
+    }
+}
+
+// Blanket implementation for any complex FFT provider.
+impl<T: Float, U: FftImpl<T>> RealFftImpl<T> for U {}
+
+/// Perform a real-input FFT using only stack allocation.
+///
+/// The output buffer must have length `N/2 + 1`.
+pub fn rfft_stack<const N: usize, const M: usize>(
+    input: &[f32; N],
+    output: &mut [Complex32; M],
+) -> Result<(), FftError> {
+    if N == 0 {
+        return Err(FftError::EmptyInput);
+    }
+    if M != N / 2 + 1 {
+        return Err(FftError::MismatchedLengths);
+    }
+    let mut buf = [Complex32::new(0.0, 0.0); N];
+    for i in 0..N {
+        buf[i] = Complex32::new(input[i], 0.0);
+    }
+    fft_inplace_stack(&mut buf)?;
+    for k in 0..=N / 2 {
+        output[k] = buf[k];
+    }
+    Ok(())
+}
+
+/// Perform an inverse real-input FFT using only stack allocation.
+///
+/// The input buffer must have length `N/2 + 1`.
+pub fn irfft_stack<const N: usize, const M: usize>(
+    input: &[Complex32; M],
+    output: &mut [f32; N],
+) -> Result<(), FftError> {
+    if N == 0 {
+        return Err(FftError::EmptyInput);
+    }
+    if M != N / 2 + 1 {
+        return Err(FftError::MismatchedLengths);
+    }
+    let mut buf = [Complex32::new(0.0, 0.0); N];
+    for k in 0..=N / 2 {
+        buf[k] = input[k];
+    }
+    for k in 1..N / 2 {
+        buf[N - k] = Complex32::new(input[k].re, -input[k].im);
+    }
+    ifft_inplace_stack(&mut buf)?;
+    for i in 0..N {
+        output[i] = buf[i].re;
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::fft::ScalarFftImpl;
+    use alloc::vec;
+
+    #[test]
+    fn rfft_irfft_roundtrip() {
+        let fft = ScalarFftImpl::<f32>::default();
+        let mut input = vec![1.0f32, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0];
+        let mut freq = vec![Complex32::new(0.0, 0.0); input.len() / 2 + 1];
+        fft.rfft(&mut input, &mut freq).unwrap();
+        let mut out = vec![0.0f32; input.len()];
+        fft.irfft(&mut freq, &mut out).unwrap();
+        for (a, b) in input.iter().zip(out.iter()) {
+            assert!((a - b).abs() < 1e-5);
+        }
+    }
+
+    #[test]
+    fn rfft_stack_roundtrip() {
+        let input = [1.0f32, 2.0, 3.0, 4.0];
+        let mut freq = [Complex32::new(0.0, 0.0); 3];
+        rfft_stack(&input, &mut freq).unwrap();
+        let mut out = [0.0f32; 4];
+        irfft_stack(&freq, &mut out).unwrap();
+        for (a, b) in input.iter().zip(out.iter()) {
+            assert!((a - b).abs() < 1e-5);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- introduce `rfft` module with `RealFftImpl` trait for real-to-complex and complex-to-real transforms
- add stack-only helpers `rfft_stack` and `irfft_stack`
- document usage and add `rfft_usage` example and README snippets

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_689dc30c12d4832b998c7633c32fa6b2