### PR TITLE
Use block-wise transposes for multi-dimensional FFTs

### DIFF
--- a/examples/ndfft_usage.rs
+++ b/examples/ndfft_usage.rs
@@ -12,7 +12,7 @@ fn main() -> Result<(), FftError> {
     ];
     let (mut data, rows, cols) = flatten_2d(nested)?;
     let fft = ScalarFftImpl::<f32>::default();
-    let mut scratch = vec![Complex32::zero(); rows];
+    let mut scratch = vec![Complex32::zero(); rows * cols];
 
     fft2d_inplace(&mut data, rows, cols, &fft, &mut scratch)?;
     println!("2D FFT result: {:?}", data);

--- a/kofft-bench/Cargo.toml
+++ b/kofft-bench/Cargo.toml
@@ -21,6 +21,10 @@ harness = false
 name = "bench_dct"
 harness = false
 
+[[bench]]
+name = "bench_ndfft"
+harness = false
+
 [[example]]
 name = "update_bench_readme"
 path = "examples/update_bench_readme.rs"

--- a/kofft-bench/benches/bench_ndfft.rs
+++ b/kofft-bench/benches/bench_ndfft.rs
@@ -1,0 +1,40 @@
+use criterion::{criterion_group, criterion_main, Criterion};
+use kofft::fft::{Complex32, FftPlanner, ScalarFftImpl};
+use kofft::ndfft::{fft2d_inplace, fft3d_inplace, Fft3dScratch};
+
+fn bench_fft2d(c: &mut Criterion) {
+    let rows = 128;
+    let cols = 128;
+    let planner = FftPlanner::new();
+    let fft = ScalarFftImpl::<f32>::with_planner(planner);
+    let mut data = vec![Complex32::zero(); rows * cols];
+    let mut scratch = vec![Complex32::zero(); rows * cols];
+    c.bench_function("fft2d", |b| {
+        b.iter(|| {
+            fft2d_inplace(&mut data, rows, cols, &fft, &mut scratch).unwrap();
+        });
+    });
+}
+
+fn bench_fft3d(c: &mut Criterion) {
+    let depth = 32;
+    let rows = 32;
+    let cols = 32;
+    let planner = FftPlanner::new();
+    let fft = ScalarFftImpl::<f32>::with_planner(planner);
+    let mut data = vec![Complex32::zero(); depth * rows * cols];
+    let mut plane = vec![Complex32::zero(); rows * cols];
+    let mut volume = vec![Complex32::zero(); depth * rows * cols];
+    let mut scratch = Fft3dScratch {
+        plane: &mut plane,
+        volume: &mut volume,
+    };
+    c.bench_function("fft3d", |b| {
+        b.iter(|| {
+            fft3d_inplace(&mut data, depth, rows, cols, &fft, &mut scratch).unwrap();
+        });
+    });
+}
+
+criterion_group!(benches, bench_fft2d, bench_fft3d);
+criterion_main!(benches);


### PR DESCRIPTION
## Summary
- introduce block-wise transpose helper and use it for 2D/3D in-place FFTs
- require scratch buffers for transpose operations and update ndfft example
- add criterion benchmark for 2D/3D transforms

## Testing
- `cargo test`
- `cargo bench --manifest-path kofft-bench/Cargo.toml --bench bench_ndfft`


------
https://chatgpt.com/codex/tasks/task_e_689e71668430832b9e8540e4aef48288