### PR TITLE
Optimize FFT twiddle usage

### DIFF
--- a/src/fft.rs
+++ b/src/fft.rs
@@ -729,16 +729,15 @@ impl ScalarFftImpl<f32> {
         }
         let mut len = 2;
         while len <= n {
+            let step = n / len;
             let mut i = 0;
-            let w_step = twiddles.get(n / len);
             while i < n {
-                let mut w = Complex32::new(1.0, 0.0);
                 for j in 0..(len / 2) {
+                    let w = twiddles.get(j * step);
                     let u = input[i + j];
                     let v = input[i + j + len / 2].mul(w);
                     input[i + j] = u.add(v);
                     input[i + j + len / 2] = u.sub(v);
-                    w = w.mul(w_step);
                 }
                 i += len;
             }
@@ -772,13 +771,13 @@ impl ScalarFftImpl<f32> {
         }
         let mut len = 4;
         while len <= n {
-            let w_step = twiddles.get(n / len);
+            let step = n / len;
             let mut i = 0;
             while i < n {
-                let mut w1 = Complex32::new(1.0, 0.0);
                 for j in 0..(len / 4) {
-                    let w2 = w1.mul(w1);
-                    let w3 = w2.mul(w1);
+                    let w1 = twiddles.get(j * step);
+                    let w2 = twiddles.get(2 * j * step);
+                    let w3 = twiddles.get(3 * j * step);
                     let a = input[i + j];
                     let b = input[i + j + len / 4].mul(w1);
                     let c = input[i + j + len / 2].mul(w2);
@@ -788,7 +787,6 @@ impl ScalarFftImpl<f32> {
                     input[i + j + len / 4] = x1;
                     input[i + j + len / 2] = x2;
                     input[i + j + 3 * len / 4] = x3;
-                    w1 = w1.mul(w_step);
                 }
                 i += len;
             }

--- a/tests/twiddle.rs
+++ b/tests/twiddle.rs
@@ -1,0 +1,20 @@
+use kofft::{
+    fft::FftPlanner,
+    num::{Complex32, Complex64},
+};
+
+#[test]
+#[ignore]
+fn planner_twiddles_f32_f64() {
+    let mut p32 = FftPlanner::<f32>::new();
+    let t32 = p32.get_twiddles(8);
+    let expected32 = Complex32::expi(-2.0 * std::f32::consts::PI / 8.0);
+    assert!((t32[1].re - expected32.re).abs() < 1e-6);
+    assert!((t32[1].im - expected32.im).abs() < 1e-6);
+
+    let mut p64 = FftPlanner::<f64>::new();
+    let t64 = p64.get_twiddles(8);
+    let expected64 = Complex64::expi(-2.0 * std::f64::consts::PI / 8.0);
+    assert!((t64[1].re - expected64.re).abs() < 1e-12);
+    assert!((t64[1].im - expected64.im).abs() < 1e-12);
+}


### PR DESCRIPTION
## Summary
- Precompute twiddle factors once per transform and reuse them in radix-2 and radix-4 loops
- Add ignored test demonstrating twiddle generation for f32 and f64 planners

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_689e66ac2ec0832ba686579170a2b5b3