### PR TITLE
Add sin_cos to Float trait and optimize Complex::expi

### DIFF
--- a/src/num.rs
+++ b/src/num.rs
@@ -1,14 +1,25 @@
 use core::f32::consts::PI as PI32;
 
 // Minimal float trait for generic FFT (no_std, no external deps)
-pub trait Float: Copy + Clone + PartialEq + PartialOrd + core::fmt::Debug +
-    core::ops::Add<Output=Self> + core::ops::Sub<Output=Self> + core::ops::Mul<Output=Self> +
-    core::ops::Div<Output=Self> + core::ops::Neg<Output=Self> + 'static {
+pub trait Float:
+    Copy
+    + Clone
+    + PartialEq
+    + PartialOrd
+    + core::fmt::Debug
+    + core::ops::Add<Output = Self>
+    + core::ops::Sub<Output = Self>
+    + core::ops::Mul<Output = Self>
+    + core::ops::Div<Output = Self>
+    + core::ops::Neg<Output = Self>
+    + 'static
+{
     fn zero() -> Self;
     fn one() -> Self;
     fn from_f32(x: f32) -> Self;
     fn cos(self) -> Self;
     fn sin(self) -> Self;
+    fn sin_cos(self) -> (Self, Self);
     fn pi() -> Self;
 }
 
@@ -22,12 +33,27 @@ pub trait Float: Copy + Clone + PartialEq + PartialOrd + core::fmt::Debug +
 /// - This is a known linter false positive and is safe to suppress.
 #[allow(unconditional_recursion)]
 impl Float for f32 {
-    fn zero() -> Self { 0.0 }
-    fn one() -> Self { 1.0 }
-    fn from_f32(x: f32) -> Self { x }
-    fn cos(self) -> Self { f32::cos(self) }
-    fn sin(self) -> Self { f32::sin(self) }
-    fn pi() -> Self { PI32 }
+    fn zero() -> Self {
+        0.0
+    }
+    fn one() -> Self {
+        1.0
+    }
+    fn from_f32(x: f32) -> Self {
+        x
+    }
+    fn cos(self) -> Self {
+        f32::cos(self)
+    }
+    fn sin(self) -> Self {
+        f32::sin(self)
+    }
+    fn sin_cos(self) -> (Self, Self) {
+        f32::sin_cos(self)
+    }
+    fn pi() -> Self {
+        PI32
+    }
 }
 
 ///
@@ -40,12 +66,27 @@ impl Float for f32 {
 /// - This is a known linter false positive and is safe to suppress.
 #[allow(unconditional_recursion)]
 impl Float for f64 {
-    fn zero() -> Self { 0.0 }
-    fn one() -> Self { 1.0 }
-    fn from_f32(x: f32) -> Self { x as f64 }
-    fn cos(self) -> Self { f64::cos(self) }
-    fn sin(self) -> Self { f64::sin(self) }
-    fn pi() -> Self { core::f64::consts::PI }
+    fn zero() -> Self {
+        0.0
+    }
+    fn one() -> Self {
+        1.0
+    }
+    fn from_f32(x: f32) -> Self {
+        x as f64
+    }
+    fn cos(self) -> Self {
+        f64::cos(self)
+    }
+    fn sin(self) -> Self {
+        f64::sin(self)
+    }
+    fn sin_cos(self) -> (Self, Self) {
+        f64::sin_cos(self)
+    }
+    fn pi() -> Self {
+        core::f64::consts::PI
+    }
 }
 
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -55,18 +96,32 @@ pub struct Complex<T: Float> {
 }
 
 impl<T: Float> Complex<T> {
-    pub fn new(re: T, im: T) -> Self { Self { re, im } }
-    pub fn zero() -> Self { Self { re: T::zero(), im: T::zero() } }
+    pub fn new(re: T, im: T) -> Self {
+        Self { re, im }
+    }
+    pub fn zero() -> Self {
+        Self {
+            re: T::zero(),
+            im: T::zero(),
+        }
+    }
     pub fn expi(theta: T) -> Self {
-        Self { re: theta.cos(), im: theta.sin() }
+        let (sin, cos) = theta.sin_cos();
+        Self { re: cos, im: sin }
     }
     #[allow(clippy::should_implement_trait)]
     pub fn add(self, other: Self) -> Self {
-        Self { re: self.re + other.re, im: self.im + other.im }
+        Self {
+            re: self.re + other.re,
+            im: self.im + other.im,
+        }
     }
     #[allow(clippy::should_implement_trait)]
     pub fn sub(self, other: Self) -> Self {
-        Self { re: self.re - other.re, im: self.im - other.im }
+        Self {
+            re: self.re - other.re,
+            im: self.im - other.im,
+        }
     }
     #[allow(clippy::should_implement_trait)]
     pub fn mul(self, other: Self) -> Self {
@@ -79,20 +134,31 @@ impl<T: Float> Complex<T> {
 
 impl<T: Float> core::ops::Neg for Complex<T> {
     type Output = Self;
-    fn neg(self) -> Self { Self { re: -self.re, im: -self.im } }
+    fn neg(self) -> Self {
+        Self {
+            re: -self.re,
+            im: -self.im,
+        }
+    }
 }
 
 impl<T: Float> core::ops::Add for Complex<T> {
     type Output = Self;
     fn add(self, other: Self) -> Self {
-        Self { re: self.re + other.re, im: self.im + other.im }
+        Self {
+            re: self.re + other.re,
+            im: self.im + other.im,
+        }
     }
 }
 
 impl<T: Float> core::ops::Sub for Complex<T> {
     type Output = Self;
     fn sub(self, other: Self) -> Self {
-        Self { re: self.re - other.re, im: self.im - other.im }
+        Self {
+            re: self.re - other.re,
+            im: self.im - other.im,
+        }
     }
 }
 
@@ -125,4 +191,3 @@ mod tests {
         let _e = Complex64::expi(<f64 as Float>::pi());
     }
 }
-


### PR DESCRIPTION
## Summary
- add `sin_cos` method to `Float` trait
- implement `sin_cos` for `f32` and `f64`
- use `sin_cos` in `Complex::expi` for combined sine/cosine calculation

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_689e463815c0832b9c8653ca384433c5