### PR TITLE
Reuse FFT plans in STFT helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,17 +240,19 @@ For background on STFT, see [Wikipedia](https://en.wikipedia.org/wiki/Short-time
 ```rust
 use kofft::stft::{stft, istft};
 use kofft::window::hann;
+use kofft::fft::ScalarFftImpl;
 
 let signal = vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0];
 let window = hann(4);
 let hop_size = 2;
+let fft = ScalarFftImpl::<f32>::default();
 
 let mut frames = vec![vec![]; (signal.len() + hop_size - 1) / hop_size];
-stft(&signal, &window, hop_size, &mut frames)?;
+stft(&signal, &window, hop_size, &mut frames, &fft)?;
 
 let mut output = vec![0.0; signal.len()];
 let mut scratch = vec![0.0; output.len()];
-istft(&mut frames, &window, hop_size, &mut output, &mut scratch)?;
+istft(&mut frames, &window, hop_size, &mut output, &mut scratch, &fft)?;
 ```
 
 #### Streaming STFT/ISTFT
@@ -258,12 +260,13 @@ istft(&mut frames, &window, hop_size, &mut output, &mut scratch)?;
 ```rust
 use kofft::stft::{StftStream, istft};
 use kofft::window::hann;
-use kofft::fft::Complex32;
+use kofft::fft::{Complex32, ScalarFftImpl};
 
 let signal = vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0];
 let window = hann(4);
 let hop_size = 2;
-let mut stream = StftStream::new(&signal, &window, hop_size)?;
+let fft = ScalarFftImpl::<f32>::default();
+let mut stream = StftStream::new(&signal, &window, hop_size, &fft)?;
 let mut frames = Vec::new();
 let mut frame = vec![Complex32::new(0.0, 0.0); window.len()];
 while stream.next_frame(&mut frame)? {
@@ -271,7 +274,7 @@ while stream.next_frame(&mut frame)? {
 }
 let mut output = vec![0.0; signal.len()];
 let mut scratch = vec![0.0; output.len()];
-istft(&mut frames, &window, hop_size, &mut output, &mut scratch)?;
+istft(&mut frames, &window, hop_size, &mut output, &mut scratch, &fft)?;
 ```
 
 ### Batch Processing

--- a/examples/stft_usage.rs
+++ b/examples/stft_usage.rs
@@ -4,7 +4,7 @@
 //!
 //! When built with `--features parallel`, also showcases the parallel STFT helper.
 
-use kofft::fft::FftError;
+use kofft::fft::{FftError, ScalarFftImpl};
 #[cfg(feature = "parallel")]
 use kofft::stft::parallel;
 use kofft::stft::{istft, stft};
@@ -15,20 +15,28 @@ fn main() -> Result<(), FftError> {
     let window = hann(4);
     let hop = 2;
 
+    let fft = ScalarFftImpl::<f32>::default();
     let mut frames = vec![vec![]; signal.len().div_ceil(hop)];
-    stft(&signal, &window, hop, &mut frames)?;
+    stft(&signal, &window, hop, &mut frames, &fft)?;
     println!("STFT frames: {:?}", frames);
 
     #[cfg(feature = "parallel")]
     {
         let mut frames_par = vec![vec![]; signal.len().div_ceil(hop)];
-        parallel(&signal, &window, hop, &mut frames_par)?;
+        parallel(&signal, &window, hop, &mut frames_par, &fft)?;
         println!("Parallel STFT frames: {:?}", frames_par);
     }
 
     let mut reconstructed = vec![0.0; signal.len()];
     let mut scratch = vec![0.0; reconstructed.len()];
-    istft(&mut frames, &window, hop, &mut reconstructed, &mut scratch)?;
+    istft(
+        &mut frames,
+        &window,
+        hop,
+        &mut reconstructed,
+        &mut scratch,
+        &fft,
+    )?;
     println!("Reconstructed signal: {:?}", reconstructed);
     Ok(())
 }


### PR DESCRIPTION
## Summary
- Add generic FFT parameter to `stft`, `istft`, and streaming helpers
- Allow `StftStream` and parallel variants to reuse a caller-provided FFT instance
- Update examples and README to construct FFT once and pass by reference

## Testing
- `cargo test`
- `cargo test --features parallel`


------
https://chatgpt.com/codex/tasks/task_e_689e6b415950832bb2f70722a90a5045