### PR TITLE
Add default SIMD backends and streaming STFT docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ See [benchmarks/latest.json](benchmarks/latest.json) for full results.
 
 ```toml
 [dependencies]
-kofft = { version = "0.1.1", features = [
+kofft = { version = "0.1.4", features = [
     # "x86_64",   # enable AVX2 on x86_64
     # "sse",      # enable SSE on x86_64 without AVX2
     # "aarch64",  # enable NEON on AArch64
@@ -252,6 +252,26 @@ let mut output = vec![0.0; signal.len()];
 istft(&frames, &window, hop_size, &mut output)?;
 ```
 
+#### Streaming STFT/ISTFT
+
+```rust
+use kofft::stft::{StftStream, istft};
+use kofft::window::hann;
+use kofft::fft::Complex32;
+
+let signal = vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0];
+let window = hann(4);
+let hop_size = 2;
+let mut stream = StftStream::new(&signal, &window, hop_size)?;
+let mut frames = Vec::new();
+let mut frame = vec![Complex32::new(0.0, 0.0); window.len()];
+while stream.next_frame(&mut frame)? {
+    frames.push(frame.clone());
+}
+let mut output = vec![0.0; signal.len()];
+istft(&frames, &window, hop_size, &mut output)?;
+```
+
 ### Batch Processing
 
 ```rust
@@ -285,7 +305,7 @@ Enable optional features in `Cargo.toml`:
 
 ```toml
 [dependencies]
-kofft = { version = "0.1.1", features = [
+kofft = { version = "0.1.4", features = [
     # "x86_64",   # AVX2 on x86_64
     # "aarch64",  # NEON on AArch64
     # "wasm",     # WebAssembly SIMD

--- a/src/dct.rs
+++ b/src/dct.rs
@@ -27,8 +27,7 @@ pub fn dct1(input: &[f32]) -> Vec<f32> {
             } else {
                 -input[n - 1]
             };
-        for (offset, &x) in input[1..n - 1].iter().enumerate() {
-            let i = offset + 1;
+        for (i, &x) in input.iter().take(n - 1).enumerate().skip(1) {
             sum += 2.0 * x * (factor * i as f32 * k as f32).cos();
         }
         *out = sum;
@@ -99,8 +98,7 @@ pub fn dct1_inplace_stack<const N: usize>(
             } else {
                 -input[N - 1]
             };
-        for (offset, &x) in input[1..N - 1].iter().enumerate() {
-            let i = offset + 1;
+        for (i, &x) in input.iter().take(N - 1).enumerate().skip(1) {
             sum += 2.0 * x * (factor * i as f32 * k as f32).cos();
         }
         *out = sum;

--- a/src/fft.rs
+++ b/src/fft.rs
@@ -563,6 +563,7 @@ impl<T: Float> ScalarFftImpl<T> {
 }
 
 #[cfg(feature = "std")]
+#[derive(Clone, Debug)]
 pub struct TwiddleFactorBuffer {
     pub n: usize,
     pub twiddles: alloc::vec::Vec<Complex32>,
@@ -852,6 +853,7 @@ use core::arch::x86_64::*;
     target_arch = "x86_64",
     any(feature = "x86_64", target_feature = "avx2")
 ))]
+#[derive(Default)]
 pub struct SimdFftX86_64Impl;
 #[cfg(all(
     target_arch = "x86_64",
@@ -1075,6 +1077,7 @@ impl FftImpl<f32> for SimdFftX86_64Impl {
 
 // x86_64 SSE SIMD implementation
 #[cfg(all(target_arch = "x86_64", any(feature = "sse", target_feature = "sse2")))]
+#[derive(Default)]
 pub struct SimdFftSseImpl;
 #[cfg(all(target_arch = "x86_64", any(feature = "sse", target_feature = "sse2")))]
 impl FftImpl<f32> for SimdFftSseImpl {
@@ -1294,6 +1297,7 @@ use core::arch::aarch64::*;
     target_arch = "aarch64",
     any(feature = "aarch64", target_feature = "neon")
 ))]
+#[derive(Default)]
 pub struct SimdFftAArch64Impl;
 #[cfg(all(
     target_arch = "aarch64",
@@ -1491,6 +1495,7 @@ use core::arch::wasm32::*;
     target_arch = "wasm32",
     any(feature = "wasm", target_feature = "simd128")
 ))]
+#[derive(Default)]
 pub struct SimdFftWasmImpl;
 #[cfg(all(
     target_arch = "wasm32",

--- a/src/stft.rs
+++ b/src/stft.rs
@@ -1,4 +1,39 @@
-//! Short-Time Fourier Transform (STFT) implementation using ScalarFftImpl.
+//! Short-Time Fourier Transform (STFT) utilities.
+//!
+//! # Examples
+//!
+//! Batch STFT/ISTFT:
+//! ```no_run
+//! use kofft::stft::{stft, istft};
+//! use kofft::window::hann;
+//!
+//! let signal = vec![1.0, 2.0, 3.0, 4.0];
+//! let window = hann(2);
+//! let hop = 1;
+//! let mut frames = vec![vec![]; 4];
+//! stft(&signal, &window, hop, &mut frames).unwrap();
+//! let mut out = vec![0.0; signal.len()];
+//! istft(&frames, &window, hop, &mut out).unwrap();
+//! ```
+//!
+//! Streaming STFT:
+//! ```no_run
+//! use kofft::stft::{StftStream, istft};
+//! use kofft::window::hann;
+//! use kofft::fft::Complex32;
+//!
+//! let signal = vec![1.0, 2.0, 3.0, 4.0];
+//! let window = hann(2);
+//! let hop = 1;
+//! let mut stream = StftStream::new(&signal, &window, hop).unwrap();
+//! let mut frames = Vec::new();
+//! let mut buf = vec![Complex32::new(0.0, 0.0); window.len()];
+//! while stream.next_frame(&mut buf).unwrap() {
+//!     frames.push(buf.clone());
+//! }
+//! let mut out = vec![0.0; signal.len()];
+//! istft(&frames, &window, hop, &mut out).unwrap();
+//! ```
 
 extern crate alloc;
 use crate::fft::{Complex32, FftError, FftImpl, ScalarFftImpl};
@@ -83,7 +118,9 @@ pub fn istft(
     }
     Ok(())
 }
-
+/// Streaming STFT helper.
+///
+/// See the module-level documentation for an example.
 pub struct StftStream<'a> {
     signal: &'a [f32],
     window: &'a [f32],


### PR DESCRIPTION
## Summary
- derive `Clone`/`Debug` for `TwiddleFactorBuffer`
- implement `Default` for AVX2, SSE2, AArch64 and WASM SIMD FFT backends
- document streaming STFT/ISTFT and update README version references
- refactor DCT loops to iterate with `enumerate`

## Testing
- `cargo clippy --all-targets`
- `cargo test -q`

------
https://chatgpt.com/codex/tasks/task_e_689e0e6474f0832bbd760a0d69c11f6d