### PR TITLE
feat: adapt parallel FFT threshold with runtime tuning

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,10 +29,11 @@ libm = "0.2"
 proptest = { version = "1.4", optional = true }
 rand = { version = "0.8", optional = true }
 hashbrown = "0.14"
+num_cpus = { version = "1.16", optional = true }
 
 [features]
 default = ["std"]
-std = []
+std = ["num_cpus"]
 parallel = ["rayon"]
 x86_64 = []
 sse = []

--- a/README.md
+++ b/README.md
@@ -78,6 +78,12 @@ threads via [Rayon](https://crates.io/crates/rayon). Use the `fft_parallel` and
 `ifft_parallel` helpers which safely fall back to single-threaded execution when
 Rayon is not available.
 
+By default, kofft parallelizes an FFT when each CPU core would process roughly
+4,096 points (~32&nbsp;KiB for `f32`). The heuristic scales with the number of
+detected cores (via [`num_cpus`](https://crates.io/crates/num_cpus)) and can be
+overridden by setting the `KOFFT_PAR_FFT_THRESHOLD` environment variable or by
+calling `kofft::fft::set_parallel_fft_threshold` at runtime.
+
 ```rust
 use kofft::fft::{fft_parallel, ifft_parallel, Complex32};
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -65,6 +65,8 @@
 
 #![no_std]
 extern crate alloc;
+#[cfg(feature = "std")]
+extern crate std;
 
 pub mod fft;
 /// Real-input FFT helpers built on top of complex FFT routines


### PR DESCRIPTION
## Summary
- replace fixed parallel FFT threshold with heuristic based on cores and size
- allow overriding threshold via `KOFFT_PAR_FFT_THRESHOLD` or `set_parallel_fft_threshold`
- document parallel FFT heuristic and expose setter

## Testing
- `cargo test`
- `cargo test --features parallel`


------
https://chatgpt.com/codex/tasks/task_e_689e6b46b600832b80aadc3bcf663ba9