### PR TITLE
Add multi-level wavelet transforms and new families

### DIFF
--- a/README.md
+++ b/README.md
@@ -253,7 +253,7 @@ parallel(&signal, &window, hop_size, &mut frames)?;
 - **DCT** – Discrete Cosine Transform ([Wikipedia](https://en.wikipedia.org/wiki/Discrete_cosine_transform))
 - **DST** – Discrete Sine Transform ([Wikipedia](https://en.wikipedia.org/wiki/Discrete_sine_transform))
 - **Hartley Transform** – ([Wikipedia](https://en.wikipedia.org/wiki/Discrete_Hartley_transform))
-- **Wavelet Transform** – ([Wikipedia](https://en.wikipedia.org/wiki/Wavelet_transform))
+- **Wavelet Transform** – multi-level Haar, Daubechies, Symlets, Coiflets ([Wikipedia](https://en.wikipedia.org/wiki/Wavelet_transform))
 - **Goertzel Algorithm** – ([Wikipedia](https://en.wikipedia.org/wiki/Goertzel_algorithm))
 - **Chirp Z-Transform** – ([Wikipedia](https://en.wikipedia.org/wiki/Chirp_Z-transform))
 - **Hilbert Transform** – ([Wikipedia](https://en.wikipedia.org/wiki/Hilbert_transform))
@@ -276,8 +276,14 @@ let dst3_result = dst::dst3(&input);
 let hartley_result = hartley::dht(&input);
 
 // Wavelet Transform
-let (avg, diff) = wavelet::haar_forward(&input);
-let reconstructed = wavelet::haar_inverse(&avg, &diff);
+use wavelet::{
+    haar_forward_multi, haar_inverse_multi, db4_forward_multi, db4_inverse_multi,
+};
+let (approx, details) = haar_forward_multi(&input, 2);
+let reconstructed = haar_inverse_multi(&approx, &details);
+// Additional families, e.g. Daubechies-4
+let (db4_a, db4_d) = db4_forward_multi(&input, 2);
+let db4_recon = db4_inverse_multi(&db4_a, &db4_d);
 
 // Goertzel Algorithm (single frequency detection)
 let magnitude = goertzel::goertzel_f32(&input, 44100.0, 1000.0);

--- a/examples/wavelet_usage.rs
+++ b/examples/wavelet_usage.rs
@@ -1,0 +1,16 @@
+use kofft::wavelet::{
+    haar_forward_multi, haar_inverse_multi, db4_forward_multi, db4_inverse_multi,
+};
+
+fn main() {
+    let signal = vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0];
+    let (approx, details) = haar_forward_multi(&signal, 2);
+    println!("Haar approx: {:?}\nHaar details: {:?}", approx, details);
+    let recon = haar_inverse_multi(&approx, &details);
+    println!("Haar recon: {:?}", recon);
+
+    let (approx2, details2) = db4_forward_multi(&signal, 2);
+    println!("Db4 approx: {:?}\nDb4 details: {:?}", approx2, details2);
+    let recon2 = db4_inverse_multi(&approx2, &details2);
+    println!("Db4 recon: {:?}", recon2);
+}

--- a/src/wavelet.rs
+++ b/src/wavelet.rs
@@ -45,6 +45,65 @@ pub fn batch_inverse(avgs: &[Vec<f32>], diffs: &[Vec<f32>]) -> Vec<Vec<f32>> {
     avgs.iter().zip(diffs.iter()).map(|(a, d)| haar_inverse(a, d)).collect()
 }
 
+/// Multi-level decomposition using a single-level forward function.
+pub fn multi_level_forward<F>(input: &[f32], levels: usize, forward: F) -> (Vec<f32>, Vec<Vec<f32>>)
+where
+    F: Fn(&[f32]) -> (Vec<f32>, Vec<f32>),
+{
+    let mut current = input.to_vec();
+    let mut details = Vec::with_capacity(levels);
+    for _ in 0..levels {
+        if current.len() % 2 != 0 {
+            if let Some(&last) = current.last() {
+                current.push(last);
+            }
+        }
+        let (avg, diff) = forward(&current);
+        details.push(diff);
+        current = avg;
+    }
+    (current, details)
+}
+
+/// Multi-level reconstruction using a single-level inverse function.
+pub fn multi_level_inverse<F>(approx: &[f32], details: &[Vec<f32>], inverse: F) -> Vec<f32>
+where
+    F: Fn(&[f32], &[f32]) -> Vec<f32>,
+{
+    let mut current = approx.to_vec();
+    for d in details.iter().rev() {
+        current = inverse(&current, d);
+    }
+    current
+}
+
+/// Batch multi-level decomposition.
+pub fn multi_level_forward_batch<F>(inputs: &[Vec<f32>], levels: usize, forward: F) -> (Vec<Vec<f32>>, Vec<Vec<Vec<f32>>>)
+where
+    F: Fn(&[f32]) -> (Vec<f32>, Vec<f32>),
+{
+    let mut avgs = Vec::with_capacity(inputs.len());
+    let mut diffs = Vec::with_capacity(inputs.len());
+    for input in inputs {
+        let (avg, diff_levels) = multi_level_forward(input, levels, &forward);
+        avgs.push(avg);
+        diffs.push(diff_levels);
+    }
+    (avgs, diffs)
+}
+
+/// Batch multi-level reconstruction.
+pub fn multi_level_inverse_batch<F>(avgs: &[Vec<f32>], diffs: &[Vec<Vec<f32>>], inverse: F) -> Vec<Vec<f32>>
+where
+    F: Fn(&[f32], &[f32]) -> Vec<f32>,
+{
+    avgs
+        .iter()
+        .zip(diffs.iter())
+        .map(|(a, d)| multi_level_inverse(a, d, &inverse))
+        .collect()
+}
+
 /// MCU/stack-only, const-generic, in-place Haar wavelet forward (N must be even, no heap)
 /// Output buffers avg and diff must be of length N/2.
 pub fn haar_forward_inplace_stack<const N: usize>(input: &[f32; N], avg: &mut [f32], diff: &mut [f32]) {
@@ -84,11 +143,16 @@ pub fn db2_forward(input: &[f32]) -> (Vec<f32>, Vec<f32>) {
     let g2 = 0.8365163037378079;
     let g3 = -0.4829629131445341;
     let len = input.len();
-    let reflect = |idx: isize| -> f32 {
-        let mut i = idx;
-        if i < 0 { i = -i; }
-        if i >= len as isize { i = 2 * (len as isize - 1) - i; }
-        input[i as usize]
+    let reflect = |mut idx: isize| -> f32 {
+        let n = len as isize;
+        while idx < 0 || idx >= n {
+            if idx < 0 {
+                idx = -idx;
+            } else {
+                idx = 2 * (n - 1) - idx;
+            }
+        }
+        input[idx as usize]
     };
     for i in 0..n {
         let j = 2 * i as isize;
@@ -112,11 +176,16 @@ pub fn db2_inverse(approx: &[f32], detail: &[f32]) -> Vec<f32> {
     let _h1 = -0.2241438680420134;
     let _h2 = 0.8365163037378079;
     let _h3 = -0.4829629131445341;
-    let reflect = |idx: isize| -> usize {
-        let mut i = idx;
-        if i < 0 { i = -i; }
-        if i >= len as isize { i = 2 * (len as isize - 1) - i; }
-        i as usize
+    let reflect = |mut idx: isize| -> usize {
+        let n = len as isize;
+        while idx < 0 || idx >= n {
+            if idx < 0 {
+                idx = -idx;
+            } else {
+                idx = 2 * (n - 1) - idx;
+            }
+        }
+        idx as usize
     };
     // Upsample and convolve
     for i in 0..n {
@@ -161,6 +230,313 @@ pub fn db2_forward_batch(inputs: &[Vec<f32>]) -> (Vec<Vec<f32>>, Vec<Vec<f32>>) 
 /// Batch db2 inverse transform
 pub fn db2_inverse_batch(avgs: &[Vec<f32>], diffs: &[Vec<f32>]) -> Vec<Vec<f32>> {
     avgs.iter().zip(diffs.iter()).map(|(a, d)| db2_inverse(a, d)).collect()
+}
+
+/// Daubechies-4 (db4) wavelet transform (single level)
+pub fn db4_forward(input: &[f32]) -> (Vec<f32>, Vec<f32>) {
+    let n = input.len() / 2;
+    let mut approx = vec![0.0; n];
+    let mut detail = vec![0.0; n];
+    // db4 coefficients
+    let h = [
+        -0.010597401785069032,
+        0.0328830116668852,
+        0.030841381835560764,
+        -0.18703481171909309,
+        -0.027983769416859854,
+        0.6308807679298589,
+        0.7148465705529157,
+        0.2303778133088965,
+    ];
+    let g = [
+        -0.2303778133088965,
+        0.7148465705529157,
+        -0.6308807679298589,
+        -0.027983769416859854,
+        0.18703481171909309,
+        0.030841381835560764,
+        -0.0328830116668852,
+        -0.010597401785069032,
+    ];
+    let len = input.len();
+    let reflect = |mut idx: isize| -> f32 {
+        let n = len as isize;
+        while idx < 0 || idx >= n {
+            if idx < 0 {
+                idx = -idx;
+            } else {
+                idx = 2 * (n - 1) - idx;
+            }
+        }
+        input[idx as usize]
+    };
+    for i in 0..n {
+        let j = 2 * i as isize;
+        for k in 0..8 {
+            let val = reflect(j + k as isize);
+            approx[i] += h[k] * val;
+            detail[i] += g[k] * val;
+        }
+    }
+    (approx, detail)
+}
+
+/// Daubechies-4 (db4) inverse wavelet transform (single level)
+pub fn db4_inverse(approx: &[f32], detail: &[f32]) -> Vec<f32> {
+    let n = approx.len();
+    let len = n * 2;
+    let mut output = vec![0.0; len];
+    let g = [
+        0.2303778133088965,
+        0.7148465705529157,
+        0.6308807679298589,
+        -0.027983769416859854,
+        -0.18703481171909309,
+        0.030841381835560764,
+        0.0328830116668852,
+        -0.010597401785069032,
+    ];
+    let h = [
+        -0.010597401785069032,
+        -0.0328830116668852,
+        0.030841381835560764,
+        0.18703481171909309,
+        -0.027983769416859854,
+        -0.6308807679298589,
+        0.7148465705529157,
+        -0.2303778133088965,
+    ];
+    let reflect = |mut idx: isize| -> usize {
+        let n = len as isize;
+        while idx < 0 || idx >= n {
+            if idx < 0 {
+                idx = -idx;
+            } else {
+                idx = 2 * (n - 1) - idx;
+            }
+        }
+        idx as usize
+    };
+    for i in 0..n {
+        let j = 2 * i;
+        for k in 0..8 {
+            let idx = reflect(j as isize + k as isize);
+            output[idx] += g[k] * approx[i] + h[k] * detail[i];
+        }
+    }
+    output
+}
+
+/// Symlet-4 (sym4) wavelet transform (single level)
+pub fn sym4_forward(input: &[f32]) -> (Vec<f32>, Vec<f32>) {
+    let n = input.len() / 2;
+    let mut approx = vec![0.0; n];
+    let mut detail = vec![0.0; n];
+    let h = [
+        -0.07576571478927333,
+        -0.02963552764599851,
+        0.49761866763201545,
+        0.8037387518059161,
+        0.29785779560527736,
+        -0.09921954357684722,
+        -0.012603967262037833,
+        0.0322231006040427,
+    ];
+    let g = [
+        -0.0322231006040427,
+        -0.012603967262037833,
+        0.09921954357684722,
+        0.29785779560527736,
+        -0.8037387518059161,
+        0.49761866763201545,
+        0.02963552764599851,
+        -0.07576571478927333,
+    ];
+    let len = input.len();
+    let reflect = |mut idx: isize| -> f32 {
+        let n = len as isize;
+        while idx < 0 || idx >= n {
+            if idx < 0 {
+                idx = -idx;
+            } else {
+                idx = 2 * (n - 1) - idx;
+            }
+        }
+        input[idx as usize]
+    };
+    for i in 0..n {
+        let j = 2 * i as isize;
+        for k in 0..8 {
+            let val = reflect(j + k as isize);
+            approx[i] += h[k] * val;
+            detail[i] += g[k] * val;
+        }
+    }
+    (approx, detail)
+}
+
+/// Symlet-4 (sym4) inverse wavelet transform (single level)
+pub fn sym4_inverse(approx: &[f32], detail: &[f32]) -> Vec<f32> {
+    let n = approx.len();
+    let len = n * 2;
+    let mut output = vec![0.0; len];
+    let g = [
+        0.0322231006040427,
+        -0.012603967262037833,
+        -0.09921954357684722,
+        0.29785779560527736,
+        0.8037387518059161,
+        0.49761866763201545,
+        -0.02963552764599851,
+        -0.07576571478927333,
+    ];
+    let h = [
+        -0.07576571478927333,
+        0.02963552764599851,
+        0.49761866763201545,
+        -0.8037387518059161,
+        0.29785779560527736,
+        0.09921954357684722,
+        -0.012603967262037833,
+        -0.0322231006040427,
+    ];
+    let reflect = |mut idx: isize| -> usize {
+        let n = len as isize;
+        while idx < 0 || idx >= n {
+            if idx < 0 {
+                idx = -idx;
+            } else {
+                idx = 2 * (n - 1) - idx;
+            }
+        }
+        idx as usize
+    };
+    for i in 0..n {
+        let j = 2 * i;
+        for k in 0..8 {
+            let idx = reflect(j as isize + k as isize);
+            output[idx] += g[k] * approx[i] + h[k] * detail[i];
+        }
+    }
+    output
+}
+
+/// Coiflet-1 (coif1) wavelet transform (single level)
+pub fn coif1_forward(input: &[f32]) -> (Vec<f32>, Vec<f32>) {
+    let n = input.len() / 2;
+    let mut approx = vec![0.0; n];
+    let mut detail = vec![0.0; n];
+    let h = [
+        -0.015655728135791993,
+        -0.07273261951252645,
+        0.3848648468648578,
+        0.8525720202116004,
+        0.3378976624574818,
+        -0.07273261951252645,
+    ];
+    let g = [
+        0.07273261951252645,
+        0.3378976624574818,
+        -0.8525720202116004,
+        0.3848648468648578,
+        0.07273261951252645,
+        -0.015655728135791993,
+    ];
+    let len = input.len();
+    let reflect = |mut idx: isize| -> f32 {
+        let n = len as isize;
+        while idx < 0 || idx >= n {
+            if idx < 0 {
+                idx = -idx;
+            } else {
+                idx = 2 * (n - 1) - idx;
+            }
+        }
+        input[idx as usize]
+    };
+    for i in 0..n {
+        let j = 2 * i as isize;
+        for k in 0..6 {
+            let val = reflect(j + k as isize);
+            approx[i] += h[k] * val;
+            detail[i] += g[k] * val;
+        }
+    }
+    (approx, detail)
+}
+
+/// Coiflet-1 (coif1) inverse wavelet transform (single level)
+pub fn coif1_inverse(approx: &[f32], detail: &[f32]) -> Vec<f32> {
+    let n = approx.len();
+    let len = n * 2;
+    let mut output = vec![0.0; len];
+    let g = [
+        -0.07273261951252645,
+        0.3378976624574818,
+        0.8525720202116004,
+        0.3848648468648578,
+        -0.07273261951252645,
+        -0.015655728135791993,
+    ];
+    let h = [
+        -0.015655728135791993,
+        0.07273261951252645,
+        0.3848648468648578,
+        -0.8525720202116004,
+        0.3378976624574818,
+        0.07273261951252645,
+    ];
+    let reflect = |mut idx: isize| -> usize {
+        let n = len as isize;
+        while idx < 0 || idx >= n {
+            if idx < 0 {
+                idx = -idx;
+            } else {
+                idx = 2 * (n - 1) - idx;
+            }
+        }
+        idx as usize
+    };
+    for i in 0..n {
+        let j = 2 * i;
+        for k in 0..6 {
+            let idx = reflect(j as isize + k as isize);
+            output[idx] += g[k] * approx[i] + h[k] * detail[i];
+        }
+    }
+    output
+}
+
+// Convenience wrappers for multi-level operations
+pub fn haar_forward_multi(input: &[f32], levels: usize) -> (Vec<f32>, Vec<Vec<f32>>) {
+    multi_level_forward(input, levels, haar_forward)
+}
+pub fn haar_inverse_multi(avg: &[f32], details: &[Vec<f32>]) -> Vec<f32> {
+    multi_level_inverse(avg, details, haar_inverse)
+}
+pub fn db2_forward_multi(input: &[f32], levels: usize) -> (Vec<f32>, Vec<Vec<f32>>) {
+    multi_level_forward(input, levels, db2_forward)
+}
+pub fn db2_inverse_multi(avg: &[f32], details: &[Vec<f32>]) -> Vec<f32> {
+    multi_level_inverse(avg, details, db2_inverse)
+}
+pub fn db4_forward_multi(input: &[f32], levels: usize) -> (Vec<f32>, Vec<Vec<f32>>) {
+    multi_level_forward(input, levels, db4_forward)
+}
+pub fn db4_inverse_multi(avg: &[f32], details: &[Vec<f32>]) -> Vec<f32> {
+    multi_level_inverse(avg, details, db4_inverse)
+}
+pub fn sym4_forward_multi(input: &[f32], levels: usize) -> (Vec<f32>, Vec<Vec<f32>>) {
+    multi_level_forward(input, levels, sym4_forward)
+}
+pub fn sym4_inverse_multi(avg: &[f32], details: &[Vec<f32>]) -> Vec<f32> {
+    multi_level_inverse(avg, details, sym4_inverse)
+}
+pub fn coif1_forward_multi(input: &[f32], levels: usize) -> (Vec<f32>, Vec<Vec<f32>>) {
+    multi_level_forward(input, levels, coif1_forward)
+}
+pub fn coif1_inverse_multi(avg: &[f32], details: &[Vec<f32>]) -> Vec<f32> {
+    multi_level_inverse(avg, details, coif1_inverse)
 }
 
 #[cfg(test)]
@@ -227,4 +603,20 @@ mod db2_tests {
             }
         }
     }
-} 
+}
+
+#[cfg(test)]
+mod multilevel_tests {
+    use super::*;
+
+    #[test]
+    fn test_haar_multi_roundtrip() {
+        let x = vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0];
+        let (a, d) = haar_forward_multi(&x, 3);
+        let recon = haar_inverse_multi(&a, &d);
+        for (o, r) in x.iter().zip(recon.iter()) {
+            assert!((o - r).abs() < 1e-5);
+        }
+    }
+
+}


### PR DESCRIPTION
## Summary
- add generic multi-level decomposition and reconstruction helpers with batch support
- implement Daubechies-4, Symlet-4, and Coiflet-1 wavelet transforms
- provide a new example and README instructions showcasing the additional wavelets

## Testing
- `cargo test`
- `cargo run --example wavelet_usage`


------
https://chatgpt.com/codex/tasks/task_e_689dc325f754832bba5f0dcb09389abd