### PR TITLE
Refactor ND FFT interfaces and address clippy warnings

### DIFF
--- a/src/stft.rs
+++ b/src/stft.rs
@@ -247,10 +247,9 @@ pub fn inverse_parallel(
         return Err(FftError::InvalidHopSize);
     }
     let win_len = window.len();
-    let partials: Result<
-        alloc::vec::Vec<(usize, alloc::vec::Vec<f32>, alloc::vec::Vec<f32>)>,
-        FftError,
-    > = frames
+    type Accum = (usize, alloc::vec::Vec<f32>, alloc::vec::Vec<f32>);
+    type AccumResult = Result<alloc::vec::Vec<Accum>, FftError>;
+    let partials: AccumResult = frames
         .par_iter()
         .enumerate()
         .map(|(frame_idx, frame)| {


### PR DESCRIPTION
## Summary
- add type alias for flatten_3d result to reduce type complexity
- group 3D FFT scratch buffers into `Fft3dScratch` to cut argument count
- factor complex result type in STFT inverse_parallel

## Testing
- `cargo clippy --all-targets --all-features`
- `cargo test --all-features` *(fails: rfft::tests::rfft_irfft_roundtrip, tests::test_rfft_irfft_roundtrip)*

------
https://chatgpt.com/codex/tasks/task_e_689e440d4c60832ba4fd9a79a2821e4f