### PR TITLE
docs: mention radix-4/mixed-radix FFTs and benchmarks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,7 +36,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - Exposed the STFT module and added hop-size validation and streaming helpers
-- Hardened FFT helpers with stride checks, new error cases, and a radix-4 path
+- Hardened FFT helpers with stride checks, new error cases, and radix-4/mixed-radix paths ([benchmark results](benchmarks/latest.json))
 - Verified matrix dimensions for multi-dimensional FFT utilities
 
 ## [0.1.0] - 2024-12-19

--- a/README.md
+++ b/README.md
@@ -12,11 +12,22 @@ High-performance, `no_std`, MCU-friendly DSP library featuring FFT, DCT, DST, Ha
 
 - **🚀 Zero-allocation stack-only APIs** for MCU/embedded systems
 - **⚡ SIMD acceleration** (x86_64 AVX2 & SSE, AArch64 NEON, WebAssembly SIMD)
+- **🧮 Radix-4 and mixed-radix FFTs** for power-of-two and composite sizes
 - **🔧 Multiple transform types**: FFT, DCT (Types I-IV), DST (Types I-IV), Hartley, Wavelet, STFT, CZT, Goertzel
 - **📊 Window functions**: Hann, Hamming, Blackman, Kaiser
 - **🔄 Batch and multi-channel processing**
 - **🌐 WebAssembly support**
 - **📱 Parallel processing** (optional)
+
+## Benchmarks
+
+Latest benchmarks on an Intel Xeon Platinum 8370C show:
+
+- 1024-point complex FFT: ~81 µs
+- 4096-point complex FFT: ~1.0 ms
+- 1,048,576-point real FFT: ~67 ms
+
+See [benchmarks/latest.json](benchmarks/latest.json) for full results.
 
 ## Quick Start
 


### PR DESCRIPTION
## Summary
- document radix-4/mixed-radix FFT support in feature list
- add benchmark timing summary to README and link to results
- note benchmark link in changelog

## Testing
- `cargo test`
- `cargo fmt --all -- --check` *(fails: produced diff)*

------
https://chatgpt.com/codex/tasks/task_e_689df820d258832bb89c6c319feebd97