### PR TITLE
Improve STFT/ISTFT buffer reuse and in-place operations

### DIFF
--- a/README.md
+++ b/README.md
@@ -249,7 +249,8 @@ let mut frames = vec![vec![]; (signal.len() + hop_size - 1) / hop_size];
 stft(&signal, &window, hop_size, &mut frames)?;
 
 let mut output = vec![0.0; signal.len()];
-istft(&frames, &window, hop_size, &mut output)?;
+let mut scratch = vec![0.0; output.len()];
+istft(&mut frames, &window, hop_size, &mut output, &mut scratch)?;
 ```
 
 #### Streaming STFT/ISTFT
@@ -269,7 +270,8 @@ while stream.next_frame(&mut frame)? {
     frames.push(frame.clone());
 }
 let mut output = vec![0.0; signal.len()];
-istft(&frames, &window, hop_size, &mut output)?;
+let mut scratch = vec![0.0; output.len()];
+istft(&mut frames, &window, hop_size, &mut output, &mut scratch)?;
 ```
 
 ### Batch Processing

--- a/examples/stft_usage.rs
+++ b/examples/stft_usage.rs
@@ -27,7 +27,8 @@ fn main() -> Result<(), FftError> {
     }
 
     let mut reconstructed = vec![0.0; signal.len()];
-    istft(&frames, &window, hop, &mut reconstructed)?;
+    let mut scratch = vec![0.0; reconstructed.len()];
+    istft(&mut frames, &window, hop, &mut reconstructed, &mut scratch)?;
     println!("Reconstructed signal: {:?}", reconstructed);
     Ok(())
 }


### PR DESCRIPTION
## Summary
- avoid per-frame allocations in `stft` by resizing frames and writing via indices
- run inverse STFT in-place with reusable normalization scratch buffer
- update documentation and examples for new `istft` signature

## Testing
- `cargo test --features "internal-tests parallel"`

------
https://chatgpt.com/codex/tasks/task_e_689e67a1e0e8832b9ca470b307e8ed2f