### PR TITLE
Add SSE feature and fallback FFT kernels

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,3 +13,5 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
       - name: Test
         run: cargo test --all --verbose
+      - name: Test SSE only
+        run: cargo test --no-default-features --features sse,std --verbose

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Window functions: Hann, Hamming, Blackman, Kaiser
 - Stack-only APIs for embedded/MCU usage
 - SIMD acceleration for x86_64 (AVX2), AArch64 (NEON), and WebAssembly
+- Added SSE feature for x86_64 as fallback when AVX2 is unavailable
 - Parallel processing support with Rayon
 - Batch and multi-channel processing
 - Real FFT optimization for real input signals
@@ -53,4 +54,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Minimum Rust version: 1.70
 - License: MIT OR Apache-2.0
 - Dependencies: libm (0.2), rayon (optional, 1.7)
-- Features: std, parallel, x86_64, aarch64, wasm 
+- Features: std, parallel, sse, x86_64, aarch64, wasm

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,7 @@ default = ["std"]
 std = []
 parallel = ["rayon"]
 x86_64 = []
+sse = []
 aarch64 = []
 wasm = []
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ High-performance, `no_std`, MCU-friendly DSP library featuring FFT, DCT, DST, Ha
 ## Features
 
 - **🚀 Zero-allocation stack-only APIs** for MCU/embedded systems
-- **⚡ SIMD acceleration** (x86_64 AVX2, AArch64 NEON, WebAssembly SIMD)
+- **⚡ SIMD acceleration** (x86_64 SSE/AVX2, AArch64 NEON, WebAssembly SIMD)
 - **🔧 Multiple transform types**: FFT, DCT, DST, Hartley, Wavelet, STFT, CZT, Goertzel
 - **📊 Window functions**: Hann, Hamming, Blackman, Kaiser
 - **🔄 Batch and multi-channel processing**
@@ -25,6 +25,7 @@ High-performance, `no_std`, MCU-friendly DSP library featuring FFT, DCT, DST, Ha
 ```toml
 [dependencies]
 kofft = { version = "0.1.1", features = [
+    # "sse",      # enable SSE on x86_64 (fallback)
     # "x86_64",   # enable AVX2 on x86_64
     # "aarch64",  # enable NEON on AArch64
     # "wasm",     # enable WebAssembly SIMD
@@ -222,6 +223,7 @@ Enable optional features in `Cargo.toml`:
 ```toml
 [dependencies]
 kofft = { version = "0.1.1", features = [
+    # "sse",      # SSE on x86_64 (fallback)
     # "x86_64",   # AVX2 on x86_64
     # "aarch64",  # NEON on AArch64
     # "wasm",     # WebAssembly SIMD
@@ -232,6 +234,10 @@ kofft = { version = "0.1.1", features = [
 ### SIMD Acceleration
 
 Enable one of the CPU-specific SIMD features above for better performance.
+
+On x86_64 platforms, enabling `x86_64` activates AVX2/FMA kernels while `sse`
+provides an SSE fallback for older CPUs. If both features are enabled,
+`x86_64` takes precedence over `sse`.
 
 ### Parallel Processing
 
@@ -335,12 +341,13 @@ fn main() -> ! {
 
 ## Platform Support
 
-| Platform | SIMD Support | Features |
-|----------|-------------|----------|
-| x86_64   | AVX2/FMA    | `x86_64` feature |
-| AArch64  | NEON        | `aarch64` feature |
-| WebAssembly | SIMD128   | `wasm` feature |
-| Generic  | Scalar      | Default fallback |
+| Platform        | SIMD Support | Features         |
+|-----------------|-------------|------------------|
+| x86_64 (AVX2)   | AVX2/FMA    | `x86_64` feature |
+| x86_64 (SSE)    | SSE         | `sse` feature    |
+| AArch64         | NEON        | `aarch64` feature |
+| WebAssembly     | SIMD128     | `wasm` feature   |
+| Generic         | Scalar      | Default fallback |
 
 ## License
 

--- a/src/fft.rs
+++ b/src/fft.rs
@@ -3,7 +3,7 @@
 //! This module implements real and complex FFT routines based on the
 //! [Cooley–Tukey algorithm](https://en.wikipedia.org/wiki/Cooley%E2%80%93Tukey_FFT_algorithm).
 //! A [`FftPlanner`] caches twiddle factors for reuse. Optional SIMD features
-//! (`x86_64`, `aarch64`, `wasm`) accelerate computation, and both in-place and
+//! (`x86_64`, `sse`, `aarch64`, `wasm`) accelerate computation, and both in-place and
 //! out-of-place APIs are provided for single or batched transforms.
 
 use core::f32::consts::PI;
@@ -732,6 +732,225 @@ impl ScalarFftImpl<f32> {
 
 // SIMD FFT implementations (feature-gated)
 
+// x86_64 SSE SIMD implementation
+#[cfg(all(feature = "sse", target_arch = "x86_64", not(feature = "x86_64")))]
+use core::arch::x86_64::*;
+
+#[cfg(all(feature = "sse", target_arch = "x86_64", not(feature = "x86_64")))]
+pub struct SimdFftSseImpl;
+#[cfg(all(feature = "sse", target_arch = "x86_64", not(feature = "x86_64")))]
+impl FftImpl<f32> for SimdFftSseImpl {
+    fn fft(&self, input: &mut [Complex32]) -> Result<(), FftError> {
+        let n = input.len();
+        if n <= 1 {
+            return Ok(());
+        }
+        let aligned = (input.as_ptr() as usize) % 16 == 0;
+        if n >= 4 {
+            unsafe {
+                let mut j = 0;
+                let mut i = 1;
+                while i + 3 < n {
+                    let mut bit = n >> 1;
+                    while j & bit != 0 {
+                        j ^= bit;
+                        bit >>= 1;
+                    }
+                    j ^= bit;
+                    if i < j {
+                        let ptr_i = input.as_mut_ptr().add(i);
+                        let ptr_j = input.as_mut_ptr().add(j);
+                        if aligned {
+                            let re_i = _mm_load_ps(ptr_i as *const f32);
+                            let im_i = _mm_load_ps(ptr_i.add(1) as *const f32);
+                            let re_j = _mm_load_ps(ptr_j as *const f32);
+                            let im_j = _mm_load_ps(ptr_j.add(1) as *const f32);
+                            _mm_store_ps(ptr_i as *mut f32, re_j);
+                            _mm_store_ps(ptr_i.add(1) as *mut f32, im_j);
+                            _mm_store_ps(ptr_j as *mut f32, re_i);
+                            _mm_store_ps(ptr_j.add(1) as *mut f32, im_i);
+                        } else {
+                            let re_i = _mm_loadu_ps(ptr_i as *const f32);
+                            let im_i = _mm_loadu_ps(ptr_i.add(1) as *const f32);
+                            let re_j = _mm_loadu_ps(ptr_j as *const f32);
+                            let im_j = _mm_loadu_ps(ptr_j.add(1) as *const f32);
+                            _mm_storeu_ps(ptr_i as *mut f32, re_j);
+                            _mm_storeu_ps(ptr_i.add(1) as *mut f32, im_j);
+                            _mm_storeu_ps(ptr_j as *mut f32, re_i);
+                            _mm_storeu_ps(ptr_j.add(1) as *mut f32, im_i);
+                        }
+                    }
+                    i += 4;
+                }
+                for k in i..n {
+                    let mut bit = n >> 1;
+                    while j & bit != 0 {
+                        j ^= bit;
+                        bit >>= 1;
+                    }
+                    j ^= bit;
+                    if k < j {
+                        input.swap(k, j);
+                    }
+                }
+            }
+        } else {
+            let mut j = 0;
+            for i in 1..n {
+                let mut bit = n >> 1;
+                while j & bit != 0 {
+                    j ^= bit;
+                    bit >>= 1;
+                }
+                j ^= bit;
+                if i < j {
+                    input.swap(i, j);
+                }
+            }
+        }
+        if n % 4 != 0 {
+            let scalar = ScalarFftImpl::<f32>::default();
+            scalar.fft(input)?;
+            return Ok(());
+        }
+        unsafe {
+            let mut len = 2;
+            while len <= n {
+                let ang = -2.0 * PI / (len as f32);
+                let wlen = Complex32::expi(ang);
+                let mut i = 0;
+                while i < n {
+                    let mut w = Complex32::new(1.0, 0.0);
+                    let half = len / 2;
+                    let simd_width = 4;
+                    let simd_iters = half / simd_width;
+                    for s in 0..simd_iters {
+                        let j = s * simd_width;
+                        let mut w_re = [0.0f32; 4];
+                        let mut w_im = [0.0f32; 4];
+                        let mut wj = w;
+                        for k in 0..simd_width {
+                            w_re[k] = wj.re;
+                            w_im[k] = wj.im;
+                            wj = wj.mul(wlen);
+                        }
+                        let w_re_v = if aligned {
+                            _mm_load_ps(w_re.as_ptr())
+                        } else {
+                            _mm_loadu_ps(w_re.as_ptr())
+                        };
+                        let w_im_v = if aligned {
+                            _mm_load_ps(w_im.as_ptr())
+                        } else {
+                            _mm_loadu_ps(w_im.as_ptr())
+                        };
+                        let u_re = if aligned {
+                            _mm_load_ps(&input[i + j].re as *const f32)
+                        } else {
+                            _mm_loadu_ps(&input[i + j].re as *const f32)
+                        };
+                        let u_im = if aligned {
+                            _mm_load_ps(&input[i + j].im as *const f32)
+                        } else {
+                            _mm_loadu_ps(&input[i + j].im as *const f32)
+                        };
+                        let v_re = if aligned {
+                            _mm_load_ps(&input[i + j + half].re as *const f32)
+                        } else {
+                            _mm_loadu_ps(&input[i + j + half].re as *const f32)
+                        };
+                        let v_im = if aligned {
+                            _mm_load_ps(&input[i + j + half].im as *const f32)
+                        } else {
+                            _mm_loadu_ps(&input[i + j + half].im as *const f32)
+                        };
+                        let t1 = _mm_mul_ps(v_re, w_re_v);
+                        let t2 = _mm_mul_ps(v_im, w_im_v);
+                        let t3 = _mm_mul_ps(v_re, w_im_v);
+                        let t4 = _mm_mul_ps(v_im, w_re_v);
+                        let vw_re = _mm_sub_ps(t1, t2);
+                        let vw_im = _mm_add_ps(t3, t4);
+                        let out_re = _mm_add_ps(u_re, vw_re);
+                        let out_im = _mm_add_ps(u_im, vw_im);
+                        let out2_re = _mm_sub_ps(u_re, vw_re);
+                        let out2_im = _mm_sub_ps(u_im, vw_im);
+                        if aligned {
+                            _mm_store_ps(&mut input[i + j].re as *mut f32, out_re);
+                            _mm_store_ps(&mut input[i + j].im as *mut f32, out_im);
+                            _mm_store_ps(&mut input[i + j + half].re as *mut f32, out2_re);
+                            _mm_store_ps(&mut input[i + j + half].im as *mut f32, out2_im);
+                        } else {
+                            _mm_storeu_ps(&mut input[i + j].re as *mut f32, out_re);
+                            _mm_storeu_ps(&mut input[i + j].im as *mut f32, out_im);
+                            _mm_storeu_ps(&mut input[i + j + half].re as *mut f32, out2_re);
+                            _mm_storeu_ps(&mut input[i + j + half].im as *mut f32, out2_im);
+                        }
+                        for _ in 0..simd_width {
+                            w = w.mul(wlen);
+                        }
+                    }
+                    for j in (simd_iters * simd_width)..half {
+                        let u = input[i + j];
+                        let v = input[i + j + half].mul(w);
+                        input[i + j] = u.add(v);
+                        input[i + j + half] = u.sub(v);
+                        w = w.mul(wlen);
+                    }
+                    i += len;
+                }
+                len <<= 1;
+            }
+        }
+        Ok(())
+    }
+    fn ifft(&self, input: &mut [Complex32]) -> Result<(), FftError> {
+        let scalar = ScalarFftImpl::<f32>::default();
+        scalar.ifft(input)?;
+        Ok(())
+    }
+
+    fn fft_strided(&self, input: &mut [Complex32], stride: usize) -> Result<(), FftError> {
+        let scalar = ScalarFftImpl::<f32>::default();
+        scalar.fft_strided(input, stride)
+    }
+
+    fn ifft_strided(&self, input: &mut [Complex32], stride: usize) -> Result<(), FftError> {
+        let scalar = ScalarFftImpl::<f32>::default();
+        scalar.ifft_strided(input, stride)
+    }
+
+    fn fft_out_of_place_strided(
+        &self,
+        input: &[Complex32],
+        in_stride: usize,
+        output: &mut [Complex32],
+        out_stride: usize,
+    ) -> Result<(), FftError> {
+        let scalar = ScalarFftImpl::<f32>::default();
+        scalar.fft_out_of_place_strided(input, in_stride, output, out_stride)
+    }
+
+    fn ifft_out_of_place_strided(
+        &self,
+        input: &[Complex32],
+        in_stride: usize,
+        output: &mut [Complex32],
+        out_stride: usize,
+    ) -> Result<(), FftError> {
+        let scalar = ScalarFftImpl::<f32>::default();
+        scalar.ifft_out_of_place_strided(input, in_stride, output, out_stride)
+    }
+
+    fn fft_with_strategy(
+        &self,
+        input: &mut [Complex32],
+        strategy: FftStrategy,
+    ) -> Result<(), FftError> {
+        let scalar = ScalarFftImpl::<f32>::default();
+        scalar.fft_with_strategy(input, strategy)
+    }
+}
+
 // x86_64 AVX2/FMA SIMD implementation
 #[cfg(all(feature = "x86_64", target_arch = "x86_64"))]
 use core::arch::x86_64::*;
@@ -1332,6 +1551,10 @@ pub fn new_fft_impl() -> Box<dyn FftImpl<f32>> {
     {
         return Box::new(SimdFftX86_64Impl);
     }
+    #[cfg(all(feature = "sse", target_arch = "x86_64", not(feature = "x86_64")))]
+    {
+        return Box::new(SimdFftSseImpl);
+    }
     #[cfg(all(feature = "aarch64", target_arch = "aarch64"))]
     {
         return Box::new(SimdFftAArch64Impl);
@@ -1342,6 +1565,7 @@ pub fn new_fft_impl() -> Box<dyn FftImpl<f32>> {
     }
     #[cfg(not(any(
         all(feature = "x86_64", target_arch = "x86_64"),
+        all(feature = "sse", target_arch = "x86_64", not(feature = "x86_64")),
         all(feature = "aarch64", target_arch = "aarch64"),
         all(feature = "wasm", target_arch = "wasm32")
     )))]
@@ -1877,8 +2101,7 @@ mod coverage_tests {
             .map(|i| Complex32::new(i as f32, 0.0))
             .collect::<Vec<_>>();
         let tw6 = TwiddleFactorBuffer::new(6);
-        fft.fft_mixed_radix_with_twiddles(&mut mix6, &tw6)
-            .unwrap();
+        fft.fft_mixed_radix_with_twiddles(&mut mix6, &tw6).unwrap();
     }
 
     #[test]
@@ -1895,8 +2118,7 @@ mod coverage_tests {
     fn test_fft_radix4_sizes() {
         let fft = ScalarFftImpl::<f32>::default();
         for &n in &[16usize, 64usize] {
-            let mut data: Vec<Complex32> =
-                (0..n).map(|i| Complex32::new(i as f32, 0.0)).collect();
+            let mut data: Vec<Complex32> = (0..n).map(|i| Complex32::new(i as f32, 0.0)).collect();
             fft.fft_radix4(&mut data).unwrap();
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,7 +6,7 @@
 //! ## Features
 //!
 //! - **🚀 Zero-allocation stack-only APIs** for MCU/embedded systems
-//! - **⚡ SIMD acceleration** (x86_64 AVX2, AArch64 NEON, WebAssembly SIMD)
+//! - **⚡ SIMD acceleration** (x86_64 SSE/AVX2, AArch64 NEON, WebAssembly SIMD)
 //! - **🔧 Multiple transform types**: FFT, DCT, DST, Hartley, Wavelet, STFT, CZT, Goertzel
 //! - **📊 Window functions**: Hann, Hamming, Blackman, Kaiser
 //! - **🔄 Batch and multi-channel processing**
@@ -18,8 +18,12 @@
 //! - `std` (default): Enable standard library features
 //! - `parallel`: Enable parallel processing with Rayon
 //! - `x86_64`: Enable x86_64 SIMD optimizations
-//! - `aarch64`: Enable AArch64 SIMD optimizations  
+//! - `sse`: Enable x86_64 SSE optimizations (fallback if AVX2 is unavailable)
+//! - `aarch64`: Enable AArch64 SIMD optimizations
 //! - `wasm`: Enable WebAssembly SIMD optimizations
+//!
+//! On x86_64, enabling `x86_64` activates AVX2/FMA kernels while `sse`
+//! provides an SSE fallback. When both are enabled, `x86_64` takes precedence.
 //!
 //! ## Performance
 //!
@@ -30,12 +34,13 @@
 //!
 //! ## Platform Support
 //!
-//! | Platform | SIMD Support | Features |
-//! |----------|-------------|----------|
-//! | x86_64   | AVX2/FMA    | `x86_64` feature |
-//! | AArch64  | NEON        | `aarch64` feature |
-//! | WebAssembly | SIMD128   | `wasm` feature |
-//! | Generic  | Scalar      | Default fallback |
+//! | Platform        | SIMD Support | Features         |
+//! |-----------------|-------------|------------------|
+//! | x86_64 (AVX2)   | AVX2/FMA    | `x86_64` feature |
+//! | x86_64 (SSE)    | SSE         | `sse` feature    |
+//! | AArch64         | NEON        | `aarch64` feature |
+//! | WebAssembly     | SIMD128     | `wasm` feature   |
+//! | Generic         | Scalar      | Default fallback |
 //!
 //! ## Examples
 //!


### PR DESCRIPTION
## Summary
- add `sse` cargo feature and SSE FFT kernels for x86_64
- document SIMD feature precedence and update build/test scripts
- cover SSE-only builds in CI

## Testing
- `cargo test --all --verbose`
- `cargo test --no-default-features --features sse,std --quiet`


------
https://chatgpt.com/codex/tasks/task_e_689dc33e94c4832b9ed1d13442a58bd4