### PR TITLE
Add split-complex FFT support and benchmark

### DIFF
--- a/kofft-bench/Cargo.toml
+++ b/kofft-bench/Cargo.toml
@@ -21,6 +21,10 @@ harness = false
 name = "bench_dct"
 harness = false
 
+[[bench]]
+name = "aos_vs_soa"
+harness = false
+
 [[example]]
 name = "update_bench_readme"
 path = "examples/update_bench_readme.rs"

--- a/kofft-bench/benches/aos_vs_soa.rs
+++ b/kofft-bench/benches/aos_vs_soa.rs
@@ -1,0 +1,25 @@
+use criterion::{criterion_group, criterion_main, Criterion};
+use kofft::fft::{ScalarFftImpl, FftImpl, Complex32};
+
+fn bench_aos_vs_soa(c: &mut Criterion) {
+    let size = 1024;
+    let mut aos: Vec<Complex32> = (0..size).map(|i| Complex32::new(i as f32, 0.0)).collect();
+    let mut re: Vec<f32> = aos.iter().map(|c| c.re).collect();
+    let mut im: Vec<f32> = aos.iter().map(|c| c.im).collect();
+    let fft = ScalarFftImpl::<f32>::default();
+
+    c.bench_function("fft_aos", |b| {
+        b.iter(|| {
+            fft.fft(&mut aos).unwrap();
+        });
+    });
+
+    c.bench_function("fft_soa", |b| {
+        b.iter(|| {
+            fft.fft_split(&mut re, &mut im).unwrap();
+        });
+    });
+}
+
+criterion_group!(benches, bench_aos_vs_soa);
+criterion_main!(benches);

--- a/src/fft.rs
+++ b/src/fft.rs
@@ -82,7 +82,7 @@ fn should_parallelize_fft(n: usize) -> bool {
     n / cores >= 4096
 }
 
-pub use crate::num::{Complex, Complex32, Complex64, Float};
+pub use crate::num::{Complex, Complex32, Complex64, Float, SplitComplex, copy_from_complex, copy_to_complex};
 
 type BluesteinPair<T> = (Arc<[Complex<T>]>, Arc<[Complex<T>]>);
 
@@ -289,6 +289,38 @@ pub trait FftImpl<T: Float> {
         let mut scratch = alloc::vec::Vec::with_capacity(n);
         scratch.resize(n, Complex::zero());
         self.ifft_strided(input, stride, &mut scratch)
+    }
+
+    fn fft_split(&self, re: &mut [T], im: &mut [T]) -> Result<(), FftError> {
+        if re.len() != im.len() {
+            return Err(FftError::MismatchedLengths);
+        }
+        let mut buf = alloc::vec::Vec::with_capacity(re.len());
+        for i in 0..re.len() {
+            buf.push(Complex::new(re[i], im[i]));
+        }
+        self.fft(&mut buf)?;
+        for i in 0..re.len() {
+            re[i] = buf[i].re;
+            im[i] = buf[i].im;
+        }
+        Ok(())
+    }
+
+    fn ifft_split(&self, re: &mut [T], im: &mut [T]) -> Result<(), FftError> {
+        if re.len() != im.len() {
+            return Err(FftError::MismatchedLengths);
+        }
+        let mut buf = alloc::vec::Vec::with_capacity(re.len());
+        for i in 0..re.len() {
+            buf.push(Complex::new(re[i], im[i]));
+        }
+        self.ifft(&mut buf)?;
+        for i in 0..re.len() {
+            re[i] = buf[i].re;
+            im[i] = buf[i].im;
+        }
+        Ok(())
     }
 }
 
@@ -2012,6 +2044,20 @@ impl<T: Float> FftPlan<T> {
         output.copy_from_slice(input);
         self.ifft(output)
     }
+
+    pub fn fft_split(&self, re: &mut [T], im: &mut [T]) -> Result<(), FftError> {
+        if re.len() != self.n || im.len() != self.n {
+            return Err(FftError::MismatchedLengths);
+        }
+        self.fft.fft_split(re, im)
+    }
+
+    pub fn ifft_split(&self, re: &mut [T], im: &mut [T]) -> Result<(), FftError> {
+        if re.len() != self.n || im.len() != self.n {
+            return Err(FftError::MismatchedLengths);
+        }
+        self.fft.ifft_split(re, im)
+    }
 }
 
 /// Compute FFT using the default planner. When the `parallel` feature is
@@ -2026,6 +2072,14 @@ pub fn fft_parallel<T: Float>(input: &mut [Complex<T>]) -> Result<(), FftError> 
 /// the same manner as [`fft_parallel`].
 pub fn ifft_parallel<T: Float>(input: &mut [Complex<T>]) -> Result<(), FftError> {
     ScalarFftImpl::<T>::default().ifft(input)
+}
+
+pub fn fft_split<T: Float>(re: &mut [T], im: &mut [T]) -> Result<(), FftError> {
+    ScalarFftImpl::<T>::default().fft_split(re, im)
+}
+
+pub fn ifft_split<T: Float>(re: &mut [T], im: &mut [T]) -> Result<(), FftError> {
+    ScalarFftImpl::<T>::default().ifft_split(re, im)
 }
 
 /// Batch FFT: process a batch of mutable slices in-place

--- a/src/num.rs
+++ b/src/num.rs
@@ -1,4 +1,5 @@
 use core::f32::consts::PI as PI32;
+use alloc::vec::Vec;
 
 // Minimal float trait for generic FFT (no_std, no external deps)
 pub trait Float:
@@ -194,6 +195,59 @@ impl<T: Float> core::ops::Mul for Complex<T> {
 
 pub type Complex32 = Complex<f32>;
 pub type Complex64 = Complex<f64>;
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct SplitComplex<T: Float> {
+    pub re: Vec<T>,
+    pub im: Vec<T>,
+}
+
+impl<T: Float> SplitComplex<T> {
+    pub fn new(re: Vec<T>, im: Vec<T>) -> Self {
+        assert_eq!(re.len(), im.len());
+        Self { re, im }
+    }
+    pub fn len(&self) -> usize {
+        self.re.len()
+    }
+    pub fn from_complex_vec(v: &[Complex<T>]) -> Self {
+        let mut re = Vec::with_capacity(v.len());
+        let mut im = Vec::with_capacity(v.len());
+        for c in v {
+            re.push(c.re);
+            im.push(c.im);
+        }
+        Self { re, im }
+    }
+    pub fn to_complex_vec(&self) -> Vec<Complex<T>> {
+        let mut out = Vec::with_capacity(self.re.len());
+        for i in 0..self.re.len() {
+            out.push(Complex::new(self.re[i], self.im[i]));
+        }
+        out
+    }
+}
+
+pub type SplitComplex32 = SplitComplex<f32>;
+pub type SplitComplex64 = SplitComplex<f64>;
+
+pub fn copy_from_complex<T: Float>(input: &[Complex<T>], re: &mut [T], im: &mut [T]) {
+    assert_eq!(input.len(), re.len());
+    assert_eq!(input.len(), im.len());
+    for i in 0..input.len() {
+        re[i] = input[i].re;
+        im[i] = input[i].im;
+    }
+}
+
+pub fn copy_to_complex<T: Float>(re: &[T], im: &[T], out: &mut [Complex<T>]) {
+    assert_eq!(re.len(), im.len());
+    assert_eq!(re.len(), out.len());
+    for i in 0..re.len() {
+        out[i].re = re[i];
+        out[i].im = im[i];
+    }
+}
 
 #[cfg(all(feature = "internal-tests", test))]
 mod tests {

--- a/tests/split.rs
+++ b/tests/split.rs
@@ -1,0 +1,19 @@
+use kofft::fft::{ScalarFftImpl, FftImpl};
+use kofft::fft::Complex32;
+
+#[test]
+fn fft_split_matches_aos() {
+    let n = 16;
+    let mut data: Vec<Complex32> = (0..n).map(|i| Complex32::new(i as f32, 0.0)).collect();
+    let mut re: Vec<f32> = data.iter().map(|c| c.re).collect();
+    let mut im: Vec<f32> = data.iter().map(|c| c.im).collect();
+
+    let fft = ScalarFftImpl::<f32>::default();
+    let mut aos = data.clone();
+    fft.fft(&mut aos).unwrap();
+    fft.fft_split(&mut re, &mut im).unwrap();
+    for i in 0..n {
+        assert!((aos[i].re - re[i]).abs() < 1e-6);
+        assert!((aos[i].im - im[i]).abs() < 1e-6);
+    }
+}


### PR DESCRIPTION
## Summary
- add `SplitComplex` structure and helpers to convert between AoS and SoA
- allow FFT implementations and plans to run on split real/imag arrays
- benchmark AoS vs SoA FFT performance

## Testing
- `cargo test`
- `cargo bench -p kofft-bench --bench aos_vs_soa`


------
https://chatgpt.com/codex/tasks/task_e_689e7167707c832ba546fcd3fe7d6824