### PR TITLE
Improve FFT parallelization heuristic

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,11 +78,15 @@ threads via [Rayon](https://crates.io/crates/rayon). Use the `fft_parallel` and
 `ifft_parallel` helpers which safely fall back to single-threaded execution when
 Rayon is not available.
 
-By default, kofft parallelizes an FFT when each CPU core would process roughly
-4,096 points (~32&nbsp;KiB for `f32`). The heuristic scales with the number of
-detected cores (via [`num_cpus`](https://crates.io/crates/num_cpus)) and can be
-overridden by setting the `KOFFT_PAR_FFT_THRESHOLD` environment variable or by
-calling `kofft::fft::set_parallel_fft_threshold` at runtime.
+By default, kofft parallelizes an FFT when each CPU core would process at least
+`max(L1_cache_bytes / size_of::<Complex32>(), per_core_work)` elements. The
+defaults assume a 32&nbsp;KiB L1 cache and require roughly 4,096 points per core.
+The heuristic scales with the number of detected cores (via
+[`num_cpus`](https://crates.io/crates/num_cpus)) and can be tuned using the
+`KOFFT_PAR_FFT_THRESHOLD`, `KOFFT_PAR_FFT_CACHE_BYTES`, or
+`KOFFT_PAR_FFT_PER_CORE_WORK` environment variables, or by calling
+`kofft::fft::set_parallel_fft_threshold`, `set_parallel_fft_l1_cache`, or
+`set_parallel_fft_per_core_work` at runtime.
 
 ```rust
 use kofft::fft::{fft_parallel, ifft_parallel, Complex32};


### PR DESCRIPTION
## Summary
- account for cache size and per-core work in the FFT parallelization heuristic
- avoid repeated env and CPU lookups by caching results
- document heuristic and expose tuning knobs via functions and env vars

## Testing
- `cargo fmt`
- `cargo test`
- `cargo test --features=parallel`


------
https://chatgpt.com/codex/tasks/task_e_689e7160b010832b9c2b07d08ee38666