### PR TITLE
feat: add benchmark suite and automation

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -1,0 +1,32 @@
+name: Benchmarks
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [ main ]
+  pull_request:
+
+jobs:
+  bench:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          override: true
+      - name: Run benchmarks
+        run: cargo bench --bench bench_fft --features parallel -- --sample-size=10 --measurement-time=0.5 --warm-up-time=0.2
+      - name: Update README
+        run: cargo run --example update_bench_readme
+      - name: Commit results
+        run: |
+          git config user.name github-actions
+          git config user.email github-actions@github.com
+          if [[ -n "$(git status --porcelain README.md benchmarks/latest.json)" ]]; then
+            git add README.md benchmarks/latest.json
+            git commit -m "chore: update benchmark results"
+            git push
+          fi

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,6 +35,13 @@ wasm = []
 [dev-dependencies]
 rand = "0.8"
 proptest = "1.4"
+criterion = { version = "0.7", features = ["html_reports"] }
+rustfft = "6"
+realfft = "3"
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+once_cell = "1"
+chrono = { version = "0.4", default-features = false, features = ["clock"] }
 
 [dependencies.rayon]
 version = "1.7"
@@ -65,3 +72,11 @@ path = "examples/ndfft_usage.rs"
 name = "parallel_benchmark"
 path = "examples/parallel_benchmark.rs"
 required-features = ["parallel"]
+
+[[example]]
+name = "update_bench_readme"
+path = "examples/update_bench_readme.rs"
+
+[[bench]]
+name = "bench_fft"
+harness = false

--- a/README.md
+++ b/README.md
@@ -405,6 +405,69 @@ fn main() -> ! {
 
 Feature selection precedence: `x86_64` (AVX2) → `sse` → scalar fallback.
 
+## Benchmark
+<!-- BENCH_START -->
+Last run: 2025-08-14T12:04:00.734481659+00:00 on local (Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz; rustc 1.87.0 (17067e9ac 2025-05-09); flags: ``)
+
+| Library | Transform | Size (N) | Mode | Time/op | Ops/sec | Allocations | Date/Runner |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| kofft | Complex | 1024 | Single | 0.081 ms | 12334.56 | 3 | 2025-08-14 local |
+| kofft | Complex | 1024 | Parallel | 0.040 ms | 24846.57 | 3 | 2025-08-14 local |
+| rustfft | Complex | 1024 | Single | 0.026 ms | 38292.17 | 1 | 2025-08-14 local |
+| kofft | Real | 1024 | Single | 0.060 ms | 16627.59 | 4 | 2025-08-14 local |
+| realfft | Real | 1024 | Single | 0.004 ms | 258933.20 | 0 | 2025-08-14 local |
+| kofft | Complex | 2048 | Single | 0.075 ms | 13320.37 | 3 | 2025-08-14 local |
+| kofft | Complex | 2048 | Parallel | 0.085 ms | 11782.59 | 3 | 2025-08-14 local |
+| rustfft | Complex | 2048 | Single | 0.009 ms | 112917.80 | 1 | 2025-08-14 local |
+| kofft | Real | 2048 | Single | 0.098 ms | 10237.41 | 4 | 2025-08-14 local |
+| realfft | Real | 2048 | Single | 0.007 ms | 134102.19 | 0 | 2025-08-14 local |
+| kofft | Complex | 4096 | Single | 1.046 ms | 955.65 | 3 | 2025-08-14 local |
+| kofft | Complex | 4096 | Parallel | 2.799 ms | 357.33 | 4 | 2025-08-14 local |
+| rustfft | Complex | 4096 | Single | 0.024 ms | 41382.16 | 1 | 2025-08-14 local |
+| kofft | Real | 4096 | Single | 1.171 ms | 853.74 | 4 | 2025-08-14 local |
+| realfft | Real | 4096 | Single | 0.015 ms | 64951.94 | 0 | 2025-08-14 local |
+| kofft | Complex | 8192 | Single | 2.378 ms | 420.60 | 3 | 2025-08-14 local |
+| kofft | Complex | 8192 | Parallel | 2.194 ms | 455.88 | 3 | 2025-08-14 local |
+| rustfft | Complex | 8192 | Single | 0.036 ms | 28052.85 | 1 | 2025-08-14 local |
+| kofft | Real | 8192 | Single | 1.225 ms | 816.26 | 4 | 2025-08-14 local |
+| realfft | Real | 8192 | Single | 0.031 ms | 32217.53 | 0 | 2025-08-14 local |
+| kofft | Complex | 16384 | Single | 3.120 ms | 320.51 | 3 | 2025-08-14 local |
+| kofft | Complex | 16384 | Parallel | 3.706 ms | 269.86 | 3 | 2025-08-14 local |
+| rustfft | Complex | 16384 | Single | 0.049 ms | 20264.66 | 1 | 2025-08-14 local |
+| kofft | Real | 16384 | Single | 2.298 ms | 435.16 | 4 | 2025-08-14 local |
+| realfft | Real | 16384 | Single | 0.027 ms | 36964.48 | 0 | 2025-08-14 local |
+| kofft | Complex | 32768 | Single | 3.654 ms | 273.68 | 3 | 2025-08-14 local |
+| kofft | Complex | 32768 | Parallel | 4.138 ms | 241.63 | 3 | 2025-08-14 local |
+| rustfft | Complex | 32768 | Single | 0.105 ms | 9564.16 | 1 | 2025-08-14 local |
+| kofft | Real | 32768 | Single | 3.871 ms | 258.33 | 4 | 2025-08-14 local |
+| realfft | Real | 32768 | Single | 0.076 ms | 13146.31 | 0 | 2025-08-14 local |
+| kofft | Complex | 65536 | Single | 4.232 ms | 236.32 | 3 | 2025-08-14 local |
+| kofft | Complex | 65536 | Parallel | 2.834 ms | 352.88 | 3 | 2025-08-14 local |
+| rustfft | Complex | 65536 | Single | 0.249 ms | 4015.79 | 1 | 2025-08-14 local |
+| kofft | Real | 65536 | Single | 2.854 ms | 350.41 | 4 | 2025-08-14 local |
+| realfft | Real | 65536 | Single | 0.140 ms | 7142.30 | 0 | 2025-08-14 local |
+| kofft | Complex | 131072 | Single | 5.810 ms | 172.11 | 4 | 2025-08-14 local |
+| kofft | Complex | 131072 | Parallel | 4.891 ms | 204.47 | 3 | 2025-08-14 local |
+| rustfft | Complex | 131072 | Single | 1.374 ms | 728.06 | 1 | 2025-08-14 local |
+| kofft | Real | 131072 | Single | 6.192 ms | 161.51 | 5 | 2025-08-14 local |
+| realfft | Real | 131072 | Single | 0.554 ms | 1806.64 | 0 | 2025-08-14 local |
+| kofft | Complex | 262144 | Single | 15.280 ms | 65.45 | 3 | 2025-08-14 local |
+| kofft | Complex | 262144 | Parallel | 9.065 ms | 110.32 | 3 | 2025-08-14 local |
+| rustfft | Complex | 262144 | Single | 7.525 ms | 132.88 | 1 | 2025-08-14 local |
+| kofft | Real | 262144 | Single | 21.934 ms | 45.59 | 4 | 2025-08-14 local |
+| realfft | Real | 262144 | Single | 0.733 ms | 1364.44 | 0 | 2025-08-14 local |
+| kofft | Complex | 524288 | Single | 29.240 ms | 34.20 | 3 | 2025-08-14 local |
+| kofft | Complex | 524288 | Parallel | 29.209 ms | 34.24 | 3 | 2025-08-14 local |
+| rustfft | Complex | 524288 | Single | 14.538 ms | 68.78 | 1 | 2025-08-14 local |
+| kofft | Real | 524288 | Single | 37.093 ms | 26.96 | 4 | 2025-08-14 local |
+| realfft | Real | 524288 | Single | 1.982 ms | 504.63 | 0 | 2025-08-14 local |
+| kofft | Complex | 1048576 | Single | 59.265 ms | 16.87 | 3 | 2025-08-14 local |
+| kofft | Complex | 1048576 | Parallel | 60.507 ms | 16.53 | 4 | 2025-08-14 local |
+| rustfft | Complex | 1048576 | Single | 30.361 ms | 32.94 | 1 | 2025-08-14 local |
+| kofft | Real | 1048576 | Single | 66.946 ms | 14.94 | 4 | 2025-08-14 local |
+| realfft | Real | 1048576 | Single | 4.361 ms | 229.31 | 0 | 2025-08-14 local |
+<!-- BENCH_END -->
+
 ## License
 
 Licensed under either of

--- a/benches/bench_fft.rs
+++ b/benches/bench_fft.rs
@@ -1,0 +1,360 @@
+use std::alloc::{GlobalAlloc, Layout, System};
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::Mutex;
+use std::time::{Duration, Instant};
+use std::{env, fs, process::Command};
+
+use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
+use once_cell::sync::Lazy;
+use serde::Serialize;
+
+use kofft::fft::{fft_parallel, Complex32, FftPlanner, ScalarFftImpl, FftImpl};
+use kofft::rfft::RealFftImpl;
+use rustfft::FftPlanner as RustFftPlanner;
+use realfft::RealFftPlanner as RustRealFftPlanner;
+
+// ---------------- Allocation tracking ----------------
+struct CountingAllocator;
+
+static ALLOCATIONS: AtomicUsize = AtomicUsize::new(0);
+static CURRENT_BYTES: AtomicUsize = AtomicUsize::new(0);
+static PEAK_BYTES: AtomicUsize = AtomicUsize::new(0);
+
+unsafe impl GlobalAlloc for CountingAllocator {
+    unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
+        let ptr = System.alloc(layout);
+        if !ptr.is_null() {
+            ALLOCATIONS.fetch_add(1, Ordering::Relaxed);
+            let new = CURRENT_BYTES.fetch_add(layout.size(), Ordering::Relaxed) + layout.size();
+            update_peak(new);
+        }
+        ptr
+    }
+
+    unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout) {
+        System.dealloc(ptr, layout);
+        CURRENT_BYTES.fetch_sub(layout.size(), Ordering::Relaxed);
+    }
+}
+
+#[global_allocator]
+static GLOBAL: CountingAllocator = CountingAllocator;
+
+fn update_peak(new: usize) {
+    let mut peak = PEAK_BYTES.load(Ordering::Relaxed);
+    while new > peak {
+        match PEAK_BYTES.compare_exchange(peak, new, Ordering::Relaxed, Ordering::Relaxed) {
+            Ok(_) => break,
+            Err(old) => peak = old,
+        }
+    }
+}
+
+fn reset_alloc() {
+    ALLOCATIONS.store(0, Ordering::Relaxed);
+    CURRENT_BYTES.store(0, Ordering::Relaxed);
+    PEAK_BYTES.store(0, Ordering::Relaxed);
+}
+
+fn alloc_stats() -> (usize, usize) {
+    (ALLOCATIONS.load(Ordering::Relaxed), PEAK_BYTES.load(Ordering::Relaxed))
+}
+
+// ---------------- Result tracking ----------------
+#[derive(Serialize, Clone)]
+struct BenchRecord {
+    library: String,
+    transform: String,
+    size: usize,
+    mode: String,
+    time_per_op_ns: f64,
+    ops_per_sec: f64,
+    allocations: usize,
+    peak_bytes: usize,
+}
+
+#[derive(Serialize)]
+struct BenchFile {
+    env: EnvInfo,
+    results: Vec<BenchRecord>,
+}
+
+#[derive(Serialize)]
+struct EnvInfo {
+    cpu: String,
+    os: String,
+    rustc: String,
+    flags: String,
+    date: String,
+    runner: String,
+}
+
+static RESULTS: Lazy<Mutex<Vec<BenchRecord>>> = Lazy::new(|| Mutex::new(Vec::new()));
+
+// ---------------- Benchmark helpers ----------------
+fn bench_complex(c: &mut Criterion, size: usize) {
+    let mut group = c.benchmark_group(format!("complex_{}", size));
+
+    let mut input: Vec<Complex32> = (0..size)
+        .map(|i| Complex32::new(i as f32, 0.0))
+        .collect();
+    let mut data = input.clone();
+
+    // kofft single-threaded
+    let planner = FftPlanner::<f32>::new();
+    let fft = ScalarFftImpl::with_planner(planner);
+    let mut first = true;
+    group.bench_function(BenchmarkId::new("kofft/single", size), |b| {
+        b.iter_custom(|iters| {
+            let mut total = Duration::ZERO;
+            let mut alloc_total = 0;
+            let mut peak = 0;
+            for _ in 0..iters {
+                data.copy_from_slice(&input);
+                reset_alloc();
+                let start = Instant::now();
+                fft.fft(&mut data).unwrap();
+                let dur = start.elapsed();
+                let (a, p) = alloc_stats();
+                alloc_total += a;
+                if p > peak { peak = p; }
+                total += dur;
+            }
+            if first {
+                let t = total.as_secs_f64() / iters as f64;
+                RESULTS.lock().unwrap().push(BenchRecord {
+                    library: "kofft".into(),
+                    transform: "Complex".into(),
+                    size,
+                    mode: "Single".into(),
+                    time_per_op_ns: t * 1e9,
+                    ops_per_sec: 1.0 / t,
+                    allocations: alloc_total / iters as usize,
+                    peak_bytes: peak,
+                });
+                first = false;
+            }
+            total
+        });
+    });
+
+    // kofft parallel (if enabled)
+    #[cfg(feature = "parallel")]
+    {
+        let mut first_p = true;
+        group.bench_function(BenchmarkId::new("kofft/parallel", size), |b| {
+            b.iter_custom(|iters| {
+                let mut total = Duration::ZERO;
+                let mut alloc_total = 0;
+                let mut peak = 0;
+                for _ in 0..iters {
+                    data.copy_from_slice(&input);
+                    reset_alloc();
+                    let start = Instant::now();
+                    fft_parallel(&mut data).unwrap();
+                    let dur = start.elapsed();
+                    let (a, p) = alloc_stats();
+                    alloc_total += a;
+                    if p > peak { peak = p; }
+                    total += dur;
+                }
+                if first_p {
+                    let t = total.as_secs_f64() / iters as f64;
+                    RESULTS.lock().unwrap().push(BenchRecord {
+                        library: "kofft".into(),
+                        transform: "Complex".into(),
+                        size,
+                        mode: "Parallel".into(),
+                        time_per_op_ns: t * 1e9,
+                        ops_per_sec: 1.0 / t,
+                        allocations: alloc_total / iters as usize,
+                        peak_bytes: peak,
+                    });
+                    first_p = false;
+                }
+                total
+            });
+        });
+    }
+
+    // rustfft single-threaded
+    let mut rust_planner = RustFftPlanner::<f32>::new();
+    let rust_fft = rust_planner.plan_fft_forward(size);
+    let mut rust_input: Vec<rustfft::num_complex::Complex<f32>> = (0..size)
+        .map(|i| rustfft::num_complex::Complex::new(i as f32, 0.0))
+        .collect();
+    let mut rust_data = rust_input.clone();
+    let mut first_rust = true;
+    group.bench_function(BenchmarkId::new("rustfft/single", size), |b| {
+        b.iter_custom(|iters| {
+            let mut total = Duration::ZERO;
+            let mut alloc_total = 0;
+            let mut peak = 0;
+            for _ in 0..iters {
+                rust_data.copy_from_slice(&rust_input);
+                reset_alloc();
+                let start = Instant::now();
+                rust_fft.process(&mut rust_data);
+                let dur = start.elapsed();
+                let (a, p) = alloc_stats();
+                alloc_total += a;
+                if p > peak { peak = p; }
+                total += dur;
+            }
+            if first_rust {
+                let t = total.as_secs_f64() / iters as f64;
+                RESULTS.lock().unwrap().push(BenchRecord {
+                    library: "rustfft".into(),
+                    transform: "Complex".into(),
+                    size,
+                    mode: "Single".into(),
+                    time_per_op_ns: t * 1e9,
+                    ops_per_sec: 1.0 / t,
+                    allocations: alloc_total / iters as usize,
+                    peak_bytes: peak,
+                });
+                first_rust = false;
+            }
+            total
+        });
+    });
+
+    group.finish();
+}
+
+fn bench_real(c: &mut Criterion, size: usize) {
+    let mut group = c.benchmark_group(format!("real_{}", size));
+
+    let mut input: Vec<f32> = (0..size).map(|i| i as f32).collect();
+    let mut output = vec![Complex32::new(0.0, 0.0); size / 2 + 1];
+
+    // kofft real
+    let planner = FftPlanner::<f32>::new();
+    let fft = ScalarFftImpl::with_planner(planner);
+    let mut first = true;
+    group.bench_function(BenchmarkId::new("kofft/single", size), |b| {
+        b.iter_custom(|iters| {
+            let mut total = Duration::ZERO;
+            let mut alloc_total = 0;
+            let mut peak = 0;
+            for _ in 0..iters {
+                reset_alloc();
+                let start = Instant::now();
+                fft.rfft(&mut input, &mut output).unwrap();
+                let dur = start.elapsed();
+                let (a, p) = alloc_stats();
+                alloc_total += a;
+                if p > peak { peak = p; }
+                total += dur;
+            }
+            if first {
+                let t = total.as_secs_f64() / iters as f64;
+                RESULTS.lock().unwrap().push(BenchRecord {
+                    library: "kofft".into(),
+                    transform: "Real".into(),
+                    size,
+                    mode: "Single".into(),
+                    time_per_op_ns: t * 1e9,
+                    ops_per_sec: 1.0 / t,
+                    allocations: alloc_total / iters as usize,
+                    peak_bytes: peak,
+                });
+                first = false;
+            }
+            total
+        });
+    });
+
+    // realfft crate
+    let mut planner = RustRealFftPlanner::<f32>::new();
+    let rfft = planner.plan_fft_forward(size);
+    let mut in_data = input.clone();
+    let mut out_data = rfft.make_output_vec();
+    let mut first_realfft = true;
+    group.bench_function(BenchmarkId::new("realfft/single", size), |b| {
+        b.iter_custom(|iters| {
+            let mut total = Duration::ZERO;
+            let mut alloc_total = 0;
+            let mut peak = 0;
+            for _ in 0..iters {
+                in_data.copy_from_slice(&input);
+                reset_alloc();
+                let start = Instant::now();
+                rfft.process(&mut in_data, &mut out_data).unwrap();
+                let dur = start.elapsed();
+                let (a, p) = alloc_stats();
+                alloc_total += a;
+                if p > peak { peak = p; }
+                total += dur;
+            }
+            if first_realfft {
+                let t = total.as_secs_f64() / iters as f64;
+                RESULTS.lock().unwrap().push(BenchRecord {
+                    library: "realfft".into(),
+                    transform: "Real".into(),
+                    size,
+                    mode: "Single".into(),
+                    time_per_op_ns: t * 1e9,
+                    ops_per_sec: 1.0 / t,
+                    allocations: alloc_total / iters as usize,
+                    peak_bytes: peak,
+                });
+                first_realfft = false;
+            }
+            total
+        });
+    });
+
+    group.finish();
+}
+
+fn save_results() {
+    let cpu = Command::new("sh")
+        .arg("-c")
+        .arg("grep 'model name' /proc/cpuinfo | head -n1 | cut -d: -f2")
+        .output()
+        .ok()
+        .and_then(|o| String::from_utf8(o.stdout).ok())
+        .unwrap_or_default()
+        .trim()
+        .to_string();
+    let os = Command::new("uname")
+        .arg("-srmo")
+        .output()
+        .ok()
+        .and_then(|o| String::from_utf8(o.stdout).ok())
+        .unwrap_or_default()
+        .trim()
+        .to_string();
+    let rustc = Command::new("rustc")
+        .arg("--version")
+        .output()
+        .ok()
+        .and_then(|o| String::from_utf8(o.stdout).ok())
+        .unwrap_or_default()
+        .trim()
+        .to_string();
+    let flags = env::var("RUSTFLAGS").unwrap_or_default();
+    let date = chrono::Utc::now().to_rfc3339();
+    let runner = env::var("RUNNER_NAME").unwrap_or_else(|_| "local".to_string());
+
+    let file = BenchFile {
+        env: EnvInfo { cpu, os, rustc, flags, date: date.clone(), runner },
+        results: RESULTS.lock().unwrap().clone(),
+    };
+    let json = serde_json::to_string_pretty(&file).unwrap();
+    fs::create_dir_all("benchmarks").unwrap();
+    fs::write("benchmarks/latest.json", json).unwrap();
+}
+
+fn main_bench(c: &mut Criterion) {
+    let sizes: Vec<usize> = (10..=20).map(|p| 1usize << p).collect();
+    for size in sizes {
+        bench_complex(c, size);
+        bench_real(c, size);
+    }
+    save_results();
+}
+
+criterion_group!(benches, main_bench);
+criterion_main!(benches);

--- a/benchmarks/latest.json
+++ b/benchmarks/latest.json
@@ -1,0 +1,562 @@
+{
+  "env": {
+    "cpu": "Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz",
+    "os": "Linux 6.12.13 x86_64 GNU/Linux",
+    "rustc": "rustc 1.87.0 (17067e9ac 2025-05-09)",
+    "flags": "",
+    "date": "2025-08-14T12:04:00.734481659+00:00",
+    "runner": "local"
+  },
+  "results": [
+    {
+      "library": "kofft",
+      "transform": "Complex",
+      "size": 1024,
+      "mode": "Single",
+      "time_per_op_ns": 81073.0,
+      "ops_per_sec": 12334.562678080249,
+      "allocations": 3,
+      "peak_bytes": 8424
+    },
+    {
+      "library": "kofft",
+      "transform": "Complex",
+      "size": 1024,
+      "mode": "Parallel",
+      "time_per_op_ns": 40247.0,
+      "ops_per_sec": 24846.572415335304,
+      "allocations": 3,
+      "peak_bytes": 8424
+    },
+    {
+      "library": "rustfft",
+      "transform": "Complex",
+      "size": 1024,
+      "mode": "Single",
+      "time_per_op_ns": 26115.0,
+      "ops_per_sec": 38292.16925138809,
+      "allocations": 1,
+      "peak_bytes": 8192
+    },
+    {
+      "library": "kofft",
+      "transform": "Real",
+      "size": 1024,
+      "mode": "Single",
+      "time_per_op_ns": 60141.0,
+      "ops_per_sec": 16627.591825875857,
+      "allocations": 4,
+      "peak_bytes": 16616
+    },
+    {
+      "library": "realfft",
+      "transform": "Real",
+      "size": 1024,
+      "mode": "Single",
+      "time_per_op_ns": 3861.9999999999995,
+      "ops_per_sec": 258933.19523562925,
+      "allocations": 0,
+      "peak_bytes": 0
+    },
+    {
+      "library": "kofft",
+      "transform": "Complex",
+      "size": 2048,
+      "mode": "Single",
+      "time_per_op_ns": 75073.0,
+      "ops_per_sec": 13320.368174976356,
+      "allocations": 3,
+      "peak_bytes": 16616
+    },
+    {
+      "library": "kofft",
+      "transform": "Complex",
+      "size": 2048,
+      "mode": "Parallel",
+      "time_per_op_ns": 84871.0,
+      "ops_per_sec": 11782.587691908899,
+      "allocations": 3,
+      "peak_bytes": 16616
+    },
+    {
+      "library": "rustfft",
+      "transform": "Complex",
+      "size": 2048,
+      "mode": "Single",
+      "time_per_op_ns": 8856.0,
+      "ops_per_sec": 112917.79584462511,
+      "allocations": 1,
+      "peak_bytes": 16384
+    },
+    {
+      "library": "kofft",
+      "transform": "Real",
+      "size": 2048,
+      "mode": "Single",
+      "time_per_op_ns": 97681.0,
+      "ops_per_sec": 10237.405431967321,
+      "allocations": 4,
+      "peak_bytes": 33000
+    },
+    {
+      "library": "realfft",
+      "transform": "Real",
+      "size": 2048,
+      "mode": "Single",
+      "time_per_op_ns": 7457.0,
+      "ops_per_sec": 134102.1858656296,
+      "allocations": 0,
+      "peak_bytes": 0
+    },
+    {
+      "library": "kofft",
+      "transform": "Complex",
+      "size": 4096,
+      "mode": "Single",
+      "time_per_op_ns": 1046403.0,
+      "ops_per_sec": 955.654752518867,
+      "allocations": 3,
+      "peak_bytes": 33000
+    },
+    {
+      "library": "kofft",
+      "transform": "Complex",
+      "size": 4096,
+      "mode": "Parallel",
+      "time_per_op_ns": 2798523.0,
+      "ops_per_sec": 357.3313494296813,
+      "allocations": 4,
+      "peak_bytes": 34520
+    },
+    {
+      "library": "rustfft",
+      "transform": "Complex",
+      "size": 4096,
+      "mode": "Single",
+      "time_per_op_ns": 24165.0,
+      "ops_per_sec": 41382.16428719222,
+      "allocations": 1,
+      "peak_bytes": 32768
+    },
+    {
+      "library": "kofft",
+      "transform": "Real",
+      "size": 4096,
+      "mode": "Single",
+      "time_per_op_ns": 1171315.0,
+      "ops_per_sec": 853.7413078463095,
+      "allocations": 4,
+      "peak_bytes": 65768
+    },
+    {
+      "library": "realfft",
+      "transform": "Real",
+      "size": 4096,
+      "mode": "Single",
+      "time_per_op_ns": 15396.0,
+      "ops_per_sec": 64951.93556767992,
+      "allocations": 0,
+      "peak_bytes": 0
+    },
+    {
+      "library": "kofft",
+      "transform": "Complex",
+      "size": 8192,
+      "mode": "Single",
+      "time_per_op_ns": 2377548.0,
+      "ops_per_sec": 420.60139269533147,
+      "allocations": 3,
+      "peak_bytes": 65768
+    },
+    {
+      "library": "kofft",
+      "transform": "Complex",
+      "size": 8192,
+      "mode": "Parallel",
+      "time_per_op_ns": 2193568.0,
+      "ops_per_sec": 455.87827685305405,
+      "allocations": 3,
+      "peak_bytes": 65768
+    },
+    {
+      "library": "rustfft",
+      "transform": "Complex",
+      "size": 8192,
+      "mode": "Single",
+      "time_per_op_ns": 35647.0,
+      "ops_per_sec": 28052.85157236233,
+      "allocations": 1,
+      "peak_bytes": 65536
+    },
+    {
+      "library": "kofft",
+      "transform": "Real",
+      "size": 8192,
+      "mode": "Single",
+      "time_per_op_ns": 1225100.0,
+      "ops_per_sec": 816.259897151253,
+      "allocations": 4,
+      "peak_bytes": 131304
+    },
+    {
+      "library": "realfft",
+      "transform": "Real",
+      "size": 8192,
+      "mode": "Single",
+      "time_per_op_ns": 31039.0,
+      "ops_per_sec": 32217.532781339607,
+      "allocations": 0,
+      "peak_bytes": 0
+    },
+    {
+      "library": "kofft",
+      "transform": "Complex",
+      "size": 16384,
+      "mode": "Single",
+      "time_per_op_ns": 3120038.0,
+      "ops_per_sec": 320.5089168785765,
+      "allocations": 3,
+      "peak_bytes": 131304
+    },
+    {
+      "library": "kofft",
+      "transform": "Complex",
+      "size": 16384,
+      "mode": "Parallel",
+      "time_per_op_ns": 3705577.0,
+      "ops_per_sec": 269.86350573743306,
+      "allocations": 3,
+      "peak_bytes": 131304
+    },
+    {
+      "library": "rustfft",
+      "transform": "Complex",
+      "size": 16384,
+      "mode": "Single",
+      "time_per_op_ns": 49347.0,
+      "ops_per_sec": 20264.656412750523,
+      "allocations": 1,
+      "peak_bytes": 131072
+    },
+    {
+      "library": "kofft",
+      "transform": "Real",
+      "size": 16384,
+      "mode": "Single",
+      "time_per_op_ns": 2298023.0,
+      "ops_per_sec": 435.1566542197358,
+      "allocations": 4,
+      "peak_bytes": 262376
+    },
+    {
+      "library": "realfft",
+      "transform": "Real",
+      "size": 16384,
+      "mode": "Single",
+      "time_per_op_ns": 27053.0,
+      "ops_per_sec": 36964.47713747089,
+      "allocations": 0,
+      "peak_bytes": 0
+    },
+    {
+      "library": "kofft",
+      "transform": "Complex",
+      "size": 32768,
+      "mode": "Single",
+      "time_per_op_ns": 3653932.0,
+      "ops_per_sec": 273.67778053888253,
+      "allocations": 3,
+      "peak_bytes": 262376
+    },
+    {
+      "library": "kofft",
+      "transform": "Complex",
+      "size": 32768,
+      "mode": "Parallel",
+      "time_per_op_ns": 4138496.9999999995,
+      "ops_per_sec": 241.63361722867023,
+      "allocations": 3,
+      "peak_bytes": 262376
+    },
+    {
+      "library": "rustfft",
+      "transform": "Complex",
+      "size": 32768,
+      "mode": "Single",
+      "time_per_op_ns": 104557.0,
+      "ops_per_sec": 9564.161175244126,
+      "allocations": 1,
+      "peak_bytes": 262144
+    },
+    {
+      "library": "kofft",
+      "transform": "Real",
+      "size": 32768,
+      "mode": "Single",
+      "time_per_op_ns": 3871067.0,
+      "ops_per_sec": 258.32670940595966,
+      "allocations": 4,
+      "peak_bytes": 524520
+    },
+    {
+      "library": "realfft",
+      "transform": "Real",
+      "size": 32768,
+      "mode": "Single",
+      "time_per_op_ns": 76067.0,
+      "ops_per_sec": 13146.305230914852,
+      "allocations": 0,
+      "peak_bytes": 0
+    },
+    {
+      "library": "kofft",
+      "transform": "Complex",
+      "size": 65536,
+      "mode": "Single",
+      "time_per_op_ns": 4231512.0,
+      "ops_per_sec": 236.32214678819298,
+      "allocations": 3,
+      "peak_bytes": 524520
+    },
+    {
+      "library": "kofft",
+      "transform": "Complex",
+      "size": 65536,
+      "mode": "Parallel",
+      "time_per_op_ns": 2833812.0,
+      "ops_per_sec": 352.88156024464575,
+      "allocations": 3,
+      "peak_bytes": 524520
+    },
+    {
+      "library": "rustfft",
+      "transform": "Complex",
+      "size": 65536,
+      "mode": "Single",
+      "time_per_op_ns": 249016.99999999997,
+      "ops_per_sec": 4015.7900866205923,
+      "allocations": 1,
+      "peak_bytes": 524288
+    },
+    {
+      "library": "kofft",
+      "transform": "Real",
+      "size": 65536,
+      "mode": "Single",
+      "time_per_op_ns": 2853792.0,
+      "ops_per_sec": 350.4109619762057,
+      "allocations": 4,
+      "peak_bytes": 1048808
+    },
+    {
+      "library": "realfft",
+      "transform": "Real",
+      "size": 65536,
+      "mode": "Single",
+      "time_per_op_ns": 140011.0,
+      "ops_per_sec": 7142.295962460093,
+      "allocations": 0,
+      "peak_bytes": 0
+    },
+    {
+      "library": "kofft",
+      "transform": "Complex",
+      "size": 131072,
+      "mode": "Single",
+      "time_per_op_ns": 5810307.0,
+      "ops_per_sec": 172.10794541493246,
+      "allocations": 4,
+      "peak_bytes": 1050328
+    },
+    {
+      "library": "kofft",
+      "transform": "Complex",
+      "size": 131072,
+      "mode": "Parallel",
+      "time_per_op_ns": 4890712.0,
+      "ops_per_sec": 204.46920611968153,
+      "allocations": 3,
+      "peak_bytes": 1048808
+    },
+    {
+      "library": "rustfft",
+      "transform": "Complex",
+      "size": 131072,
+      "mode": "Single",
+      "time_per_op_ns": 1373512.0,
+      "ops_per_sec": 728.0606212395669,
+      "allocations": 1,
+      "peak_bytes": 1048576
+    },
+    {
+      "library": "kofft",
+      "transform": "Real",
+      "size": 131072,
+      "mode": "Single",
+      "time_per_op_ns": 6191692.0,
+      "ops_per_sec": 161.50674161440847,
+      "allocations": 5,
+      "peak_bytes": 2098904
+    },
+    {
+      "library": "realfft",
+      "transform": "Real",
+      "size": 131072,
+      "mode": "Single",
+      "time_per_op_ns": 553515.0,
+      "ops_per_sec": 1806.6357731949452,
+      "allocations": 0,
+      "peak_bytes": 0
+    },
+    {
+      "library": "kofft",
+      "transform": "Complex",
+      "size": 262144,
+      "mode": "Single",
+      "time_per_op_ns": 15279566.0,
+      "ops_per_sec": 65.44688507513892,
+      "allocations": 3,
+      "peak_bytes": 2097384
+    },
+    {
+      "library": "kofft",
+      "transform": "Complex",
+      "size": 262144,
+      "mode": "Parallel",
+      "time_per_op_ns": 9064773.0,
+      "ops_per_sec": 110.3171585212338,
+      "allocations": 3,
+      "peak_bytes": 2097384
+    },
+    {
+      "library": "rustfft",
+      "transform": "Complex",
+      "size": 262144,
+      "mode": "Single",
+      "time_per_op_ns": 7525413.0,
+      "ops_per_sec": 132.8830723310468,
+      "allocations": 1,
+      "peak_bytes": 2097152
+    },
+    {
+      "library": "kofft",
+      "transform": "Real",
+      "size": 262144,
+      "mode": "Single",
+      "time_per_op_ns": 21933523.0,
+      "ops_per_sec": 45.59231091147555,
+      "allocations": 4,
+      "peak_bytes": 4194536
+    },
+    {
+      "library": "realfft",
+      "transform": "Real",
+      "size": 262144,
+      "mode": "Single",
+      "time_per_op_ns": 732899.0,
+      "ops_per_sec": 1364.4444868938285,
+      "allocations": 0,
+      "peak_bytes": 0
+    },
+    {
+      "library": "kofft",
+      "transform": "Complex",
+      "size": 524288,
+      "mode": "Single",
+      "time_per_op_ns": 29239924.0,
+      "ops_per_sec": 34.19981529363756,
+      "allocations": 3,
+      "peak_bytes": 4194536
+    },
+    {
+      "library": "kofft",
+      "transform": "Complex",
+      "size": 524288,
+      "mode": "Parallel",
+      "time_per_op_ns": 29208634.0,
+      "ops_per_sec": 34.23645213945986,
+      "allocations": 3,
+      "peak_bytes": 4194536
+    },
+    {
+      "library": "rustfft",
+      "transform": "Complex",
+      "size": 524288,
+      "mode": "Single",
+      "time_per_op_ns": 14538185.0,
+      "ops_per_sec": 68.78437714198849,
+      "allocations": 1,
+      "peak_bytes": 4194304
+    },
+    {
+      "library": "kofft",
+      "transform": "Real",
+      "size": 524288,
+      "mode": "Single",
+      "time_per_op_ns": 37093445.0,
+      "ops_per_sec": 26.958941128277516,
+      "allocations": 4,
+      "peak_bytes": 8388840
+    },
+    {
+      "library": "realfft",
+      "transform": "Real",
+      "size": 524288,
+      "mode": "Single",
+      "time_per_op_ns": 1981662.9999999998,
+      "ops_per_sec": 504.6266696204148,
+      "allocations": 0,
+      "peak_bytes": 0
+    },
+    {
+      "library": "kofft",
+      "transform": "Complex",
+      "size": 1048576,
+      "mode": "Single",
+      "time_per_op_ns": 59265262.0,
+      "ops_per_sec": 16.873290798916912,
+      "allocations": 3,
+      "peak_bytes": 8388840
+    },
+    {
+      "library": "kofft",
+      "transform": "Complex",
+      "size": 1048576,
+      "mode": "Parallel",
+      "time_per_op_ns": 60506740.0,
+      "ops_per_sec": 16.527084420677763,
+      "allocations": 4,
+      "peak_bytes": 8390360
+    },
+    {
+      "library": "rustfft",
+      "transform": "Complex",
+      "size": 1048576,
+      "mode": "Single",
+      "time_per_op_ns": 30360928.0,
+      "ops_per_sec": 32.93706964424803,
+      "allocations": 1,
+      "peak_bytes": 8388608
+    },
+    {
+      "library": "kofft",
+      "transform": "Real",
+      "size": 1048576,
+      "mode": "Single",
+      "time_per_op_ns": 66945585.0,
+      "ops_per_sec": 14.937504840685161,
+      "allocations": 4,
+      "peak_bytes": 16777448
+    },
+    {
+      "library": "realfft",
+      "transform": "Real",
+      "size": 1048576,
+      "mode": "Single",
+      "time_per_op_ns": 4360857.0,
+      "ops_per_sec": 229.31272454015345,
+      "allocations": 0,
+      "peak_bytes": 0
+    }
+  ]
+}

--- a/examples/update_bench_readme.rs
+++ b/examples/update_bench_readme.rs
@@ -1,0 +1,71 @@
+use std::fs;
+use std::error::Error;
+use serde::Deserialize;
+
+#[derive(Deserialize)]
+struct BenchFile {
+    env: EnvInfo,
+    results: Vec<BenchRecord>,
+}
+
+#[derive(Deserialize)]
+struct EnvInfo {
+    cpu: String,
+    os: String,
+    rustc: String,
+    flags: String,
+    date: String,
+    runner: String,
+}
+
+#[derive(Deserialize)]
+struct BenchRecord {
+    library: String,
+    transform: String,
+    size: usize,
+    mode: String,
+    time_per_op_ns: f64,
+    ops_per_sec: f64,
+    allocations: usize,
+    peak_bytes: usize,
+}
+
+fn main() -> Result<(), Box<dyn Error>> {
+    let data = fs::read_to_string("benchmarks/latest.json")?;
+    let bf: BenchFile = serde_json::from_str(&data)?;
+
+    let mut table = String::new();
+    table.push_str(&format!(
+        "Last run: {} on {} ({}; {}; flags: `{}`)\n\n",
+        bf.env.date, bf.env.runner, bf.env.cpu.trim(), bf.env.rustc, bf.env.flags
+    ));
+    table.push_str("| Library | Transform | Size (N) | Mode | Time/op | Ops/sec | Allocations | Date/Runner |\n");
+    table.push_str("| --- | --- | --- | --- | --- | --- | --- | --- |\n");
+    let date_short = bf.env.date.split('T').next().unwrap_or("");
+    for r in &bf.results {
+        let time_ms = r.time_per_op_ns / 1_000_000.0;
+        table.push_str(&format!(
+            "| {} | {} | {} | {} | {:.3} ms | {:.2} | {} | {} {} |\n",
+            r.library, r.transform, r.size, r.mode, time_ms, r.ops_per_sec,
+            r.allocations, date_short, bf.env.runner
+        ));
+    }
+    update_readme(&table)?;
+    Ok(())
+}
+
+fn update_readme(table: &str) -> Result<(), Box<dyn Error>> {
+    let path = "README.md";
+    let content = fs::read_to_string(path)?;
+    let start = "<!-- BENCH_START -->";
+    let end = "<!-- BENCH_END -->";
+    if let (Some(s), Some(e)) = (content.find(start), content.find(end)) {
+        let mut new_content = String::new();
+        new_content.push_str(&content[..s + start.len()]);
+        new_content.push('\n');
+        new_content.push_str(table);
+        new_content.push_str(&content[e..]);
+        fs::write(path, new_content)?;
+    }
+    Ok(())
+}


### PR DESCRIPTION
## Summary
- add Criterion-based FFT benchmarks comparing kofft with rustfft and realfft
- track allocations and env info and expose latest results in README
- set up GitHub Actions workflow to run benchmarks and auto-commit table

## Testing
- `cargo bench --bench bench_fft --features parallel -- --sample-size=10 --measurement-time=0.5 --warm-up-time=0.2`
- `cargo run --example update_bench_readme`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_689dce90f52c832bbe39cf275ec9d7fa