### PR TITLE
Use half-size FFT for real transforms

### DIFF
--- a/examples/basic_usage.rs
+++ b/examples/basic_usage.rs
@@ -8,10 +8,10 @@ use kofft::czt::czt_f32;
 use kofft::dct::dct2;
 use kofft::dst::dst2;
 use kofft::fft::{FftImpl, ScalarFftImpl};
-use kofft::rfft::RealFftImpl;
 use kofft::goertzel::goertzel_f32;
 use kofft::hartley::dht;
 use kofft::hilbert::hilbert_analytic;
+use kofft::rfft::RealFftImpl;
 use kofft::wavelet::haar_forward;
 use kofft::window::{hamming, hann};
 use kofft::Complex32;
@@ -63,8 +63,10 @@ fn main() {
     println!("2. Real FFT");
     let mut real_input = vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0];
     let mut real_output = vec![Complex32::zero(); real_input.len() / 2 + 1];
+    let mut scratch = vec![Complex32::zero(); real_input.len() / 2];
 
-    fft.rfft(&mut real_input, &mut real_output).unwrap();
+    fft.rfft_with_scratch(&mut real_input, &mut real_output, &mut scratch)
+        .unwrap();
     println!("   Real input: {:?}", real_input);
     println!(
         "   RFFT: {:?}",

--- a/examples/benchmark.rs
+++ b/examples/benchmark.rs
@@ -1,9 +1,9 @@
 //! Benchmark example for kofft
-//! 
+//!
 //! This example compares the performance of different implementations
 //! and features of the kofft library.
 
-use kofft::fft::{Complex32, ScalarFftImpl, FftImpl};
+use kofft::fft::{Complex32, FftImpl, ScalarFftImpl};
 use kofft::rfft::RealFftImpl;
 use std::time::Instant;
 
@@ -73,30 +73,39 @@ fn main() {
     }
     let ifft_duration = start.elapsed();
 
-    println!("FFT:  {} iterations in {:?} ({:.0} FFT/s)", 
-             iterations, fft_duration, 
-             iterations as f64 / (fft_duration.as_micros() as f64 / 1_000_000.0));
-    println!("IFFT: {} iterations in {:?} ({:.0} IFFT/s)", 
-             iterations, ifft_duration,
-             iterations as f64 / (ifft_duration.as_micros() as f64 / 1_000_000.0));
+    println!(
+        "FFT:  {} iterations in {:?} ({:.0} FFT/s)",
+        iterations,
+        fft_duration,
+        iterations as f64 / (fft_duration.as_micros() as f64 / 1_000_000.0)
+    );
+    println!(
+        "IFFT: {} iterations in {:?} ({:.0} IFFT/s)",
+        iterations,
+        ifft_duration,
+        iterations as f64 / (ifft_duration.as_micros() as f64 / 1_000_000.0)
+    );
     println!();
 
     // Real FFT performance
     println!("Real FFT Performance");
-    let mut real_input: Vec<f32> = (0..1024)
-        .map(|i| (i as f32 * 0.1).sin())
-        .collect();
+    let mut real_input: Vec<f32> = (0..1024).map(|i| (i as f32 * 0.1).sin()).collect();
     let mut real_output = vec![Complex32::zero(); real_input.len() / 2 + 1];
+    let mut scratch = vec![Complex32::zero(); real_input.len() / 2];
 
     let start = Instant::now();
     for _ in 0..iterations {
-        fft.rfft(&mut real_input, &mut real_output).unwrap();
+        fft.rfft_with_scratch(&mut real_input, &mut real_output, &mut scratch)
+            .unwrap();
     }
     let rfft_duration = start.elapsed();
 
-    println!("RFFT: {} iterations in {:?} ({:.0} RFFT/s)", 
-             iterations, rfft_duration,
-             iterations as f64 / (rfft_duration.as_micros() as f64 / 1_000_000.0));
+    println!(
+        "RFFT: {} iterations in {:?} ({:.0} RFFT/s)",
+        iterations,
+        rfft_duration,
+        iterations as f64 / (rfft_duration.as_micros() as f64 / 1_000_000.0)
+    );
     println!();
 
     // Memory usage comparison
@@ -107,7 +116,7 @@ fn main() {
     let sizes = [64, 128, 256, 512, 1024];
     for &size in &sizes {
         let complex_memory = size * 8; // Complex32 = 8 bytes
-        let real_memory = size * 4;    // f32 = 4 bytes
+        let real_memory = size * 4; // f32 = 4 bytes
         let rfft_memory = (size / 2 + 1) * 8; // RFFT output
 
         println!("Complex FFT\t\t{}\t\t{}", size, complex_memory);
@@ -141,4 +150,4 @@ fn main() {
     println!("Stack-only APIs\t\tYes\t\t\tZero allocation");
 
     println!("\n=== Benchmark completed! ===");
-} 
+}

--- a/examples/rfft_usage.rs
+++ b/examples/rfft_usage.rs
@@ -7,10 +7,13 @@ fn main() {
     let fft = ScalarFftImpl::<f32>::default();
     let mut input = vec![1.0f32, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0];
     let mut spectrum = vec![Complex32::new(0.0, 0.0); input.len() / 2 + 1];
-    fft.rfft(&mut input, &mut spectrum).unwrap();
+    let mut scratch = vec![Complex32::new(0.0, 0.0); input.len() / 2];
+    fft.rfft_with_scratch(&mut input, &mut spectrum, &mut scratch)
+        .unwrap();
 
     let mut output = vec![0.0f32; input.len()];
-    fft.irfft(&mut spectrum, &mut output).unwrap();
+    fft.irfft_with_scratch(&mut spectrum, &mut output, &mut scratch)
+        .unwrap();
     println!("Input: {:?}\nReconstructed: {:?}", input, output);
 
     // Stack-only helpers
@@ -19,5 +22,8 @@ fn main() {
     rfft_stack(&stack_input, &mut stack_freq).unwrap();
     let mut stack_out = [0.0f32; 4];
     irfft_stack(&stack_freq, &mut stack_out).unwrap();
-    println!("Stack input: {:?}\nStack output: {:?}", stack_input, stack_out);
+    println!(
+        "Stack input: {:?}\nStack output: {:?}",
+        stack_input, stack_out
+    );
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -422,10 +422,13 @@ mod tests {
         let mut input = vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0];
         let mut freq = vec![Complex32::zero(); input.len() / 2 + 1];
         let mut output = vec![0.0; input.len()];
+        let mut scratch = vec![Complex32::zero(); input.len() / 2];
 
         let fft = ScalarFftImpl::<f32>::default();
-        fft.rfft(&mut input, &mut freq).unwrap();
-        fft.irfft(&mut freq, &mut output).unwrap();
+        fft.rfft_with_scratch(&mut input, &mut freq, &mut scratch)
+            .unwrap();
+        fft.irfft_with_scratch(&mut freq, &mut output, &mut scratch)
+            .unwrap();
 
         for (a, b) in input.iter().zip(output.iter()) {
             assert!((a - b).abs() < 1e-5, "{} vs {}", a, b);
@@ -436,9 +439,11 @@ mod tests {
     fn test_rfft_hermitian_symmetry() {
         let mut input = vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0];
         let mut freq = vec![Complex32::zero(); input.len() / 2 + 1];
+        let mut scratch = vec![Complex32::zero(); input.len() / 2];
 
         let fft = ScalarFftImpl::<f32>::default();
-        fft.rfft(&mut input, &mut freq).unwrap();
+        fft.rfft_with_scratch(&mut input, &mut freq, &mut scratch)
+            .unwrap();
 
         // Check that the result has the expected Hermitian symmetry
         // The first element should be real


### PR DESCRIPTION
## Summary
- implement real FFT using half-size complex FFT with reusable scratch buffers
- expose rfft_with_scratch/irfft_with_scratch and update examples and benchmarks

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_689ddf73ba5c832bba6bc2ba88121fa7