### PR TITLE
Use strided FFT for ND transforms

### DIFF
--- a/src/fft.rs
+++ b/src/fft.rs
@@ -425,11 +425,14 @@ impl<T: Float> FftImpl<T> for ScalarFftImpl<T> {
         stride: usize,
         scratch: &mut [Complex<T>],
     ) -> Result<(), FftError> {
-        if stride == 0 || input.len() % stride != 0 {
+        if stride == 0 {
             return Err(FftError::InvalidStride);
         }
-        let n = input.len() / stride;
-        if scratch.len() < n {
+        let n = scratch.len();
+        if n == 0 {
+            return Ok(());
+        }
+        if input.len() < (n - 1) * stride + 1 {
             return Err(FftError::MismatchedLengths);
         }
         for i in 0..n {
@@ -447,11 +450,14 @@ impl<T: Float> FftImpl<T> for ScalarFftImpl<T> {
         stride: usize,
         scratch: &mut [Complex<T>],
     ) -> Result<(), FftError> {
-        if stride == 0 || input.len() % stride != 0 {
+        if stride == 0 {
             return Err(FftError::InvalidStride);
         }
-        let n = input.len() / stride;
-        if scratch.len() < n {
+        let n = scratch.len();
+        if n == 0 {
+            return Ok(());
+        }
+        if input.len() < (n - 1) * stride + 1 {
             return Err(FftError::MismatchedLengths);
         }
         for i in 0..n {


### PR DESCRIPTION
## Summary
- apply `fft_strided`/`ifft_strided` to 2D and 3D ND FFT routines
- update scalar FFT to support strided transforms with explicit scratch length
- switch tests to use strided inverse helpers

## Testing
- `cargo test --all-features`
- memory check for 128x128 FFT (manual vs strided)


------
https://chatgpt.com/codex/tasks/task_e_689e6b452bdc832b8c47c066d26e2e7a