### PR TITLE
Add optional parallel FFT helpers and benchmark

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,3 +59,8 @@ path = "examples/stft_usage.rs"
 [[example]]
 name = "ndfft_usage"
 path = "examples/ndfft_usage.rs"
+
+[[example]]
+name = "parallel_benchmark"
+path = "examples/parallel_benchmark.rs"
+required-features = ["parallel"]

--- a/README.md
+++ b/README.md
@@ -59,6 +59,21 @@ fft.fft(&mut data)?;
 fft.ifft(&mut data)?;
 ```
 
+### Parallel FFT
+
+Enable the `parallel` feature to automatically split large transforms across
+threads via [Rayon](https://crates.io/crates/rayon). Use the `fft_parallel` and
+`ifft_parallel` helpers which safely fall back to single-threaded execution when
+Rayon is not available.
+
+```rust
+use kofft::fft::{fft_parallel, ifft_parallel, Complex32};
+
+let mut data = vec![Complex32::new(1.0, 0.0); 1 << 14];
+fft_parallel(&mut data)?;
+ifft_parallel(&mut data)?;
+```
+
 ## Embedded/MCU Usage (No Heap)
 
 All stack-only APIs require you to provide output buffers. This enables `no_std` operation without any heap allocation.
@@ -213,6 +228,7 @@ cargo run --example stft_usage
 cargo run --example ndfft_usage
 cargo run --example embedded_example
 cargo run --example benchmark
+cargo run --features parallel --example parallel_benchmark
 ```
 
 ## Advanced Features
@@ -330,6 +346,7 @@ fn main() -> ! {
 
 - **Stack-only APIs**: No heap allocation, suitable for MCUs with limited RAM
 - **SIMD acceleration**: 2-4x speedup on supported platforms
+- **Parallel FFT**: Enable the `parallel` feature to scale across CPU cores
 - **Power-of-two sizes**: Most efficient for FFT operations
 - **Memory usage**: Stack usage scales with transform size (e.g., 8-point FFT uses ~64 bytes for `Complex32`)
 

--- a/examples/parallel_benchmark.rs
+++ b/examples/parallel_benchmark.rs
@@ -1,0 +1,42 @@
+use kofft::fft::{fft_parallel, Complex32};
+use std::time::Instant;
+
+#[cfg(feature = "parallel")]
+use rayon::ThreadPoolBuilder;
+
+fn main() {
+    #[cfg(feature = "parallel")]
+    {
+        let size = 1 << 14; // 16384-point FFT
+        let data: Vec<Complex32> = (0..size)
+            .map(|i| Complex32::new((i as f32 * 0.1).sin(), (i as f32 * 0.1).cos()))
+            .collect();
+
+        let pool_single = ThreadPoolBuilder::new().num_threads(1).build().unwrap();
+        let seq_time = {
+            let mut buf = data.clone();
+            let start = Instant::now();
+            pool_single.install(|| fft_parallel(&mut buf).unwrap());
+            start.elapsed()
+        };
+
+        let pool_multi = ThreadPoolBuilder::new().build().unwrap();
+        let par_time = {
+            let mut buf = data.clone();
+            let start = Instant::now();
+            pool_multi.install(|| fft_parallel(&mut buf).unwrap());
+            start.elapsed()
+        };
+
+        println!("Sequential (1 thread): {:?}", seq_time);
+        println!(
+            "Parallel   ({} threads): {:?}",
+            pool_multi.current_num_threads(),
+            par_time
+        );
+    }
+    #[cfg(not(feature = "parallel"))]
+    {
+        println!("Enable the `parallel` feature to run this example");
+    }
+}

--- a/src/fft.rs
+++ b/src/fft.rs
@@ -15,6 +15,12 @@ use alloc::rc::Rc;
 use alloc::vec::Vec;
 use core::cell::RefCell;
 
+#[cfg(feature = "parallel")]
+use rayon::prelude::*;
+
+#[cfg(feature = "parallel")]
+const PARALLEL_FFT_THRESHOLD: usize = 4096;
+
 pub use crate::num::{Complex, Complex32, Complex64, Float};
 
 pub struct FftPlanner<T: Float> {
@@ -170,17 +176,54 @@ impl<T: Float> FftImpl<T> for ScalarFftImpl<T> {
             while len <= n {
                 let stride = n / len;
                 let wlen = twiddles[stride];
-                let mut i = 0;
-                while i < n {
-                    let mut w = Complex::new(T::one(), T::zero());
-                    for j in 0..(len / 2) {
-                        let u = input[i + j];
-                        let v = input[i + j + len / 2].mul(w);
-                        input[i + j] = u.add(v);
-                        input[i + j + len / 2] = u.sub(v);
-                        w = w.mul(wlen);
+                #[cfg(feature = "parallel")]
+                {
+                    if n >= PARALLEL_FFT_THRESHOLD
+                        && core::any::TypeId::of::<T>() == core::any::TypeId::of::<f32>()
+                    {
+                        let input32 =
+                            unsafe { &mut *(input as *mut [Complex<T>] as *mut [Complex32]) };
+                        let wlen32 = unsafe { *(&wlen as *const Complex<T> as *const Complex32) };
+                        input32.par_chunks_mut(len).for_each(|chunk| {
+                            let mut w = Complex32::new(1.0, 0.0);
+                            let half = len / 2;
+                            for j in 0..half {
+                                let u = chunk[j];
+                                let v = chunk[j + half].mul(w);
+                                chunk[j] = u.add(v);
+                                chunk[j + half] = u.sub(v);
+                                w = w.mul(wlen32);
+                            }
+                        });
+                    } else {
+                        let mut i = 0;
+                        while i < n {
+                            let mut w = Complex::new(T::one(), T::zero());
+                            for j in 0..(len / 2) {
+                                let u = input[i + j];
+                                let v = input[i + j + len / 2].mul(w);
+                                input[i + j] = u.add(v);
+                                input[i + j + len / 2] = u.sub(v);
+                                w = w.mul(wlen);
+                            }
+                            i += len;
+                        }
                     }
-                    i += len;
+                }
+                #[cfg(not(feature = "parallel"))]
+                {
+                    let mut i = 0;
+                    while i < n {
+                        let mut w = Complex::new(T::one(), T::zero());
+                        for j in 0..(len / 2) {
+                            let u = input[i + j];
+                            let v = input[i + j + len / 2].mul(w);
+                            input[i + j] = u.add(v);
+                            input[i + j + len / 2] = u.sub(v);
+                            w = w.mul(wlen);
+                        }
+                        i += len;
+                    }
                 }
                 len <<= 1;
             }
@@ -248,6 +291,23 @@ impl<T: Float> FftImpl<T> for ScalarFftImpl<T> {
         }
         if n == 1 {
             return Ok(());
+        }
+        #[cfg(feature = "parallel")]
+        {
+            if n >= PARALLEL_FFT_THRESHOLD
+                && core::any::TypeId::of::<T>() == core::any::TypeId::of::<f32>()
+            {
+                let input32 = unsafe { &mut *(input as *mut [Complex<T>] as *mut [Complex32]) };
+                input32.par_iter_mut().for_each(|c| c.im = -c.im);
+                self.fft(input)?;
+                let scale = 1.0 / n as f32;
+                input32.par_iter_mut().for_each(|c| {
+                    c.im = -c.im;
+                    c.re *= scale;
+                    c.im *= scale;
+                });
+                return Ok(());
+            }
         }
         for c in input.iter_mut() {
             c.im = -c.im;
@@ -1446,6 +1506,20 @@ impl<T: Float> FftPlan<T> {
     }
 }
 
+/// Compute FFT using the default planner. When the `parallel` feature is
+/// enabled and the input length exceeds a threshold, the transform is split
+/// across threads using Rayon. Falls back to single-threaded execution when
+/// Rayon is absent.
+pub fn fft_parallel<T: Float>(input: &mut [Complex<T>]) -> Result<(), FftError> {
+    ScalarFftImpl::<T>::default().fft(input)
+}
+
+/// Compute inverse FFT using the default planner. Parallelism is applied in
+/// the same manner as [`fft_parallel`].
+pub fn ifft_parallel<T: Float>(input: &mut [Complex<T>]) -> Result<(), FftError> {
+    ScalarFftImpl::<T>::default().ifft(input)
+}
+
 /// Batch FFT: process a batch of mutable slices in-place
 pub fn batch<T: Float, F: FftImpl<T>>(
     fft: &F,
@@ -1877,8 +1951,7 @@ mod coverage_tests {
             .map(|i| Complex32::new(i as f32, 0.0))
             .collect::<Vec<_>>();
         let tw6 = TwiddleFactorBuffer::new(6);
-        fft.fft_mixed_radix_with_twiddles(&mut mix6, &tw6)
-            .unwrap();
+        fft.fft_mixed_radix_with_twiddles(&mut mix6, &tw6).unwrap();
     }
 
     #[test]
@@ -1895,8 +1968,7 @@ mod coverage_tests {
     fn test_fft_radix4_sizes() {
         let fft = ScalarFftImpl::<f32>::default();
         for &n in &[16usize, 64usize] {
-            let mut data: Vec<Complex32> =
-                (0..n).map(|i| Complex32::new(i as f32, 0.0)).collect();
+            let mut data: Vec<Complex32> = (0..n).map(|i| Complex32::new(i as f32, 0.0)).collect();
             fft.fft_radix4(&mut data).unwrap();
         }
     }


### PR DESCRIPTION
## Summary
- parallelize large FFTs via Rayon when `parallel` feature is enabled
- expose `fft_parallel` and `ifft_parallel` helpers
- document new parallel path and provide benchmark example

## Testing
- `cargo test`
- `cargo test --features parallel`

------
https://chatgpt.com/codex/tasks/task_e_689dc32fbf94832bbfad391a26761f36