### PR TITLE
refactor: address clippy warnings

### DIFF
--- a/src/czt.rs
+++ b/src/czt.rs
@@ -3,8 +3,8 @@
 //! no_std + alloc compatible
 
 extern crate alloc;
-use alloc::vec::Vec;
 use alloc::vec;
+use alloc::vec::Vec;
 
 // no additional libm functions needed
 
@@ -20,7 +20,7 @@ pub fn czt_f32(input: &[f32], m: usize, w: (f32, f32), a: (f32, f32)) -> Vec<(f3
     let a_inv_r = if denom == 0.0 { 0.0 } else { ar / denom };
     let a_inv_i = if denom == 0.0 { 0.0 } else { -ai / denom };
     let mut output = vec![(0.0, 0.0); m];
-    for k in 0..m {
+    for (k, out) in output.iter_mut().enumerate() {
         // compute w^k
         let mut w_k_r = 1.0;
         let mut w_k_i = 0.0;
@@ -37,8 +37,8 @@ pub fn czt_f32(input: &[f32], m: usize, w: (f32, f32), a: (f32, f32)) -> Vec<(f3
         for &x in input {
             let tr = a_pow_r * wnk_r - a_pow_i * wnk_i;
             let ti = a_pow_r * wnk_i + a_pow_i * wnk_r;
-            output[k].0 += x * tr;
-            output[k].1 += x * ti;
+            out.0 += x * tr;
+            out.1 += x * ti;
             // update powers
             let wtr = wnk_r * w_k_r - wnk_i * w_k_i;
             let wti = wnk_r * w_k_i + wnk_i * w_k_r;
@@ -56,12 +56,15 @@ pub fn czt_f32(input: &[f32], m: usize, w: (f32, f32), a: (f32, f32)) -> Vec<(f3
 #[cfg(test)]
 mod tests {
     use super::*;
-    
+
     #[test]
     fn test_czt_basic() {
         let x = [1.0, 0.0, 0.0, 0.0];
         // DFT via CZT: w = exp(-j*2pi/4), a = 1
-        let w = ((-2.0 * core::f32::consts::PI / 4.0).cos(), (-2.0 * core::f32::consts::PI / 4.0).sin());
+        let w = (
+            (-2.0 * core::f32::consts::PI / 4.0).cos(),
+            (-2.0 * core::f32::consts::PI / 4.0).sin(),
+        );
         let a = (1.0, 0.0);
         let y = czt_f32(&x, 4, w, a);
         assert!((y[0].0 - 1.0).abs() < 1e-5);

--- a/src/hartley.rs
+++ b/src/hartley.rs
@@ -3,8 +3,8 @@
 //! no_std + alloc compatible
 
 extern crate alloc;
-use alloc::vec::Vec;
 use alloc::vec;
+use alloc::vec::Vec;
 use libm::{cosf, sinf};
 
 #[cfg(not(feature = "std"))]
@@ -16,7 +16,7 @@ pub fn dht(input: &[f32]) -> Vec<f32> {
     let n = input.len();
     let mut output = vec![0.0; n];
     let factor = 2.0 * core::f32::consts::PI / n as f32;
-    for k in 0..n {
+    for (k, out) in output.iter_mut().enumerate() {
         let mut sum = 0.0;
         for (i, &x) in input.iter().enumerate() {
             let angle = factor * (i * k) as f32;
@@ -24,7 +24,7 @@ pub fn dht(input: &[f32]) -> Vec<f32> {
             let im = sinf(angle);
             sum += x * (re + im);
         }
-        output[k] = sum;
+        *out = sum;
     }
     output
 }
@@ -35,7 +35,7 @@ pub fn dht(input: &[f32]) -> Vec<f32> {
     let n = input.len();
     let mut output = vec![0.0; n];
     let factor = 2.0 * core::f32::consts::PI / n as f32;
-    for k in 0..n {
+    for (k, out) in output.iter_mut().enumerate() {
         let mut sum = 0.0;
         for (i, &x) in input.iter().enumerate() {
             let angle = factor * (i * k) as f32;
@@ -43,7 +43,7 @@ pub fn dht(input: &[f32]) -> Vec<f32> {
             let im = sinf(angle);
             sum += x * (re + im);
         }
-        output[k] = sum;
+        *out = sum;
     }
     output
 }
@@ -56,7 +56,9 @@ pub fn batch(batches: &mut [Vec<f32>]) {
     }
 }
 /// Multi-channel DHT
-pub fn multi_channel(channels: &mut [Vec<f32>]) { batch(channels) }
+pub fn multi_channel(channels: &mut [Vec<f32>]) {
+    batch(channels)
+}
 
 #[cfg(test)]
 mod tests {
@@ -86,8 +88,8 @@ mod batch_tests {
 #[cfg(test)]
 mod coverage_tests {
     use super::*;
-    use proptest::prelude::*;
     use alloc::format;
+    use proptest::prelude::*;
 
     #[test]
     fn test_dht_empty() {
@@ -105,7 +107,9 @@ mod coverage_tests {
     fn test_dht_all_zeros() {
         let x = [0.0; 8];
         let y = dht(&x);
-        for v in y { assert_eq!(v, 0.0); }
+        for v in y {
+            assert_eq!(v, 0.0);
+        }
     }
     #[test]
     fn test_dht_all_ones() {
@@ -135,4 +139,4 @@ mod coverage_tests {
             }
         }
     }
-} 
+}

--- a/src/rfft.rs
+++ b/src/rfft.rs
@@ -135,13 +135,11 @@ pub fn rfft_stack<const N: usize, const M: usize>(
         return Err(FftError::MismatchedLengths);
     }
     let mut buf = [Complex32::new(0.0, 0.0); N];
-    for i in 0..N {
-        buf[i] = Complex32::new(input[i], 0.0);
+    for (b, &x) in buf.iter_mut().zip(input.iter()) {
+        *b = Complex32::new(x, 0.0);
     }
     fft_inplace_stack(&mut buf)?;
-    for k in 0..=N / 2 {
-        output[k] = buf[k];
-    }
+    output[..(N / 2 + 1)].copy_from_slice(&buf[..(N / 2 + 1)]);
     Ok(())
 }
 
@@ -159,15 +157,13 @@ pub fn irfft_stack<const N: usize, const M: usize>(
         return Err(FftError::MismatchedLengths);
     }
     let mut buf = [Complex32::new(0.0, 0.0); N];
-    for k in 0..=N / 2 {
-        buf[k] = input[k];
-    }
+    buf[..(N / 2 + 1)].copy_from_slice(&input[..(N / 2 + 1)]);
     for k in 1..N / 2 {
         buf[N - k] = Complex32::new(input[k].re, -input[k].im);
     }
     ifft_inplace_stack(&mut buf)?;
-    for i in 0..N {
-        output[i] = buf[i].re;
+    for (o, &b) in output.iter_mut().zip(buf.iter()) {
+        *o = b.re;
     }
     Ok(())
 }


### PR DESCRIPTION
## Summary
- refactor FFT and transform helpers to use iterator-based loops and slice copying
- quiet `butterfly8` clippy lint with targeted allow
- streamline Hilbert transform handling with `div_ceil`

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_689df5f66cf4832ba0f24325023db470