### PR TITLE
Fix type mismatch in parallel scalar FFT

### DIFF
--- a/src/fft.rs
+++ b/src/fft.rs
@@ -253,6 +253,7 @@ impl<T: Float> FftImpl<T> for ScalarFftImpl<T> {
                         let input32 =
                             unsafe { &mut *(input as *mut [Complex<T>] as *mut [Complex32]) };
                         let stage_vec = stage.as_ref().clone();
+                        let stage_vec: Vec<Complex32> = unsafe { core::mem::transmute(stage_vec) };
                         let half = len / 2;
                         input32.par_chunks_mut(len).for_each(move |chunk| {
                             for j in 0..half {


### PR DESCRIPTION
## Summary
- convert stage twiddle vector to `Complex32` when executing f32 parallel FFT

## Testing
- `cargo test`
- `cargo test --features parallel`


------
https://chatgpt.com/codex/tasks/task_e_689df8dba430832bb8097c2e1527bdab