### PR TITLE
Add CI build workflow and enforce clippy warnings

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,26 @@
+name: Build
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - name: Build all targets
+        run: |
+          cargo build --all-targets
+          cargo bench --no-run
+  build-sse:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - name: Build all targets (SSE)
+        run: |
+          cargo build --no-default-features --features "sse std" --all-targets
+          cargo bench --no-run --no-default-features --features "sse std"

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -14,4 +14,4 @@ jobs:
         with:
           components: clippy
       - name: Clippy
-        run: cargo clippy --all-targets
+        run: cargo clippy --all-targets -- -D warnings

--- a/benches/bench_fft.rs
+++ b/benches/bench_fft.rs
@@ -9,7 +9,9 @@ use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
 use once_cell::sync::Lazy;
 use serde::{Deserialize, Serialize};
 
-use kofft::fft::{fft_parallel, Complex32, FftImpl, FftPlanner, FftStrategy, ScalarFftImpl};
+#[cfg(feature = "parallel")]
+use kofft::fft::fft_parallel;
+use kofft::fft::{Complex32, FftImpl, FftPlanner, FftStrategy, ScalarFftImpl};
 use kofft::rfft::RealFftImpl;
 use realfft::RealFftPlanner as RustRealFftPlanner;
 use rustfft::FftPlanner as RustFftPlanner;
@@ -104,7 +106,7 @@ static RESULTS: Lazy<Mutex<Vec<BenchRecord>>> = Lazy::new(|| Mutex::new(Vec::new
 fn bench_complex(c: &mut Criterion, size: usize) {
     let mut group = c.benchmark_group(format!("complex_{}", size));
 
-    let mut input: Vec<Complex32> = (0..size).map(|i| Complex32::new(i as f32, 0.0)).collect();
+    let input: Vec<Complex32> = (0..size).map(|i| Complex32::new(i as f32, 0.0)).collect();
     let mut data = input.clone();
 
     // kofft single-threaded
@@ -244,7 +246,7 @@ fn bench_complex(c: &mut Criterion, size: usize) {
     // rustfft single-threaded
     let mut rust_planner = RustFftPlanner::<f32>::new();
     let rust_fft = rust_planner.plan_fft_forward(size);
-    let mut rust_input: Vec<rustfft::num_complex::Complex<f32>> = (0..size)
+    let rust_input: Vec<rustfft::num_complex::Complex<f32>> = (0..size)
         .map(|i| rustfft::num_complex::Complex::new(i as f32, 0.0))
         .collect();
     let mut rust_data = rust_input.clone();

--- a/examples/embedded_example.rs
+++ b/examples/embedded_example.rs
@@ -108,17 +108,17 @@ fn main() {
     ];
 
     // Apply window function (multiply signal by window)
-    for i in 0..8 {
-        signal[i].re *= hann_window[i];
+    for (sig, w) in signal.iter_mut().zip(hann_window.iter()) {
+        sig.re *= *w;
     }
 
     // Compute FFT
     if let Ok(()) = fft_inplace_stack(&mut signal) {
         // Process in frequency domain
         // For example, apply a simple low-pass filter
-        for i in 4..8 {
-            signal[i].re *= 0.1; // Attenuate high frequencies
-            signal[i].im *= 0.1;
+        for bin in signal.iter_mut().skip(4) {
+            bin.re *= 0.1; // Attenuate high frequencies
+            bin.im *= 0.1;
         }
 
         // Compute IFFT

--- a/examples/stft_usage.rs
+++ b/examples/stft_usage.rs
@@ -15,13 +15,13 @@ fn main() -> Result<(), FftError> {
     let window = hann(4);
     let hop = 2;
 
-    let mut frames = vec![vec![]; (signal.len() + hop - 1) / hop];
+    let mut frames = vec![vec![]; signal.len().div_ceil(hop)];
     stft(&signal, &window, hop, &mut frames)?;
     println!("STFT frames: {:?}", frames);
 
     #[cfg(feature = "parallel")]
     {
-        let mut frames_par = vec![vec![]; (signal.len() + hop - 1) / hop];
+        let mut frames_par = vec![vec![]; signal.len().div_ceil(hop)];
         parallel(&signal, &window, hop, &mut frames_par)?;
         println!("Parallel STFT frames: {:?}", frames_par);
     }

--- a/src/dst.rs
+++ b/src/dst.rs
@@ -257,7 +257,7 @@ mod coverage_tests {
     fn test_dst_all_ones() {
         let x = [1.0; 8];
         let y = dst1(&x);
-        assert!(y.iter().all(|&v| (v as f32).abs() > 0.0));
+        assert!(y.iter().all(|&v| v.abs() > 0.0));
     }
     #[test]
     fn test_dst2_dst3_roundtrip() {

--- a/src/ndfft.rs
+++ b/src/ndfft.rs
@@ -123,6 +123,11 @@ pub fn fft3d_inplace<T: Float>(
 // TODO: 3D FFT, real input, streaming, property-based tests
 
 #[cfg(test)]
+#[allow(
+    clippy::needless_range_loop,
+    clippy::manual_memcpy,
+    clippy::zero_repeat_side_effects
+)]
 mod tests {
     use super::*;
     use crate::fft::{Complex, FftError, ScalarFftImpl};
@@ -379,6 +384,11 @@ mod tests {
 }
 
 #[cfg(test)]
+#[allow(
+    clippy::needless_range_loop,
+    clippy::manual_memcpy,
+    clippy::zero_repeat_side_effects
+)]
 mod coverage_tests {
     use super::*;
     use crate::fft::{Complex32, ScalarFftImpl};

--- a/src/stft.rs
+++ b/src/stft.rs
@@ -347,10 +347,7 @@ impl<'a, Fft: crate::fft::FftImpl<f32>> IstftStream<'a, Fft> {
     }
 
     /// Feed in the next STFT frame, get a slice of output samples (may be empty if not enough overlap)
-    pub fn push_frame(
-        &mut self,
-        frame: &[crate::fft::Complex32],
-    ) -> Result<&[f32], FftError> {
+    pub fn push_frame(&mut self, frame: &[crate::fft::Complex32]) -> Result<&[f32], FftError> {
         if frame.len() != self.win_len {
             return Err(FftError::MismatchedLengths);
         }
@@ -387,9 +384,9 @@ mod tests {
     #[test]
     fn test_stft_istft_frame_roundtrip() {
         let fft = ScalarFftImpl::<f32>::default();
-        let n = 8;
-        let win_len = 4;
-        let hop = 2;
+        let n: usize = 8;
+        let win_len: usize = 4;
+        let hop: usize = 2;
         let signal = [1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0];
         let window = [1.0, 1.0, 1.0, 1.0];
         let mut output = [0.0f32; 8];
@@ -419,12 +416,12 @@ mod tests {
 
     #[test]
     fn test_stft_istft_batch_roundtrip() {
-        let n = 8;
-        let win_len = 4;
-        let hop = 2;
+        let n: usize = 8;
+        let win_len: usize = 4;
+        let hop: usize = 2;
         let signal = [1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0];
         let window = [1.0, 1.0, 1.0, 1.0];
-        let num_frames = (n + hop - 1) / hop;
+        let num_frames = n.div_ceil(hop);
         let mut frames = alloc::vec::Vec::new();
         for _ in 0..num_frames {
             frames.push(alloc::vec::Vec::with_capacity(win_len));
@@ -440,12 +437,12 @@ mod tests {
     #[cfg(feature = "parallel")]
     #[test]
     fn test_stft_istft_parallel_roundtrip() {
-        let n = 8;
-        let win_len = 4;
-        let hop = 2;
+        let n: usize = 8;
+        let win_len: usize = 4;
+        let hop: usize = 2;
         let signal = [1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0];
         let window = [1.0, 1.0, 1.0, 1.0];
-        let num_frames = (n + hop - 1) / hop;
+        let num_frames = n.div_ceil(hop);
         let mut frames = alloc::vec::Vec::new();
         for _ in 0..num_frames {
             frames.push(alloc::vec::Vec::with_capacity(win_len));
@@ -565,14 +562,14 @@ mod edge_case_tests {
 
     #[test]
     fn test_hann_window() {
-        let n = 8;
-        let win_len = 4;
-        let hop = 2;
+        let n: usize = 8;
+        let win_len: usize = 4;
+        let hop: usize = 2;
         let signal = [1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0];
         let window: Vec<f32> = (0..win_len)
             .map(|i| 0.5 - 0.5 * (core::f32::consts::PI * 2.0 * i as f32 / win_len as f32).cos())
             .collect();
-        let num_frames = (n + hop - 1) / hop;
+        let num_frames = n.div_ceil(hop);
         let mut frames = alloc::vec::Vec::new();
         for _ in 0..num_frames {
             frames.push(alloc::vec::Vec::with_capacity(win_len));
@@ -696,7 +693,10 @@ mod coverage_tests {
         let window = [1.0, 1.0, 1.0, 1.0];
         let mut stream = StftStream::new(&signal, &window, 2).unwrap();
         let mut buf = vec![Complex32::new(0.0, 0.0); 3];
-        assert_eq!(stream.next_frame(&mut buf).unwrap_err(), FftError::MismatchedLengths);
+        assert_eq!(
+            stream.next_frame(&mut buf).unwrap_err(),
+            FftError::MismatchedLengths
+        );
     }
 
     #[test]
@@ -731,7 +731,7 @@ mod coverage_tests {
             let win_len = win_len.min(len);
             let hop = hop.min(win_len);
             let window = vec![1.0f32; win_len];
-            let num_frames = (len + hop - 1) / hop;
+            let num_frames = len.div_ceil(hop);
             let mut frames = alloc::vec::Vec::new();
             for _ in 0..num_frames {
                 frames.push(alloc::vec::Vec::with_capacity(win_len));


### PR DESCRIPTION
## Summary
- convert index-based loops to iterator patterns and tighten range checks
- update examples and benchmarks to avoid clippy lint errors
- allow specific clippy lints in multidimensional FFT tests

## Testing
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets -- -D warnings`
- `cargo bench --no-run`
- `cargo bench --no-run --no-default-features --features "sse std"`
- `cargo test --all --verbose` *(incomplete: build in progress)*


------
https://chatgpt.com/codex/tasks/task_e_689dfd35a270832bb2b9c6ab76e127ee