### PR TITLE
feat: add SIMD benchmarking support

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -9,6 +9,8 @@ on:
 jobs:
   bench:
     runs-on: ubuntu-latest
+    env:
+      RUSTFLAGS: "-C target-cpu=native"
     steps:
       - uses: actions/checkout@v4
         with:
@@ -17,8 +19,10 @@ jobs:
         with:
           toolchain: stable
           override: true
-      - name: Run benchmarks
-        run: cargo bench --bench bench_fft --features parallel -- --sample-size=10 --measurement-time=0.5 --warm-up-time=0.2
+      - name: Run benchmarks (SIMD enabled)
+        run: cargo bench --bench bench_fft --features "parallel x86_64" -- --sample-size=10 --measurement-time=0.5 --warm-up-time=0.2
+      - name: SIMD speedup example
+        run: cargo run --example simd_speedup --features x86_64 --release
       - name: Update README
         run: cargo run --example update_bench_readme
       - name: Commit results

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,9 @@ exclude = [
 libm = "0.2"
 
 [features]
-default = ["std"]
+# Enable parallel helpers by default; architecture-specific SIMD features can be
+# activated explicitly for benchmarking or when targeting those platforms.
+default = ["std", "parallel"]
 std = []
 parallel = ["rayon"]
 x86_64 = []
@@ -76,6 +78,10 @@ required-features = ["parallel"]
 [[example]]
 name = "update_bench_readme"
 path = "examples/update_bench_readme.rs"
+
+[[example]]
+name = "simd_speedup"
+path = "examples/simd_speedup.rs"
 
 [[bench]]
 name = "bench_fft"

--- a/README.md
+++ b/README.md
@@ -24,12 +24,12 @@ High-performance, `no_std`, MCU-friendly DSP library featuring FFT, DCT, DST, Ha
 
 ```toml
 [dependencies]
-kofft = { version = "0.1.1", features = [
-    # "x86_64",   # enable AVX2 on x86_64
-    # "sse",      # enable SSE on x86_64 without AVX2
+kofft = { version = "0.1.4", features = [
+    # "x86_64",   # enable AVX2/FMA on x86_64
+    # "sse",      # enable SSE2 on x86_64 without AVX2
     # "aarch64",  # enable NEON on AArch64
     # "wasm",     # enable WebAssembly SIMD
-    # "parallel", # enable Rayon-based parallel helpers
+    # parallel is enabled by default
 ] }
 ```
 
@@ -404,6 +404,21 @@ fn main() -> ! {
 | Generic  | Scalar      | Default fallback |
 
 Feature selection precedence: `x86_64` (AVX2) → `sse` → scalar fallback.
+
+### Benchmarking with SIMD features
+
+For benchmarking on x86_64, enable the `x86_64` feature and compile for your
+native CPU so that AVX2/FMA instructions are used:
+
+```bash
+RUSTFLAGS="-C target-cpu=native" cargo bench --features "x86_64"
+```
+
+An example comparing scalar and SIMD implementations is available:
+
+```bash
+RUSTFLAGS="-C target-cpu=native" cargo run --release --example simd_speedup --features "x86_64"
+```
 
 ## Benchmark
 <!-- BENCH_START -->

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,37 @@
+use std::env;
+
+fn main() {
+    println!("cargo:rerun-if-changed=build.rs");
+
+    let _target_arch = env::var("CARGO_CFG_TARGET_ARCH").unwrap_or_default();
+
+    #[cfg(feature = "x86_64")]
+    {
+        let target_arch = env::var("CARGO_CFG_TARGET_ARCH").unwrap_or_default();
+        if target_arch == "x86_64" {
+            // Detect AVX2 and FMA support at build time
+            if std::arch::is_x86_feature_detected!("avx2") && std::arch::is_x86_feature_detected!("fma") {
+                println!("cargo:rustc-flags=-C target-feature=+avx2,+fma");
+            }
+        }
+    }
+
+    #[cfg(all(feature = "sse", not(feature = "x86_64")))]
+    {
+        let target_arch = env::var("CARGO_CFG_TARGET_ARCH").unwrap_or_default();
+        if target_arch == "x86_64" {
+            // Enable SSE2 when AVX2/FMA are not enabled
+            println!("cargo:rustc-flags=-C target-feature=+sse2");
+        }
+    }
+
+    #[cfg(feature = "aarch64")]
+    {
+        let target_arch = env::var("CARGO_CFG_TARGET_ARCH").unwrap_or_default();
+        if target_arch == "aarch64" {
+            // Explicitly enable NEON on AArch64 targets
+            println!("cargo:rustc-flags=-C target-feature=+neon");
+        }
+    }
+}
+

--- a/examples/simd_speedup.rs
+++ b/examples/simd_speedup.rs
@@ -1,0 +1,36 @@
+//! Compare scalar and SIMD FFT performance.
+//!
+//! Build with architecture-specific features and CPU flags, e.g.:
+//! `RUSTFLAGS="-C target-cpu=native" cargo run --release --example simd_speedup --features x86_64`
+
+use std::time::Instant;
+
+use kofft::fft::{new_fft_impl, Complex32, FftImpl, ScalarFftImpl};
+
+fn main() {
+    let size = 1 << 14;
+    let data: Vec<Complex32> = (0..size)
+        .map(|i| Complex32::new(i as f32, 0.0))
+        .collect();
+
+    // Scalar implementation
+    let mut scalar_data = data.clone();
+    let scalar = ScalarFftImpl::<f32>::default();
+    let start = Instant::now();
+    scalar.fft(&mut scalar_data).unwrap();
+    let scalar_time = start.elapsed();
+
+    // Best available implementation (SIMD when enabled)
+    let mut simd_data = data.clone();
+    let simd = new_fft_impl();
+    let start = Instant::now();
+    simd.fft(&mut simd_data).unwrap();
+    let simd_time = start.elapsed();
+
+    println!("Scalar FFT: {:?}", scalar_time);
+    println!("SIMD FFT:   {:?}", simd_time);
+    if simd_time.as_nanos() > 0 {
+        println!("Speedup: {:.2}x", scalar_time.as_secs_f64() / simd_time.as_secs_f64());
+    }
+}
+


### PR DESCRIPTION
## Summary
- enable parallel helpers by default and add SIMD speedup example
- pass AVX2/FMA/NEON flags via build script when relevant features are enabled
- run benches with native CPU flags in CI and exercise SIMD example

## Testing
- `cargo test`
- `cargo run --example simd_speedup`


------
https://chatgpt.com/codex/tasks/task_e_689dd9c6f5e4832b86697848fdeb77e9