### PR TITLE
feat: implement default for SIMD FFT and add streaming STFT docs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,26 @@
+name: Build
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - name: Build all targets
+        run: |
+          cargo build --all-targets
+          cargo bench --no-run
+  build-sse:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - name: Build all targets (SSE)
+        run: |
+          cargo build --no-default-features --features "sse std" --all-targets
+          cargo bench --no-run --no-default-features --features "sse std"

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -14,4 +14,4 @@ jobs:
         with:
           components: clippy
       - name: Clippy
-        run: cargo clippy --all-targets
+        run: cargo clippy --all-targets -- -D warnings

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ See [benchmarks/latest.json](benchmarks/latest.json) for full results.
 
 ```toml
 [dependencies]
-kofft = { version = "0.1.1", features = [
+kofft = { version = "0.1.4", features = [
     # "x86_64",   # enable AVX2 on x86_64
     # "sse",      # enable SSE on x86_64 without AVX2
     # "aarch64",  # enable NEON on AArch64
@@ -252,6 +252,30 @@ let mut output = vec![0.0; signal.len()];
 istft(&frames, &window, hop_size, &mut output)?;
 ```
 
+#### Streaming STFT
+
+Process streaming data frame by frame with [`StftStream`]:
+
+```rust
+use kofft::stft::{StftStream, istft};
+use kofft::window::hann;
+use kofft::fft::Complex32;
+
+let signal = vec![1.0, 2.0, 3.0, 4.0, 5.0];
+let window = hann(4);
+let hop_size = 2;
+
+let mut stream = StftStream::new(&signal, &window, hop_size)?;
+let mut buf = vec![Complex32::new(0.0, 0.0); window.len()];
+let mut frames = Vec::new();
+while stream.next_frame(&mut buf)? {
+    frames.push(buf.clone());
+}
+
+let mut output = vec![0.0; signal.len()];
+istft(&frames, &window, hop_size, &mut output)?;
+```
+
 ### Batch Processing
 
 ```rust
@@ -285,7 +309,7 @@ Enable optional features in `Cargo.toml`:
 
 ```toml
 [dependencies]
-kofft = { version = "0.1.1", features = [
+kofft = { version = "0.1.4", features = [
     # "x86_64",   # AVX2 on x86_64
     # "aarch64",  # NEON on AArch64
     # "wasm",     # WebAssembly SIMD

--- a/benches/bench_fft.rs
+++ b/benches/bench_fft.rs
@@ -9,7 +9,9 @@ use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
 use once_cell::sync::Lazy;
 use serde::{Deserialize, Serialize};
 
-use kofft::fft::{fft_parallel, Complex32, FftImpl, FftPlanner, FftStrategy, ScalarFftImpl};
+#[cfg(feature = "parallel")]
+use kofft::fft::fft_parallel;
+use kofft::fft::{Complex32, FftImpl, FftPlanner, FftStrategy, ScalarFftImpl};
 use kofft::rfft::RealFftImpl;
 use realfft::RealFftPlanner as RustRealFftPlanner;
 use rustfft::FftPlanner as RustFftPlanner;
@@ -104,7 +106,7 @@ static RESULTS: Lazy<Mutex<Vec<BenchRecord>>> = Lazy::new(|| Mutex::new(Vec::new
 fn bench_complex(c: &mut Criterion, size: usize) {
     let mut group = c.benchmark_group(format!("complex_{}", size));
 
-    let mut input: Vec<Complex32> = (0..size).map(|i| Complex32::new(i as f32, 0.0)).collect();
+    let input: Vec<Complex32> = (0..size).map(|i| Complex32::new(i as f32, 0.0)).collect();
     let mut data = input.clone();
 
     // kofft single-threaded
@@ -244,7 +246,7 @@ fn bench_complex(c: &mut Criterion, size: usize) {
     // rustfft single-threaded
     let mut rust_planner = RustFftPlanner::<f32>::new();
     let rust_fft = rust_planner.plan_fft_forward(size);
-    let mut rust_input: Vec<rustfft::num_complex::Complex<f32>> = (0..size)
+    let rust_input: Vec<rustfft::num_complex::Complex<f32>> = (0..size)
         .map(|i| rustfft::num_complex::Complex::new(i as f32, 0.0))
         .collect();
     let mut rust_data = rust_input.clone();

--- a/examples/embedded_example.rs
+++ b/examples/embedded_example.rs
@@ -108,17 +108,17 @@ fn main() {
     ];
 
     // Apply window function (multiply signal by window)
-    for i in 0..8 {
-        signal[i].re *= hann_window[i];
+    for (sig, w) in signal.iter_mut().zip(hann_window.iter()) {
+        sig.re *= *w;
     }
 
     // Compute FFT
     if let Ok(()) = fft_inplace_stack(&mut signal) {
         // Process in frequency domain
         // For example, apply a simple low-pass filter
-        for i in 4..8 {
-            signal[i].re *= 0.1; // Attenuate high frequencies
-            signal[i].im *= 0.1;
+        for bin in signal.iter_mut().skip(4) {
+            bin.re *= 0.1; // Attenuate high frequencies
+            bin.im *= 0.1;
         }
 
         // Compute IFFT

--- a/examples/stft_usage.rs
+++ b/examples/stft_usage.rs
@@ -15,13 +15,13 @@ fn main() -> Result<(), FftError> {
     let window = hann(4);
     let hop = 2;
 
-    let mut frames = vec![vec![]; (signal.len() + hop - 1) / hop];
+    let mut frames = vec![vec![]; signal.len().div_ceil(hop)];
     stft(&signal, &window, hop, &mut frames)?;
     println!("STFT frames: {:?}", frames);
 
     #[cfg(feature = "parallel")]
     {
-        let mut frames_par = vec![vec![]; (signal.len() + hop - 1) / hop];
+        let mut frames_par = vec![vec![]; signal.len().div_ceil(hop)];
         parallel(&signal, &window, hop, &mut frames_par)?;
         println!("Parallel STFT frames: {:?}", frames_par);
     }

--- a/examples/update_bench_readme.rs
+++ b/examples/update_bench_readme.rs
@@ -1,6 +1,6 @@
-use std::fs;
-use std::error::Error;
 use serde::Deserialize;
+use std::error::Error;
+use std::fs;
 
 #[derive(Deserialize)]
 struct BenchFile {
@@ -37,7 +37,11 @@ fn main() -> Result<(), Box<dyn Error>> {
     let mut table = String::new();
     table.push_str(&format!(
         "Last run: {} on {} ({}; {}; flags: `{}`)\n\n",
-        bf.env.date, bf.env.runner, bf.env.cpu.trim(), bf.env.rustc, bf.env.flags
+        bf.env.date,
+        bf.env.runner,
+        bf.env.cpu.trim(),
+        bf.env.rustc,
+        bf.env.flags
     ));
     table.push_str("| Library | Transform | Size (N) | Mode | Time/op | Ops/sec | Allocations | Date/Runner |\n");
     table.push_str("| --- | --- | --- | --- | --- | --- | --- | --- |\n");
@@ -46,8 +50,15 @@ fn main() -> Result<(), Box<dyn Error>> {
         let time_ms = r.time_per_op_ns / 1_000_000.0;
         table.push_str(&format!(
             "| {} | {} | {} | {} | {:.3} ms | {:.2} | {} | {} {} |\n",
-            r.library, r.transform, r.size, r.mode, time_ms, r.ops_per_sec,
-            r.allocations, date_short, bf.env.runner
+            r.library,
+            r.transform,
+            r.size,
+            r.mode,
+            time_ms,
+            r.ops_per_sec,
+            r.allocations,
+            date_short,
+            bf.env.runner
         ));
     }
     update_readme(&table)?;

--- a/examples/wavelet_usage.rs
+++ b/examples/wavelet_usage.rs
@@ -1,5 +1,5 @@
 use kofft::wavelet::{
-    haar_forward_multi, haar_inverse_multi, db4_forward_multi, db4_inverse_multi,
+    db4_forward_multi, db4_inverse_multi, haar_forward_multi, haar_inverse_multi,
 };
 
 fn main() {

--- a/src/cepstrum.rs
+++ b/src/cepstrum.rs
@@ -3,13 +3,13 @@
 //! no_std + alloc compatible
 
 extern crate alloc;
-use alloc::vec::Vec;
+use crate::fft::{Complex32, FftError, FftImpl, ScalarFftImpl};
 use alloc::vec;
-use crate::fft::{ScalarFftImpl, Complex32, FftImpl, FftError};
-use libm::{sqrtf, powf, floorf, logf, log10f};
+use alloc::vec::Vec;
+use libm::{floorf, log10f, logf, powf, sqrtf};
 
 #[cfg(not(feature = "std"))]
-use libm::{sqrtf, logf, log10f, powf, floorf};
+use libm::{floorf, log10f, logf, powf, sqrtf};
 
 /// Compute the real cepstrum of a real input signal
 pub fn real_cepstrum(input: &[f32]) -> Result<Vec<f32>, FftError> {
@@ -132,7 +132,10 @@ mod mfcc_tests {
     #[test]
     fn test_mfcc_error() {
         let frame = vec![1.0; 32];
-        assert_eq!(mfcc(&frame, 16000.0, 8, 20).unwrap_err(), FftError::InvalidValue);
+        assert_eq!(
+            mfcc(&frame, 16000.0, 8, 20).unwrap_err(),
+            FftError::InvalidValue
+        );
     }
 }
 

--- a/src/dct.rs
+++ b/src/dct.rs
@@ -3,11 +3,11 @@
 //! no_std + alloc compatible
 
 extern crate alloc;
-use alloc::vec::Vec;
-use alloc::vec;
-use core::f32::consts::PI;
 #[allow(unused_imports)]
-use crate::fft::{Float, FftError};
+use crate::fft::{FftError, Float};
+use alloc::vec;
+use alloc::vec::Vec;
+use core::f32::consts::PI;
 
 /// DCT-I (even symmetry, endpoints not repeated)
 pub fn dct1(input: &[f32]) -> Vec<f32> {
@@ -20,12 +20,17 @@ pub fn dct1(input: &[f32]) -> Vec<f32> {
     }
     let mut output = vec![0.0; n];
     let factor = PI / (n as f32 - 1.0);
-    for k in 0..n {
-        let mut sum = input[0] + if k % 2 == 0 { input[n - 1] } else { -input[n - 1] };
-        for i in 1..n - 1 {
-            sum += 2.0 * input[i] * (factor * i as f32 * k as f32).cos();
+    for (k, out_k) in output.iter_mut().enumerate() {
+        let mut sum = input[0]
+            + if k % 2 == 0 {
+                input[n - 1]
+            } else {
+                -input[n - 1]
+            };
+        for (i, &x) in input.iter().enumerate().skip(1).take(n - 2) {
+            sum += 2.0 * x * (factor * i as f32 * k as f32).cos();
         }
-        output[k] = sum;
+        *out_k = sum;
     }
     output
 }
@@ -35,12 +40,12 @@ pub fn dct2(input: &[f32]) -> Vec<f32> {
     let n = input.len();
     let mut output = vec![0.0; n];
     let factor = PI / n as f32;
-    for k in 0..n {
+    for (k, out_k) in output.iter_mut().enumerate() {
         let mut sum = 0.0;
         for (i, &x) in input.iter().enumerate() {
             sum += x * (factor * (i as f32 + 0.5) * k as f32).cos();
         }
-        output[k] = sum;
+        *out_k = sum;
     }
     output
 }
@@ -50,12 +55,12 @@ pub fn dct3(input: &[f32]) -> Vec<f32> {
     let n = input.len();
     let mut output = vec![0.0; n];
     let factor = PI / n as f32;
-    for k in 0..n {
+    for (k, out_k) in output.iter_mut().enumerate() {
         let mut sum = input[0] / 2.0;
-        for i in 1..n {
-            sum += input[i] * (factor * i as f32 * (k as f32 + 0.5)).cos();
+        for (i, &x) in input.iter().enumerate().skip(1) {
+            sum += x * (factor * i as f32 * (k as f32 + 0.5)).cos();
         }
-        output[k] = sum;
+        *out_k = sum;
     }
     output
 }
@@ -65,12 +70,12 @@ pub fn dct4(input: &[f32]) -> Vec<f32> {
     let n = input.len();
     let mut output = vec![0.0; n];
     let factor = PI / n as f32;
-    for k in 0..n {
+    for (k, out_k) in output.iter_mut().enumerate() {
         let mut sum = 0.0;
         for (i, &x) in input.iter().enumerate() {
             sum += x * (factor * (i as f32 + 0.5) * (k as f32 + 0.5)).cos();
         }
-        output[k] = sum;
+        *out_k = sum;
     }
     output
 }
@@ -86,12 +91,17 @@ pub fn dct1_inplace_stack<const N: usize>(
         return Err(FftError::NonPowerOfTwoNoStd);
     }
     let factor = core::f32::consts::PI / (N as f32 - 1.0);
-    for k in 0..N {
-        let mut sum = input[0] + if k % 2 == 0 { input[N - 1] } else { -input[N - 1] };
-        for i in 1..N - 1 {
-            sum += 2.0 * input[i] * (factor * i as f32 * k as f32).cos();
+    for (k, out_k) in output.iter_mut().enumerate() {
+        let mut sum = input[0]
+            + if k % 2 == 0 {
+                input[N - 1]
+            } else {
+                -input[N - 1]
+            };
+        for (i, &x) in input.iter().enumerate().skip(1).take(N - 2) {
+            sum += 2.0 * x * (factor * i as f32 * k as f32).cos();
         }
-        output[k] = sum;
+        *out_k = sum;
     }
     Ok(())
 }
@@ -107,12 +117,12 @@ pub fn dct2_inplace_stack<const N: usize>(
         return Err(FftError::NonPowerOfTwoNoStd);
     }
     let factor = core::f32::consts::PI / N as f32;
-    for k in 0..N {
+    for (k, out_k) in output.iter_mut().enumerate() {
         let mut sum = 0.0;
-        for i in 0..N {
-            sum += input[i] * (factor * (i as f32 + 0.5) * k as f32).cos();
+        for (i, &x) in input.iter().enumerate() {
+            sum += x * (factor * (i as f32 + 0.5) * k as f32).cos();
         }
-        output[k] = sum;
+        *out_k = sum;
     }
     Ok(())
 }
@@ -146,13 +156,21 @@ pub fn batch_iv(batches: &mut [Vec<f32>]) {
     }
 }
 /// Multi-channel DCT-I
-pub fn multi_channel_i(channels: &mut [Vec<f32>]) { batch_i(channels) }
+pub fn multi_channel_i(channels: &mut [Vec<f32>]) {
+    batch_i(channels)
+}
 /// Multi-channel DCT-II
-pub fn multi_channel_ii(channels: &mut [Vec<f32>]) { batch_ii(channels) }
+pub fn multi_channel_ii(channels: &mut [Vec<f32>]) {
+    batch_ii(channels)
+}
 /// Multi-channel DCT-III
-pub fn multi_channel_iii(channels: &mut [Vec<f32>]) { batch_iii(channels) }
+pub fn multi_channel_iii(channels: &mut [Vec<f32>]) {
+    batch_iii(channels)
+}
 /// Multi-channel DCT-IV
-pub fn multi_channel_iv(channels: &mut [Vec<f32>]) { batch_iv(channels) }
+pub fn multi_channel_iv(channels: &mut [Vec<f32>]) {
+    batch_iv(channels)
+}
 
 #[cfg(test)]
 mod tests {
@@ -163,7 +181,9 @@ mod tests {
         let nonzero = x.iter().filter(|&&v| v != 0.0).count();
         let mean = x.iter().map(|&v| v.abs()).sum::<f32>() / x.len() as f32;
         let max = x.iter().map(|&v| v.abs()).fold(0.0, f32::max);
-        if nonzero < 3 || (mean > 0.0 && max > 10.0 * mean) { return; } // skip pathological
+        if nonzero < 3 || (mean > 0.0 && max > 10.0 * mean) {
+            return;
+        } // skip pathological
         let y = dct2(&x);
         let z = dct3(&y);
         for (a, b) in x.iter().zip(z.iter()) {
@@ -233,7 +253,9 @@ mod dct4_tests {
         let nonzero = x.iter().filter(|&&v| v != 0.0).count();
         let mean = x.iter().map(|&v| v.abs()).sum::<f32>() / x.len() as f32;
         let max = x.iter().map(|&v| v.abs()).fold(0.0, f32::max);
-        if nonzero < 3 || (mean > 0.0 && max > 10.0 * mean) { return; } // skip pathological
+        if nonzero < 3 || (mean > 0.0 && max > 10.0 * mean) {
+            return;
+        } // skip pathological
         let y = dct4(&x);
         let z = dct4(&y);
         for (a, b) in x.iter().zip(z.iter()) {
@@ -252,9 +274,8 @@ mod dct4_tests {
 mod coverage_tests {
     use super::*;
     use alloc::format;
-    use proptest::proptest;
     use proptest::prop_assert;
-    
+    use proptest::proptest;
 
     #[test]
     fn test_dct_empty() {
@@ -272,7 +293,9 @@ mod coverage_tests {
     fn test_dct_all_zeros() {
         let x = [0.0; 8];
         let y = dct2(&x);
-        for v in y { assert_eq!(v, 0.0); }
+        for v in y {
+            assert_eq!(v, 0.0);
+        }
     }
     #[test]
     fn test_dct_all_ones() {
@@ -286,7 +309,9 @@ mod coverage_tests {
         let nonzero = x.iter().filter(|&&v| v != 0.0).count();
         let mean = x.iter().map(|&v| v.abs()).sum::<f32>() / x.len() as f32;
         let max = x.iter().map(|&v| v.abs()).fold(0.0, f32::max);
-        if nonzero < 3 || (mean > 0.0 && max > 10.0 * mean) { return; } // skip pathological
+        if nonzero < 3 || (mean > 0.0 && max > 10.0 * mean) {
+            return;
+        } // skip pathological
         let y = dct2(&x);
         let z = dct3(&y);
         for (a, b) in x.iter().zip(z.iter()) {
@@ -314,7 +339,10 @@ mod coverage_tests {
     fn test_dct2_inplace_stack_invalid() {
         let input = [1.0f32, 2.0, 3.0];
         let mut out = [0.0f32; 3];
-        assert_eq!(dct2_inplace_stack(&input, &mut out).unwrap_err(), FftError::NonPowerOfTwoNoStd);
+        assert_eq!(
+            dct2_inplace_stack(&input, &mut out).unwrap_err(),
+            FftError::NonPowerOfTwoNoStd
+        );
     }
     #[test]
     fn test_dct4_roundtrip() {
@@ -322,7 +350,9 @@ mod coverage_tests {
         let nonzero = x.iter().filter(|&&v| v != 0.0).count();
         let mean = x.iter().map(|&v| v.abs()).sum::<f32>() / x.len() as f32;
         let max = x.iter().map(|&v| v.abs()).fold(0.0, f32::max);
-        if nonzero < 3 || (mean > 0.0 && max > 10.0 * mean) { return; } // skip pathological
+        if nonzero < 3 || (mean > 0.0 && max > 10.0 * mean) {
+            return;
+        } // skip pathological
         let y = dct4(&x);
         let z = dct4(&y);
         for (a, b) in x.iter().zip(z.iter()) {
@@ -347,4 +377,4 @@ mod coverage_tests {
             }
         }
     }
-} 
+}

--- a/src/dst.rs
+++ b/src/dst.rs
@@ -257,7 +257,7 @@ mod coverage_tests {
     fn test_dst_all_ones() {
         let x = [1.0; 8];
         let y = dst1(&x);
-        assert!(y.iter().all(|&v| (v as f32).abs() > 0.0));
+        assert!(y.iter().all(|&v| v.abs() > 0.0));
     }
     #[test]
     fn test_dst2_dst3_roundtrip() {

--- a/src/fft.rs
+++ b/src/fft.rs
@@ -563,6 +563,7 @@ impl<T: Float> ScalarFftImpl<T> {
 }
 
 #[cfg(feature = "std")]
+#[derive(Clone, Debug)]
 pub struct TwiddleFactorBuffer {
     pub n: usize,
     pub twiddles: alloc::vec::Vec<Complex32>,
@@ -857,6 +858,15 @@ pub struct SimdFftX86_64Impl;
     target_arch = "x86_64",
     any(feature = "x86_64", target_feature = "avx2")
 ))]
+impl Default for SimdFftX86_64Impl {
+    fn default() -> Self {
+        Self
+    }
+}
+#[cfg(all(
+    target_arch = "x86_64",
+    any(feature = "x86_64", target_feature = "avx2")
+))]
 impl FftImpl<f32> for SimdFftX86_64Impl {
     fn fft(&self, input: &mut [Complex32]) -> Result<(), FftError> {
         let n = input.len();
@@ -1076,6 +1086,12 @@ impl FftImpl<f32> for SimdFftX86_64Impl {
 // x86_64 SSE SIMD implementation
 #[cfg(all(target_arch = "x86_64", any(feature = "sse", target_feature = "sse2")))]
 pub struct SimdFftSseImpl;
+#[cfg(all(target_arch = "x86_64", any(feature = "sse", target_feature = "sse2")))]
+impl Default for SimdFftSseImpl {
+    fn default() -> Self {
+        Self
+    }
+}
 #[cfg(all(target_arch = "x86_64", any(feature = "sse", target_feature = "sse2")))]
 impl FftImpl<f32> for SimdFftSseImpl {
     fn fft(&self, input: &mut [Complex32]) -> Result<(), FftError> {
@@ -1299,6 +1315,15 @@ pub struct SimdFftAArch64Impl;
     target_arch = "aarch64",
     any(feature = "aarch64", target_feature = "neon")
 ))]
+impl Default for SimdFftAArch64Impl {
+    fn default() -> Self {
+        Self
+    }
+}
+#[cfg(all(
+    target_arch = "aarch64",
+    any(feature = "aarch64", target_feature = "neon")
+))]
 impl FftImpl<f32> for SimdFftAArch64Impl {
     fn fft(&self, input: &mut [Complex32]) -> Result<(), FftError> {
         let n = input.len();
@@ -1492,6 +1517,15 @@ use core::arch::wasm32::*;
     any(feature = "wasm", target_feature = "simd128")
 ))]
 pub struct SimdFftWasmImpl;
+#[cfg(all(
+    target_arch = "wasm32",
+    any(feature = "wasm", target_feature = "simd128")
+))]
+impl Default for SimdFftWasmImpl {
+    fn default() -> Self {
+        Self
+    }
+}
 #[cfg(all(
     target_arch = "wasm32",
     any(feature = "wasm", target_feature = "simd128")

--- a/src/goertzel.rs
+++ b/src/goertzel.rs
@@ -1,9 +1,9 @@
 //! Goertzel algorithm: efficient single-bin DFT detector
 //! no_std + alloc compatible
 
-use libm::{sqrtf, floorf};
 #[allow(unused_imports)]
-use crate::fft::{Float, FftError};
+use crate::fft::{FftError, Float};
+use libm::{floorf, sqrtf};
 
 /// Compute the magnitude at a single DFT bin using the Goertzel algorithm.
 /// - `input`: real-valued signal
@@ -11,11 +11,7 @@ use crate::fft::{Float, FftError};
 /// - `sample_rate`: sample rate in Hz
 /// - `target_freq`: frequency to detect in Hz
 #[cfg(feature = "std")]
-pub fn goertzel_f32(
-    input: &[f32],
-    sample_rate: f32,
-    target_freq: f32,
-) -> Result<f32, FftError> {
+pub fn goertzel_f32(input: &[f32], sample_rate: f32, target_freq: f32) -> Result<f32, FftError> {
     if input.is_empty() {
         return Err(FftError::EmptyInput);
     }
@@ -38,12 +34,8 @@ pub fn goertzel_f32(
 }
 
 #[cfg(not(feature = "std"))]
-pub fn goertzel_f32(
-    input: &[f32],
-    sample_rate: f32,
-    target_freq: f32,
-) -> Result<f32, FftError> {
-    use libm::{sqrtf, cosf, floorf};
+pub fn goertzel_f32(input: &[f32], sample_rate: f32, target_freq: f32) -> Result<f32, FftError> {
+    use libm::{cosf, floorf, sqrtf};
     if input.is_empty() {
         return Err(FftError::EmptyInput);
     }
@@ -74,7 +66,9 @@ mod tests {
         let sr = 8000.0;
         let f = 1000.0;
         let n = 100;
-        let signal: Vec<f32> = (0..n).map(|i| (2.0 * core::f32::consts::PI * f * i as f32 / sr).sin()).collect();
+        let signal: Vec<f32> = (0..n)
+            .map(|i| (2.0 * core::f32::consts::PI * f * i as f32 / sr).sin())
+            .collect();
         let mag = goertzel_f32(&signal, sr, f).unwrap();
         let _mean = signal.iter().map(|&x| x.abs()).sum::<f32>() / signal.len() as f32;
         assert!(mag > 0.0); // Only robust check with libm
@@ -82,12 +76,18 @@ mod tests {
 
     #[test]
     fn test_goertzel_empty() {
-        assert_eq!(goertzel_f32(&[], 1.0, 1.0).unwrap_err(), FftError::EmptyInput);
+        assert_eq!(
+            goertzel_f32(&[], 1.0, 1.0).unwrap_err(),
+            FftError::EmptyInput
+        );
     }
 
     #[test]
     fn test_goertzel_bad_rate() {
         let signal = [1.0f32, 2.0];
-        assert_eq!(goertzel_f32(&signal, 0.0, 1.0).unwrap_err(), FftError::InvalidValue);
+        assert_eq!(
+            goertzel_f32(&signal, 0.0, 1.0).unwrap_err(),
+            FftError::InvalidValue
+        );
     }
 }

--- a/src/ndfft.rs
+++ b/src/ndfft.rs
@@ -123,6 +123,11 @@ pub fn fft3d_inplace<T: Float>(
 // TODO: 3D FFT, real input, streaming, property-based tests
 
 #[cfg(test)]
+#[allow(
+    clippy::needless_range_loop,
+    clippy::manual_memcpy,
+    clippy::zero_repeat_side_effects
+)]
 mod tests {
     use super::*;
     use crate::fft::{Complex, FftError, ScalarFftImpl};
@@ -379,6 +384,11 @@ mod tests {
 }
 
 #[cfg(test)]
+#[allow(
+    clippy::needless_range_loop,
+    clippy::manual_memcpy,
+    clippy::zero_repeat_side_effects
+)]
 mod coverage_tests {
     use super::*;
     use crate::fft::{Complex32, ScalarFftImpl};

--- a/src/num.rs
+++ b/src/num.rs
@@ -1,9 +1,19 @@
 use core::f32::consts::PI as PI32;
 
 // Minimal float trait for generic FFT (no_std, no external deps)
-pub trait Float: Copy + Clone + PartialEq + PartialOrd + core::fmt::Debug +
-    core::ops::Add<Output=Self> + core::ops::Sub<Output=Self> + core::ops::Mul<Output=Self> +
-    core::ops::Div<Output=Self> + core::ops::Neg<Output=Self> + 'static {
+pub trait Float:
+    Copy
+    + Clone
+    + PartialEq
+    + PartialOrd
+    + core::fmt::Debug
+    + core::ops::Add<Output = Self>
+    + core::ops::Sub<Output = Self>
+    + core::ops::Mul<Output = Self>
+    + core::ops::Div<Output = Self>
+    + core::ops::Neg<Output = Self>
+    + 'static
+{
     fn zero() -> Self;
     fn one() -> Self;
     fn from_f32(x: f32) -> Self;
@@ -22,12 +32,24 @@ pub trait Float: Copy + Clone + PartialEq + PartialOrd + core::fmt::Debug +
 /// - This is a known linter false positive and is safe to suppress.
 #[allow(unconditional_recursion)]
 impl Float for f32 {
-    fn zero() -> Self { 0.0 }
-    fn one() -> Self { 1.0 }
-    fn from_f32(x: f32) -> Self { x }
-    fn cos(self) -> Self { f32::cos(self) }
-    fn sin(self) -> Self { f32::sin(self) }
-    fn pi() -> Self { PI32 }
+    fn zero() -> Self {
+        0.0
+    }
+    fn one() -> Self {
+        1.0
+    }
+    fn from_f32(x: f32) -> Self {
+        x
+    }
+    fn cos(self) -> Self {
+        f32::cos(self)
+    }
+    fn sin(self) -> Self {
+        f32::sin(self)
+    }
+    fn pi() -> Self {
+        PI32
+    }
 }
 
 ///
@@ -40,12 +62,24 @@ impl Float for f32 {
 /// - This is a known linter false positive and is safe to suppress.
 #[allow(unconditional_recursion)]
 impl Float for f64 {
-    fn zero() -> Self { 0.0 }
-    fn one() -> Self { 1.0 }
-    fn from_f32(x: f32) -> Self { x as f64 }
-    fn cos(self) -> Self { f64::cos(self) }
-    fn sin(self) -> Self { f64::sin(self) }
-    fn pi() -> Self { core::f64::consts::PI }
+    fn zero() -> Self {
+        0.0
+    }
+    fn one() -> Self {
+        1.0
+    }
+    fn from_f32(x: f32) -> Self {
+        x as f64
+    }
+    fn cos(self) -> Self {
+        f64::cos(self)
+    }
+    fn sin(self) -> Self {
+        f64::sin(self)
+    }
+    fn pi() -> Self {
+        core::f64::consts::PI
+    }
 }
 
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -55,18 +89,34 @@ pub struct Complex<T: Float> {
 }
 
 impl<T: Float> Complex<T> {
-    pub fn new(re: T, im: T) -> Self { Self { re, im } }
-    pub fn zero() -> Self { Self { re: T::zero(), im: T::zero() } }
+    pub fn new(re: T, im: T) -> Self {
+        Self { re, im }
+    }
+    pub fn zero() -> Self {
+        Self {
+            re: T::zero(),
+            im: T::zero(),
+        }
+    }
     pub fn expi(theta: T) -> Self {
-        Self { re: theta.cos(), im: theta.sin() }
+        Self {
+            re: theta.cos(),
+            im: theta.sin(),
+        }
     }
     #[allow(clippy::should_implement_trait)]
     pub fn add(self, other: Self) -> Self {
-        Self { re: self.re + other.re, im: self.im + other.im }
+        Self {
+            re: self.re + other.re,
+            im: self.im + other.im,
+        }
     }
     #[allow(clippy::should_implement_trait)]
     pub fn sub(self, other: Self) -> Self {
-        Self { re: self.re - other.re, im: self.im - other.im }
+        Self {
+            re: self.re - other.re,
+            im: self.im - other.im,
+        }
     }
     #[allow(clippy::should_implement_trait)]
     pub fn mul(self, other: Self) -> Self {
@@ -79,20 +129,31 @@ impl<T: Float> Complex<T> {
 
 impl<T: Float> core::ops::Neg for Complex<T> {
     type Output = Self;
-    fn neg(self) -> Self { Self { re: -self.re, im: -self.im } }
+    fn neg(self) -> Self {
+        Self {
+            re: -self.re,
+            im: -self.im,
+        }
+    }
 }
 
 impl<T: Float> core::ops::Add for Complex<T> {
     type Output = Self;
     fn add(self, other: Self) -> Self {
-        Self { re: self.re + other.re, im: self.im + other.im }
+        Self {
+            re: self.re + other.re,
+            im: self.im + other.im,
+        }
     }
 }
 
 impl<T: Float> core::ops::Sub for Complex<T> {
     type Output = Self;
     fn sub(self, other: Self) -> Self {
-        Self { re: self.re - other.re, im: self.im - other.im }
+        Self {
+            re: self.re - other.re,
+            im: self.im - other.im,
+        }
     }
 }
 
@@ -125,4 +186,3 @@ mod tests {
         let _e = Complex64::expi(<f64 as Float>::pi());
     }
 }
-

--- a/src/wavelet.rs
+++ b/src/wavelet.rs
@@ -5,8 +5,8 @@
 #![allow(clippy::excessive_precision)]
 
 extern crate alloc;
-use alloc::vec::Vec;
 use alloc::vec;
+use alloc::vec::Vec;
 
 /// Forward Haar wavelet transform (single level)
 pub fn haar_forward(input: &[f32]) -> (Vec<f32>, Vec<f32>) {
@@ -44,7 +44,10 @@ pub fn batch_forward(inputs: &[Vec<f32>]) -> (Vec<Vec<f32>>, Vec<Vec<f32>>) {
 }
 /// Batch Haar inverse transform
 pub fn batch_inverse(avgs: &[Vec<f32>], diffs: &[Vec<f32>]) -> Vec<Vec<f32>> {
-    avgs.iter().zip(diffs.iter()).map(|(a, d)| haar_inverse(a, d)).collect()
+    avgs.iter()
+        .zip(diffs.iter())
+        .map(|(a, d)| haar_inverse(a, d))
+        .collect()
 }
 
 /// Multi-level decomposition using a single-level forward function.
@@ -80,7 +83,11 @@ where
 }
 
 /// Batch multi-level decomposition.
-pub fn multi_level_forward_batch<F>(inputs: &[Vec<f32>], levels: usize, forward: F) -> (Vec<Vec<f32>>, Vec<Vec<Vec<f32>>>)
+pub fn multi_level_forward_batch<F>(
+    inputs: &[Vec<f32>],
+    levels: usize,
+    forward: F,
+) -> (Vec<Vec<f32>>, Vec<Vec<Vec<f32>>>)
 where
     F: Fn(&[f32]) -> (Vec<f32>, Vec<f32>),
 {
@@ -95,12 +102,15 @@ where
 }
 
 /// Batch multi-level reconstruction.
-pub fn multi_level_inverse_batch<F>(avgs: &[Vec<f32>], diffs: &[Vec<Vec<f32>>], inverse: F) -> Vec<Vec<f32>>
+pub fn multi_level_inverse_batch<F>(
+    avgs: &[Vec<f32>],
+    diffs: &[Vec<Vec<f32>>],
+    inverse: F,
+) -> Vec<Vec<f32>>
 where
     F: Fn(&[f32], &[f32]) -> Vec<f32>,
 {
-    avgs
-        .iter()
+    avgs.iter()
         .zip(diffs.iter())
         .map(|(a, d)| multi_level_inverse(a, d, &inverse))
         .collect()
@@ -108,9 +118,16 @@ where
 
 /// MCU/stack-only, const-generic, in-place Haar wavelet forward (N must be even, no heap)
 /// Output buffers avg and diff must be of length N/2.
-pub fn haar_forward_inplace_stack<const N: usize>(input: &[f32; N], avg: &mut [f32], diff: &mut [f32]) {
+pub fn haar_forward_inplace_stack<const N: usize>(
+    input: &[f32; N],
+    avg: &mut [f32],
+    diff: &mut [f32],
+) {
     let n = N / 2;
-    assert!(avg.len() == n && diff.len() == n, "Output buffers must be of length N/2");
+    assert!(
+        avg.len() == n && diff.len() == n,
+        "Output buffers must be of length N/2"
+    );
     for i in 0..n {
         avg[i] = (input[2 * i] + input[2 * i + 1]) / 2.0;
         diff[i] = (input[2 * i] - input[2 * i + 1]) / 2.0;
@@ -121,7 +138,10 @@ pub fn haar_forward_inplace_stack<const N: usize>(input: &[f32; N], avg: &mut [f
 /// Output buffer out must be of length 2*N.
 pub fn haar_inverse_inplace_stack<const N: usize>(avg: &[f32], diff: &[f32], out: &mut [f32]) {
     let n = avg.len();
-    assert!(diff.len() == n && out.len() == 2 * n, "Output buffer must be of length 2*N");
+    assert!(
+        diff.len() == n && out.len() == 2 * n,
+        "Output buffer must be of length 2*N"
+    );
     for i in 0..n {
         out[2 * i] = avg[i] + diff[i];
         out[2 * i + 1] = avg[i] - diff[i];
@@ -158,8 +178,10 @@ pub fn db2_forward(input: &[f32]) -> (Vec<f32>, Vec<f32>) {
     };
     for i in 0..n {
         let j = 2 * i as isize;
-        approx[i] = h0 * reflect(j) + h1 * reflect(j + 1) + h2 * reflect(j + 2) + h3 * reflect(j + 3);
-        detail[i] = g0 * reflect(j) + g1 * reflect(j + 1) + g2 * reflect(j + 2) + g3 * reflect(j + 3);
+        approx[i] =
+            h0 * reflect(j) + h1 * reflect(j + 1) + h2 * reflect(j + 2) + h3 * reflect(j + 3);
+        detail[i] =
+            g0 * reflect(j) + g1 * reflect(j + 1) + g2 * reflect(j + 2) + g3 * reflect(j + 3);
     }
     (approx, detail)
 }
@@ -231,7 +253,10 @@ pub fn db2_forward_batch(inputs: &[Vec<f32>]) -> (Vec<Vec<f32>>, Vec<Vec<f32>>) 
 }
 /// Batch db2 inverse transform
 pub fn db2_inverse_batch(avgs: &[Vec<f32>], diffs: &[Vec<f32>]) -> Vec<Vec<f32>> {
-    avgs.iter().zip(diffs.iter()).map(|(a, d)| db2_inverse(a, d)).collect()
+    avgs.iter()
+        .zip(diffs.iter())
+        .map(|(a, d)| db2_inverse(a, d))
+        .collect()
 }
 
 /// Daubechies-4 (db4) wavelet transform (single level)
@@ -578,7 +603,10 @@ mod db2_tests {
     fn test_db2_batch_roundtrip() {
         // For short signals, db2 is not perfectly invertible due to boundary effects.
         // This test demonstrates the limitation: the error is small relative to the signal.
-        let xs = vec![vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0], vec![5.0, 6.0, 7.0, 8.0, 1.0, 2.0, 3.0, 4.0]];
+        let xs = vec![
+            vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0],
+            vec![5.0, 6.0, 7.0, 8.0, 1.0, 2.0, 3.0, 4.0],
+        ];
         let (avgs, diffs) = db2_forward_batch(&xs);
         let recon = db2_inverse_batch(&avgs, &diffs);
         let mut max_err = 0.0;
@@ -586,17 +614,29 @@ mod db2_tests {
         for (orig, rec) in xs.iter().zip(recon.iter()) {
             for (a, b) in orig.iter().zip(rec.iter()) {
                 let err = (a - b).abs();
-                if err > max_err { max_err = err; }
-                if a.abs() > max_val { max_val = a.abs(); }
+                if err > max_err {
+                    max_err = err;
+                }
+                if a.abs() > max_val {
+                    max_val = a.abs();
+                }
             }
         }
         // For short signals, db2 is not suitable for strict roundtrip. Error should be less than the max signal value.
-        assert!(max_err < max_val, "max error for db2 roundtrip: {} (max signal value: {})", max_err, max_val);
+        assert!(
+            max_err < max_val,
+            "max error for db2 roundtrip: {} (max signal value: {})",
+            max_err,
+            max_val
+        );
     }
     #[test]
     fn test_haar_batch_roundtrip_strict() {
         // Haar wavelet is perfectly invertible for all signal lengths
-        let xs = vec![vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0], vec![5.0, 6.0, 7.0, 8.0, 1.0, 2.0, 3.0, 4.0]];
+        let xs = vec![
+            vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0],
+            vec![5.0, 6.0, 7.0, 8.0, 1.0, 2.0, 3.0, 4.0],
+        ];
         let (avgs, diffs) = batch_forward(&xs);
         let recon = batch_inverse(&avgs, &diffs);
         for (orig, rec) in xs.iter().zip(recon.iter()) {
@@ -620,5 +660,4 @@ mod multilevel_tests {
             assert!((o - r).abs() < 1e-5);
         }
     }
-
 }

--- a/src/window.rs
+++ b/src/window.rs
@@ -5,7 +5,7 @@ use core::f32::consts::PI;
 use libm::sqrtf;
 
 #[cfg(not(feature = "std"))]
-use libm::{cosf, fabsf, powf, sinf, floorf, logf, log10f};
+use libm::{cosf, fabsf, floorf, log10f, logf, powf, sinf};
 
 #[allow(unused_imports)]
 use crate::fft::Float;
@@ -46,8 +46,7 @@ pub fn blackman(len: usize) -> alloc::vec::Vec<f32> {
             let a1 = 0.5;
             let a2 = 0.08;
             let x = i as f32 / len as f32;
-            a0 - a1 * (2.0 * PI * x).cos()
-               + a2 * (4.0 * PI * x).cos()
+            a0 - a1 * (2.0 * PI * x).cos() + a2 * (4.0 * PI * x).cos()
         })
         .collect()
 }
@@ -79,15 +78,15 @@ pub fn kaiser(len: usize, beta: f32) -> alloc::vec::Vec<f32> {
 
 /// MCU/stack-only, const-generic, in-place Hann window (no heap)
 pub fn hann_inplace_stack<const N: usize>(out: &mut [f32; N]) {
-    for i in 0..N {
-        out[i] = 0.5 - 0.5 * (2.0 * PI * i as f32 / N as f32).cos();
+    for (i, out_i) in out.iter_mut().enumerate() {
+        *out_i = 0.5 - 0.5 * (2.0 * PI * i as f32 / N as f32).cos();
     }
 }
 
 /// MCU/stack-only, const-generic, in-place Hamming window (no heap)
 pub fn hamming_inplace_stack<const N: usize>(out: &mut [f32; N]) {
-    for i in 0..N {
-        out[i] = 0.54 - 0.46 * (2.0 * PI * i as f32 / N as f32).cos();
+    for (i, out_i) in out.iter_mut().enumerate() {
+        *out_i = 0.54 - 0.46 * (2.0 * PI * i as f32 / N as f32).cos();
     }
 }
 
@@ -96,9 +95,9 @@ pub fn blackman_inplace_stack<const N: usize>(out: &mut [f32; N]) {
     let a0 = 0.42;
     let a1 = 0.5;
     let a2 = 0.08;
-    for i in 0..N {
+    for (i, out_i) in out.iter_mut().enumerate() {
         let x = i as f32 / N as f32;
-        out[i] = a0 - a1 * (2.0 * PI * x).cos() + a2 * (4.0 * PI * x).cos();
+        *out_i = a0 - a1 * (2.0 * PI * x).cos() + a2 * (4.0 * PI * x).cos();
     }
 }
 
@@ -131,8 +130,8 @@ mod tests {
         // Peak amplitude at center
         assert!((w[4] - 1.0).abs() < 1e-6);
         // Symmetry
-        for i in 0..w.len() {
-            assert!((w[i] - w[w.len() - 1 - i]).abs() < 1e-6);
+        for (a, b) in w.iter().zip(w.iter().rev()) {
+            assert!((*a - *b).abs() < 1e-6);
         }
         assert!(w.iter().all(|&x| x.is_finite()));
     }

--- a/src/window_more.rs
+++ b/src/window_more.rs
@@ -2,13 +2,13 @@
 //! no_std + alloc compatible
 
 extern crate alloc;
-use alloc::vec::Vec;
 use alloc::vec;
+use alloc::vec::Vec;
 use core::f32::consts::PI;
 
-use libm::{cosf, fabsf, sinf, floorf};
 #[allow(unused_imports)]
 use crate::fft::Float;
+use libm::{cosf, fabsf, floorf, sinf};
 
 /// Tukey window (tapered cosine)
 pub fn tukey(len: usize, alpha: f32) -> Vec<f32> {
@@ -17,15 +17,12 @@ pub fn tukey(len: usize, alpha: f32) -> Vec<f32> {
     let edge = floorf(alpha * (len as f32 - 1.0) / 2.0) as usize;
     for (n, w_n) in w.iter_mut().enumerate() {
         *w_n = if n < edge {
-            0.5 * (1.0
-                + (PI * (2.0 * n as f32 / (alpha * (len as f32 - 1.0)) - 1.0)).cos())
+            0.5 * (1.0 + (PI * (2.0 * n as f32 / (alpha * (len as f32 - 1.0)) - 1.0)).cos())
         } else if n < len - edge {
             1.0
         } else {
             0.5 * (1.0
-                + (PI
-                    * (2.0 * n as f32 / (alpha * (len as f32 - 1.0)) - 2.0 / alpha + 1.0))
-                .cos())
+                + (PI * (2.0 * n as f32 / (alpha * (len as f32 - 1.0)) - 2.0 / alpha + 1.0)).cos())
         };
     }
     w


### PR DESCRIPTION
## Summary
- impl `Default` for stateless SIMD FFT structs
- derive `Clone`/`Debug` for `TwiddleFactorBuffer`
- refactor DCT and window loops to silence clippy
- document streaming STFT usage in README and module docs
- merge latest main and resolve conflicts

## Testing
- `cargo fmt -- src/dct.rs src/window.rs >/tmp/fmt.log && wc -c /tmp/fmt.log`
- `cargo clippy >/tmp/clippy.log 2>&1 && tail -n 20 /tmp/clippy.log`
- `cargo test >/tmp/unit.log 2>&1 && tail -n 20 /tmp/unit.log`


------
https://chatgpt.com/codex/tasks/task_e_689dff3f9aa4832b83b8eb36824b903d