### PR TITLE
Use Arc-backed slice caches for FFT twiddles

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,7 @@ members = ["kofft-bench"]
 libm = "0.2"
 proptest = { version = "1.4", optional = true }
 rand = { version = "0.8", optional = true }
+hashbrown = "0.14"
 
 [features]
 default = ["std"]


### PR DESCRIPTION
## Summary
- store FFT twiddle caches in `HashMap<usize, Arc<[Complex<T>]>>`
- return `&[Complex<T>]` for twiddle lookups and stage factors
- drop `Rc`/`BTreeMap` usage and add `hashbrown` dependency

## Testing
- `cargo test --workspace`


------
https://chatgpt.com/codex/tasks/task_e_689e3678ded0832b80d98e17dec0ff90