### PR TITLE
Enable internal-tests in coverage workflow

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Install tarpaulin
         run: cargo install cargo-tarpaulin
       - name: Run Tarpaulin
-        run: cargo tarpaulin --out Xml
+        run: cargo tarpaulin --out Xml --features internal-tests
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v4
         with:


### PR DESCRIPTION
## Summary
- ensure coverage workflow runs tests with `internal-tests` feature so Codecov reports meaningful coverage

## Testing
- `cargo test --features internal-tests`

------
https://chatgpt.com/codex/tasks/task_e_689e2ef2ae1c832b90a3b85a755fb2c0