### PR TITLE
Add RfftPlanner for cached real FFT twiddles

### DIFF
--- a/examples/rfft_usage.rs
+++ b/examples/rfft_usage.rs
@@ -1,18 +1,21 @@
 use kofft::fft::ScalarFftImpl;
-use kofft::rfft::{irfft_stack, rfft_stack, RealFftImpl};
+use kofft::rfft::{irfft_stack, rfft_stack, RfftPlanner};
 use kofft::Complex32;
 
 fn main() {
     // Planner-based real FFT
     let fft = ScalarFftImpl::<f32>::default();
+    let mut planner = RfftPlanner::new();
     let mut input = vec![1.0f32, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0];
     let mut spectrum = vec![Complex32::new(0.0, 0.0); input.len() / 2 + 1];
     let mut scratch = vec![Complex32::new(0.0, 0.0); input.len() / 2];
-    fft.rfft_with_scratch(&mut input, &mut spectrum, &mut scratch)
+    planner
+        .rfft_with_scratch(&fft, &mut input, &mut spectrum, &mut scratch)
         .unwrap();
 
     let mut output = vec![0.0f32; input.len()];
-    fft.irfft_with_scratch(&mut spectrum, &mut output, &mut scratch)
+    planner
+        .irfft_with_scratch(&fft, &mut spectrum, &mut output, &mut scratch)
         .unwrap();
     println!("Input: {:?}\nReconstructed: {:?}", input, output);
 

--- a/kofft-bench/benches/bench_fft.rs
+++ b/kofft-bench/benches/bench_fft.rs
@@ -12,7 +12,7 @@ use serde::{Deserialize, Serialize};
 #[cfg(feature = "parallel")]
 use kofft::fft::fft_parallel;
 use kofft::fft::{Complex32, FftImpl, FftPlanner, FftStrategy, ScalarFftImpl};
-use kofft::rfft::{rfft_packed, RealFftImpl};
+use kofft::rfft::{rfft_packed, RealFftImpl, RfftPlanner};
 use realfft::RealFftPlanner as RustRealFftPlanner;
 use rustfft::FftPlanner as RustFftPlanner;
 
@@ -352,11 +352,12 @@ fn bench_real(c: &mut Criterion, size: usize) {
             let mut total = Duration::ZERO;
             let mut alloc_total = 0;
             let mut peak = 0;
+            let mut planner = RfftPlanner::<f32>::new();
             for _ in 0..iters {
                 input.copy_from_slice(&input_template);
                 reset_alloc();
                 let start = Instant::now();
-                rfft_packed(&fft, &mut input, &mut output, &mut scratch).unwrap();
+                rfft_packed(&mut planner, &fft, &mut input, &mut output, &mut scratch).unwrap();
                 let dur = start.elapsed();
                 let (a, p) = alloc_stats();
                 alloc_total += a;


### PR DESCRIPTION
## Summary
- add `RfftPlanner` that caches real-FFT twiddle tables by length
- update real FFT kernels and planner trait to look up cached twiddles
- update benchmarks and examples to use the new planner API

## Testing
- `cargo test`
- `cargo test` (in `kofft-bench`)
- `cargo test --examples`


------
https://chatgpt.com/codex/tasks/task_e_689e6b3f7f8c832b8124de6f85163583