### PR TITLE
feat: implement default for SIMD FFT and add streaming STFT docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ See [benchmarks/latest.json](benchmarks/latest.json) for full results.
 
 ```toml
 [dependencies]
-kofft = { version = "0.1.1", features = [
+kofft = { version = "0.1.4", features = [
     # "x86_64",   # enable AVX2 on x86_64
     # "sse",      # enable SSE on x86_64 without AVX2
     # "aarch64",  # enable NEON on AArch64
@@ -252,6 +252,30 @@ let mut output = vec![0.0; signal.len()];
 istft(&frames, &window, hop_size, &mut output)?;
 ```
 
+#### Streaming STFT
+
+Process streaming data frame by frame with [`StftStream`]:
+
+```rust
+use kofft::stft::{StftStream, istft};
+use kofft::window::hann;
+use kofft::fft::Complex32;
+
+let signal = vec![1.0, 2.0, 3.0, 4.0, 5.0];
+let window = hann(4);
+let hop_size = 2;
+
+let mut stream = StftStream::new(&signal, &window, hop_size)?;
+let mut buf = vec![Complex32::new(0.0, 0.0); window.len()];
+let mut frames = Vec::new();
+while stream.next_frame(&mut buf)? {
+    frames.push(buf.clone());
+}
+
+let mut output = vec![0.0; signal.len()];
+istft(&frames, &window, hop_size, &mut output)?;
+```
+
 ### Batch Processing
 
 ```rust
@@ -285,7 +309,7 @@ Enable optional features in `Cargo.toml`:
 
 ```toml
 [dependencies]
-kofft = { version = "0.1.1", features = [
+kofft = { version = "0.1.4", features = [
     # "x86_64",   # AVX2 on x86_64
     # "aarch64",  # NEON on AArch64
     # "wasm",     # WebAssembly SIMD

--- a/src/dct.rs
+++ b/src/dct.rs
@@ -3,11 +3,11 @@
 //! no_std + alloc compatible
 
 extern crate alloc;
-use alloc::vec::Vec;
-use alloc::vec;
-use core::f32::consts::PI;
 #[allow(unused_imports)]
-use crate::fft::{Float, FftError};
+use crate::fft::{FftError, Float};
+use alloc::vec;
+use alloc::vec::Vec;
+use core::f32::consts::PI;
 
 /// DCT-I (even symmetry, endpoints not repeated)
 pub fn dct1(input: &[f32]) -> Vec<f32> {
@@ -20,12 +20,17 @@ pub fn dct1(input: &[f32]) -> Vec<f32> {
     }
     let mut output = vec![0.0; n];
     let factor = PI / (n as f32 - 1.0);
-    for k in 0..n {
-        let mut sum = input[0] + if k % 2 == 0 { input[n - 1] } else { -input[n - 1] };
-        for i in 1..n - 1 {
-            sum += 2.0 * input[i] * (factor * i as f32 * k as f32).cos();
+    for (k, out_k) in output.iter_mut().enumerate() {
+        let mut sum = input[0]
+            + if k % 2 == 0 {
+                input[n - 1]
+            } else {
+                -input[n - 1]
+            };
+        for (i, &x) in input.iter().enumerate().skip(1).take(n - 2) {
+            sum += 2.0 * x * (factor * i as f32 * k as f32).cos();
         }
-        output[k] = sum;
+        *out_k = sum;
     }
     output
 }
@@ -35,12 +40,12 @@ pub fn dct2(input: &[f32]) -> Vec<f32> {
     let n = input.len();
     let mut output = vec![0.0; n];
     let factor = PI / n as f32;
-    for k in 0..n {
+    for (k, out_k) in output.iter_mut().enumerate() {
         let mut sum = 0.0;
         for (i, &x) in input.iter().enumerate() {
             sum += x * (factor * (i as f32 + 0.5) * k as f32).cos();
         }
-        output[k] = sum;
+        *out_k = sum;
     }
     output
 }
@@ -50,12 +55,12 @@ pub fn dct3(input: &[f32]) -> Vec<f32> {
     let n = input.len();
     let mut output = vec![0.0; n];
     let factor = PI / n as f32;
-    for k in 0..n {
+    for (k, out_k) in output.iter_mut().enumerate() {
         let mut sum = input[0] / 2.0;
-        for i in 1..n {
-            sum += input[i] * (factor * i as f32 * (k as f32 + 0.5)).cos();
+        for (i, &x) in input.iter().enumerate().skip(1) {
+            sum += x * (factor * i as f32 * (k as f32 + 0.5)).cos();
         }
-        output[k] = sum;
+        *out_k = sum;
     }
     output
 }
@@ -65,12 +70,12 @@ pub fn dct4(input: &[f32]) -> Vec<f32> {
     let n = input.len();
     let mut output = vec![0.0; n];
     let factor = PI / n as f32;
-    for k in 0..n {
+    for (k, out_k) in output.iter_mut().enumerate() {
         let mut sum = 0.0;
         for (i, &x) in input.iter().enumerate() {
             sum += x * (factor * (i as f32 + 0.5) * (k as f32 + 0.5)).cos();
         }
-        output[k] = sum;
+        *out_k = sum;
     }
     output
 }
@@ -86,12 +91,17 @@ pub fn dct1_inplace_stack<const N: usize>(
         return Err(FftError::NonPowerOfTwoNoStd);
     }
     let factor = core::f32::consts::PI / (N as f32 - 1.0);
-    for k in 0..N {
-        let mut sum = input[0] + if k % 2 == 0 { input[N - 1] } else { -input[N - 1] };
-        for i in 1..N - 1 {
-            sum += 2.0 * input[i] * (factor * i as f32 * k as f32).cos();
+    for (k, out_k) in output.iter_mut().enumerate() {
+        let mut sum = input[0]
+            + if k % 2 == 0 {
+                input[N - 1]
+            } else {
+                -input[N - 1]
+            };
+        for (i, &x) in input.iter().enumerate().skip(1).take(N - 2) {
+            sum += 2.0 * x * (factor * i as f32 * k as f32).cos();
         }
-        output[k] = sum;
+        *out_k = sum;
     }
     Ok(())
 }
@@ -107,12 +117,12 @@ pub fn dct2_inplace_stack<const N: usize>(
         return Err(FftError::NonPowerOfTwoNoStd);
     }
     let factor = core::f32::consts::PI / N as f32;
-    for k in 0..N {
+    for (k, out_k) in output.iter_mut().enumerate() {
         let mut sum = 0.0;
-        for i in 0..N {
-            sum += input[i] * (factor * (i as f32 + 0.5) * k as f32).cos();
+        for (i, &x) in input.iter().enumerate() {
+            sum += x * (factor * (i as f32 + 0.5) * k as f32).cos();
         }
-        output[k] = sum;
+        *out_k = sum;
     }
     Ok(())
 }
@@ -146,13 +156,21 @@ pub fn batch_iv(batches: &mut [Vec<f32>]) {
     }
 }
 /// Multi-channel DCT-I
-pub fn multi_channel_i(channels: &mut [Vec<f32>]) { batch_i(channels) }
+pub fn multi_channel_i(channels: &mut [Vec<f32>]) {
+    batch_i(channels)
+}
 /// Multi-channel DCT-II
-pub fn multi_channel_ii(channels: &mut [Vec<f32>]) { batch_ii(channels) }
+pub fn multi_channel_ii(channels: &mut [Vec<f32>]) {
+    batch_ii(channels)
+}
 /// Multi-channel DCT-III
-pub fn multi_channel_iii(channels: &mut [Vec<f32>]) { batch_iii(channels) }
+pub fn multi_channel_iii(channels: &mut [Vec<f32>]) {
+    batch_iii(channels)
+}
 /// Multi-channel DCT-IV
-pub fn multi_channel_iv(channels: &mut [Vec<f32>]) { batch_iv(channels) }
+pub fn multi_channel_iv(channels: &mut [Vec<f32>]) {
+    batch_iv(channels)
+}
 
 #[cfg(test)]
 mod tests {
@@ -163,7 +181,9 @@ mod tests {
         let nonzero = x.iter().filter(|&&v| v != 0.0).count();
         let mean = x.iter().map(|&v| v.abs()).sum::<f32>() / x.len() as f32;
         let max = x.iter().map(|&v| v.abs()).fold(0.0, f32::max);
-        if nonzero < 3 || (mean > 0.0 && max > 10.0 * mean) { return; } // skip pathological
+        if nonzero < 3 || (mean > 0.0 && max > 10.0 * mean) {
+            return;
+        } // skip pathological
         let y = dct2(&x);
         let z = dct3(&y);
         for (a, b) in x.iter().zip(z.iter()) {
@@ -233,7 +253,9 @@ mod dct4_tests {
         let nonzero = x.iter().filter(|&&v| v != 0.0).count();
         let mean = x.iter().map(|&v| v.abs()).sum::<f32>() / x.len() as f32;
         let max = x.iter().map(|&v| v.abs()).fold(0.0, f32::max);
-        if nonzero < 3 || (mean > 0.0 && max > 10.0 * mean) { return; } // skip pathological
+        if nonzero < 3 || (mean > 0.0 && max > 10.0 * mean) {
+            return;
+        } // skip pathological
         let y = dct4(&x);
         let z = dct4(&y);
         for (a, b) in x.iter().zip(z.iter()) {
@@ -252,9 +274,8 @@ mod dct4_tests {
 mod coverage_tests {
     use super::*;
     use alloc::format;
-    use proptest::proptest;
     use proptest::prop_assert;
-    
+    use proptest::proptest;
 
     #[test]
     fn test_dct_empty() {
@@ -272,7 +293,9 @@ mod coverage_tests {
     fn test_dct_all_zeros() {
         let x = [0.0; 8];
         let y = dct2(&x);
-        for v in y { assert_eq!(v, 0.0); }
+        for v in y {
+            assert_eq!(v, 0.0);
+        }
     }
     #[test]
     fn test_dct_all_ones() {
@@ -286,7 +309,9 @@ mod coverage_tests {
         let nonzero = x.iter().filter(|&&v| v != 0.0).count();
         let mean = x.iter().map(|&v| v.abs()).sum::<f32>() / x.len() as f32;
         let max = x.iter().map(|&v| v.abs()).fold(0.0, f32::max);
-        if nonzero < 3 || (mean > 0.0 && max > 10.0 * mean) { return; } // skip pathological
+        if nonzero < 3 || (mean > 0.0 && max > 10.0 * mean) {
+            return;
+        } // skip pathological
         let y = dct2(&x);
         let z = dct3(&y);
         for (a, b) in x.iter().zip(z.iter()) {
@@ -314,7 +339,10 @@ mod coverage_tests {
     fn test_dct2_inplace_stack_invalid() {
         let input = [1.0f32, 2.0, 3.0];
         let mut out = [0.0f32; 3];
-        assert_eq!(dct2_inplace_stack(&input, &mut out).unwrap_err(), FftError::NonPowerOfTwoNoStd);
+        assert_eq!(
+            dct2_inplace_stack(&input, &mut out).unwrap_err(),
+            FftError::NonPowerOfTwoNoStd
+        );
     }
     #[test]
     fn test_dct4_roundtrip() {
@@ -322,7 +350,9 @@ mod coverage_tests {
         let nonzero = x.iter().filter(|&&v| v != 0.0).count();
         let mean = x.iter().map(|&v| v.abs()).sum::<f32>() / x.len() as f32;
         let max = x.iter().map(|&v| v.abs()).fold(0.0, f32::max);
-        if nonzero < 3 || (mean > 0.0 && max > 10.0 * mean) { return; } // skip pathological
+        if nonzero < 3 || (mean > 0.0 && max > 10.0 * mean) {
+            return;
+        } // skip pathological
         let y = dct4(&x);
         let z = dct4(&y);
         for (a, b) in x.iter().zip(z.iter()) {
@@ -347,4 +377,4 @@ mod coverage_tests {
             }
         }
     }
-} 
+}

--- a/src/fft.rs
+++ b/src/fft.rs
@@ -563,6 +563,7 @@ impl<T: Float> ScalarFftImpl<T> {
 }
 
 #[cfg(feature = "std")]
+#[derive(Clone, Debug)]
 pub struct TwiddleFactorBuffer {
     pub n: usize,
     pub twiddles: alloc::vec::Vec<Complex32>,
@@ -857,6 +858,15 @@ pub struct SimdFftX86_64Impl;
     target_arch = "x86_64",
     any(feature = "x86_64", target_feature = "avx2")
 ))]
+impl Default for SimdFftX86_64Impl {
+    fn default() -> Self {
+        Self
+    }
+}
+#[cfg(all(
+    target_arch = "x86_64",
+    any(feature = "x86_64", target_feature = "avx2")
+))]
 impl FftImpl<f32> for SimdFftX86_64Impl {
     fn fft(&self, input: &mut [Complex32]) -> Result<(), FftError> {
         let n = input.len();
@@ -1076,6 +1086,12 @@ impl FftImpl<f32> for SimdFftX86_64Impl {
 // x86_64 SSE SIMD implementation
 #[cfg(all(target_arch = "x86_64", any(feature = "sse", target_feature = "sse2")))]
 pub struct SimdFftSseImpl;
+#[cfg(all(target_arch = "x86_64", any(feature = "sse", target_feature = "sse2")))]
+impl Default for SimdFftSseImpl {
+    fn default() -> Self {
+        Self
+    }
+}
 #[cfg(all(target_arch = "x86_64", any(feature = "sse", target_feature = "sse2")))]
 impl FftImpl<f32> for SimdFftSseImpl {
     fn fft(&self, input: &mut [Complex32]) -> Result<(), FftError> {
@@ -1299,6 +1315,15 @@ pub struct SimdFftAArch64Impl;
     target_arch = "aarch64",
     any(feature = "aarch64", target_feature = "neon")
 ))]
+impl Default for SimdFftAArch64Impl {
+    fn default() -> Self {
+        Self
+    }
+}
+#[cfg(all(
+    target_arch = "aarch64",
+    any(feature = "aarch64", target_feature = "neon")
+))]
 impl FftImpl<f32> for SimdFftAArch64Impl {
     fn fft(&self, input: &mut [Complex32]) -> Result<(), FftError> {
         let n = input.len();
@@ -1492,6 +1517,15 @@ use core::arch::wasm32::*;
     any(feature = "wasm", target_feature = "simd128")
 ))]
 pub struct SimdFftWasmImpl;
+#[cfg(all(
+    target_arch = "wasm32",
+    any(feature = "wasm", target_feature = "simd128")
+))]
+impl Default for SimdFftWasmImpl {
+    fn default() -> Self {
+        Self
+    }
+}
 #[cfg(all(
     target_arch = "wasm32",
     any(feature = "wasm", target_feature = "simd128")

--- a/src/window.rs
+++ b/src/window.rs
@@ -5,7 +5,7 @@ use core::f32::consts::PI;
 use libm::sqrtf;
 
 #[cfg(not(feature = "std"))]
-use libm::{cosf, fabsf, powf, sinf, floorf, logf, log10f};
+use libm::{cosf, fabsf, floorf, log10f, logf, powf, sinf};
 
 #[allow(unused_imports)]
 use crate::fft::Float;
@@ -46,8 +46,7 @@ pub fn blackman(len: usize) -> alloc::vec::Vec<f32> {
             let a1 = 0.5;
             let a2 = 0.08;
             let x = i as f32 / len as f32;
-            a0 - a1 * (2.0 * PI * x).cos()
-               + a2 * (4.0 * PI * x).cos()
+            a0 - a1 * (2.0 * PI * x).cos() + a2 * (4.0 * PI * x).cos()
         })
         .collect()
 }
@@ -79,15 +78,15 @@ pub fn kaiser(len: usize, beta: f32) -> alloc::vec::Vec<f32> {
 
 /// MCU/stack-only, const-generic, in-place Hann window (no heap)
 pub fn hann_inplace_stack<const N: usize>(out: &mut [f32; N]) {
-    for i in 0..N {
-        out[i] = 0.5 - 0.5 * (2.0 * PI * i as f32 / N as f32).cos();
+    for (i, out_i) in out.iter_mut().enumerate() {
+        *out_i = 0.5 - 0.5 * (2.0 * PI * i as f32 / N as f32).cos();
     }
 }
 
 /// MCU/stack-only, const-generic, in-place Hamming window (no heap)
 pub fn hamming_inplace_stack<const N: usize>(out: &mut [f32; N]) {
-    for i in 0..N {
-        out[i] = 0.54 - 0.46 * (2.0 * PI * i as f32 / N as f32).cos();
+    for (i, out_i) in out.iter_mut().enumerate() {
+        *out_i = 0.54 - 0.46 * (2.0 * PI * i as f32 / N as f32).cos();
     }
 }
 
@@ -96,9 +95,9 @@ pub fn blackman_inplace_stack<const N: usize>(out: &mut [f32; N]) {
     let a0 = 0.42;
     let a1 = 0.5;
     let a2 = 0.08;
-    for i in 0..N {
+    for (i, out_i) in out.iter_mut().enumerate() {
         let x = i as f32 / N as f32;
-        out[i] = a0 - a1 * (2.0 * PI * x).cos() + a2 * (4.0 * PI * x).cos();
+        *out_i = a0 - a1 * (2.0 * PI * x).cos() + a2 * (4.0 * PI * x).cos();
     }
 }
 
@@ -131,8 +130,8 @@ mod tests {
         // Peak amplitude at center
         assert!((w[4] - 1.0).abs() < 1e-6);
         // Symmetry
-        for i in 0..w.len() {
-            assert!((w[i] - w[w.len() - 1 - i]).abs() < 1e-6);
+        for (i, &v) in w.iter().enumerate() {
+            assert!((v - w[w.len() - 1 - i]).abs() < 1e-6);
         }
         assert!(w.iter().all(|&x| x.is_finite()));
     }


### PR DESCRIPTION
## Summary
- impl `Default` for stateless SIMD FFT structs
- derive `Clone`/`Debug` for `TwiddleFactorBuffer`
- refactor DCT and window loops to silence clippy
- document streaming STFT usage in README and module docs

## Testing
- `cargo fmt -- src/window.rs src/dct.rs src/fft.rs src/stft.rs >/tmp/fmt.log && wc -c /tmp/fmt.log`
- `cargo clippy >/tmp/clippy.log && wc -c /tmp/clippy.log`
- `cargo test >/tmp/unit.log && tail -n 20 /tmp/unit.log`


------
https://chatgpt.com/codex/tasks/task_e_689dff3f9aa4832b83b8eb36824b903d