### PR TITLE
docs: correct author name in licenses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Hardened FFT helpers with stride checks, new error cases, and radix-4/mixed-radix paths ([benchmark results](benchmarks/latest.json))
 - Verified matrix dimensions for multi-dimensional FFT utilities
 
+### Fixed
+- Corrected author name spelling in license files
+
 ## [0.1.0] - 2024-12-19
 
 ### Added

--- a/LICENSE-APACHE
+++ b/LICENSE-APACHE
@@ -181,7 +181,7 @@
       same page as the copyright notice for easier identification within
       third-party archives.
 
-   Copyright 2024 Kian Ostadian
+   Copyright 2024 Kian Ostad
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/LICENSE-MIT
+++ b/LICENSE-MIT
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2024 Kian Ostadian
+Copyright (c) 2024 Kian Ostad
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
## Summary
- fix author's name in MIT and Apache license files
- note correction in changelog

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_689e0f4a6ca0832bb59ad458bd35529d