### PR TITLE
Use portable SIMD for window generation

### DIFF
--- a/kofft-bench/Cargo.toml
+++ b/kofft-bench/Cargo.toml
@@ -21,6 +21,10 @@ harness = false
 name = "bench_dct"
 harness = false
 
+[[bench]]
+name = "bench_window"
+harness = false
+
 [[example]]
 name = "update_bench_readme"
 path = "examples/update_bench_readme.rs"

--- a/kofft-bench/benches/bench_window.rs
+++ b/kofft-bench/benches/bench_window.rs
@@ -1,0 +1,69 @@
+use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
+use kofft::window;
+
+fn hann_scalar(len: usize) -> Vec<f32> {
+    (0..len)
+        .map(|i| 0.5 - 0.5 * (2.0 * std::f32::consts::PI * i as f32 / len as f32).cos())
+        .collect()
+}
+
+fn hamming_scalar(len: usize) -> Vec<f32> {
+    (0..len)
+        .map(|i| 0.54 - 0.46 * (2.0 * std::f32::consts::PI * i as f32 / len as f32).cos())
+        .collect()
+}
+
+fn blackman_scalar(len: usize) -> Vec<f32> {
+    (0..len)
+        .map(|i| {
+            let a0 = 0.42;
+            let a1 = 0.5;
+            let a2 = 0.08;
+            let x = i as f32 / len as f32;
+            a0 - a1 * (2.0 * std::f32::consts::PI * x).cos()
+                + a2 * (4.0 * std::f32::consts::PI * x).cos()
+        })
+        .collect()
+}
+
+fn bench_hann(c: &mut Criterion) {
+    let mut g = c.benchmark_group("hann");
+    for &size in &[256usize, 1024, 4096] {
+        g.bench_with_input(BenchmarkId::new("simd", size), &size, |b, &n| {
+            b.iter(|| window::hann(n));
+        });
+        g.bench_with_input(BenchmarkId::new("scalar", size), &size, |b, &n| {
+            b.iter(|| hann_scalar(n));
+        });
+    }
+    g.finish();
+}
+
+fn bench_hamming(c: &mut Criterion) {
+    let mut g = c.benchmark_group("hamming");
+    for &size in &[256usize, 1024, 4096] {
+        g.bench_with_input(BenchmarkId::new("simd", size), &size, |b, &n| {
+            b.iter(|| window::hamming(n));
+        });
+        g.bench_with_input(BenchmarkId::new("scalar", size), &size, |b, &n| {
+            b.iter(|| hamming_scalar(n));
+        });
+    }
+    g.finish();
+}
+
+fn bench_blackman(c: &mut Criterion) {
+    let mut g = c.benchmark_group("blackman");
+    for &size in &[256usize, 1024, 4096] {
+        g.bench_with_input(BenchmarkId::new("simd", size), &size, |b, &n| {
+            b.iter(|| window::blackman(n));
+        });
+        g.bench_with_input(BenchmarkId::new("scalar", size), &size, |b, &n| {
+            b.iter(|| blackman_scalar(n));
+        });
+    }
+    g.finish();
+}
+
+criterion_group!(benches, bench_hann, bench_hamming, bench_blackman);
+criterion_main!(benches);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -63,6 +63,7 @@
 //!
 //! at your option.
 
+#![feature(portable_simd)]
 #![no_std]
 extern crate alloc;
 #[cfg(feature = "std")]

--- a/src/window.rs
+++ b/src/window.rs
@@ -1,11 +1,14 @@
 //! Common window functions for STFT and DSP
 
 use core::f32::consts::PI;
+use core::simd::{LaneCount, Simd, SupportedLaneCount};
 
 use libm::sqrtf;
 
 #[cfg(not(feature = "std"))]
 use libm::{cosf, fabsf, floorf, log10f, logf, powf, sinf};
+
+const LANES: usize = 8;
 
 #[allow(unused_imports)]
 use crate::fft::Float;
@@ -24,31 +27,112 @@ fn bessel0(x: f32) -> f32 {
     sum
 }
 
+#[inline]
+fn cos_simd<const N: usize>(x: Simd<f32, N>) -> Simd<f32, N>
+where
+    LaneCount<N>: SupportedLaneCount,
+{
+    #[cfg(feature = "std")]
+    {
+        use std::simd::StdFloat;
+        x.cos()
+    }
+    #[cfg(not(feature = "std"))]
+    {
+        let arr = x.to_array();
+        let mut out = [0.0f32; N];
+        let mut i = 0;
+        while i < N {
+            out[i] = cosf(arr[i]);
+            i += 1;
+        }
+        Simd::from_array(out)
+    }
+}
+
 /// Generate a Hann window of length `len`.
 pub fn hann(len: usize) -> alloc::vec::Vec<f32> {
-    (0..len)
-        .map(|i| 0.5 - 0.5 * (2.0 * PI * i as f32 / len as f32).cos())
-        .collect()
+    let mut out = alloc::vec![0.0f32; len];
+    hann_simd(&mut out);
+    out
+}
+
+fn hann_simd(out: &mut [f32]) {
+    let n = out.len();
+    let step = Simd::<f32, LANES>::splat(2.0 * PI / n as f32);
+    let mut idx = Simd::<f32, LANES>::from_array(core::array::from_fn(|i| i as f32));
+    let mut i = 0;
+    while i + LANES <= n {
+        let angle = step * idx;
+        let cos_val = cos_simd(angle);
+        let vals = Simd::<f32, LANES>::splat(0.5) - Simd::<f32, LANES>::splat(0.5) * cos_val;
+        out[i..i + LANES].copy_from_slice(vals.as_array());
+        i += LANES;
+        idx += Simd::<f32, LANES>::splat(LANES as f32);
+    }
+    while i < n {
+        out[i] = 0.5 - 0.5 * (2.0 * PI * i as f32 / n as f32).cos();
+        i += 1;
+    }
 }
 
 /// Generate a Hamming window of length `len`.
 pub fn hamming(len: usize) -> alloc::vec::Vec<f32> {
-    (0..len)
-        .map(|i| 0.54 - 0.46 * (2.0 * PI * i as f32 / len as f32).cos())
-        .collect()
+    let mut out = alloc::vec![0.0f32; len];
+    hamming_simd(&mut out);
+    out
+}
+
+fn hamming_simd(out: &mut [f32]) {
+    let n = out.len();
+    let step = Simd::<f32, LANES>::splat(2.0 * PI / n as f32);
+    let mut idx = Simd::<f32, LANES>::from_array(core::array::from_fn(|i| i as f32));
+    let mut i = 0;
+    while i + LANES <= n {
+        let angle = step * idx;
+        let cos_val = cos_simd(angle);
+        let vals = Simd::<f32, LANES>::splat(0.54) - Simd::<f32, LANES>::splat(0.46) * cos_val;
+        out[i..i + LANES].copy_from_slice(vals.as_array());
+        i += LANES;
+        idx += Simd::<f32, LANES>::splat(LANES as f32);
+    }
+    while i < n {
+        out[i] = 0.54 - 0.46 * (2.0 * PI * i as f32 / n as f32).cos();
+        i += 1;
+    }
 }
 
 /// Generate a Blackman window of length `len`.
 pub fn blackman(len: usize) -> alloc::vec::Vec<f32> {
-    (0..len)
-        .map(|i| {
-            let a0 = 0.42;
-            let a1 = 0.5;
-            let a2 = 0.08;
-            let x = i as f32 / len as f32;
-            a0 - a1 * (2.0 * PI * x).cos() + a2 * (4.0 * PI * x).cos()
-        })
-        .collect()
+    let mut out = alloc::vec![0.0f32; len];
+    blackman_simd(&mut out);
+    out
+}
+
+fn blackman_simd(out: &mut [f32]) {
+    let n = out.len();
+    let step = Simd::<f32, LANES>::splat(1.0 / n as f32);
+    let mut idx = Simd::<f32, LANES>::from_array(core::array::from_fn(|i| i as f32));
+    let mut i = 0;
+    let two_pi = Simd::<f32, LANES>::splat(2.0 * PI);
+    let four_pi = Simd::<f32, LANES>::splat(4.0 * PI);
+    let a0 = Simd::<f32, LANES>::splat(0.42);
+    let a1 = Simd::<f32, LANES>::splat(0.5);
+    let a2 = Simd::<f32, LANES>::splat(0.08);
+    while i + LANES <= n {
+        let x = idx * step;
+        let term1 = cos_simd(two_pi * x);
+        let term2 = cos_simd(four_pi * x);
+        let vals = a0 - a1 * term1 + a2 * term2;
+        out[i..i + LANES].copy_from_slice(vals.as_array());
+        i += LANES;
+        idx += Simd::<f32, LANES>::splat(LANES as f32);
+    }
+    while i < n {
+        let x = i as f32 / n as f32;
+        out[i] = 0.42 - 0.5 * (2.0 * PI * x).cos() + 0.08 * (4.0 * PI * x).cos();
+        i += 1;
+    }
 }
 
 /// Generate a Kaiser window of length `len` and shape parameter `beta`.
@@ -78,27 +162,17 @@ pub fn kaiser(len: usize, beta: f32) -> alloc::vec::Vec<f32> {
 
 /// MCU/stack-only, const-generic, in-place Hann window (no heap)
 pub fn hann_inplace_stack<const N: usize>(out: &mut [f32; N]) {
-    for (i, x) in out.iter_mut().enumerate() {
-        *x = 0.5 - 0.5 * (2.0 * PI * i as f32 / N as f32).cos();
-    }
+    hann_simd(out);
 }
 
 /// MCU/stack-only, const-generic, in-place Hamming window (no heap)
 pub fn hamming_inplace_stack<const N: usize>(out: &mut [f32; N]) {
-    for (i, x) in out.iter_mut().enumerate() {
-        *x = 0.54 - 0.46 * (2.0 * PI * i as f32 / N as f32).cos();
-    }
+    hamming_simd(out);
 }
 
 /// MCU/stack-only, const-generic, in-place Blackman window (no heap)
 pub fn blackman_inplace_stack<const N: usize>(out: &mut [f32; N]) {
-    let a0 = 0.42;
-    let a1 = 0.5;
-    let a2 = 0.08;
-    for (i, out_val) in out.iter_mut().enumerate() {
-        let x = i as f32 / N as f32;
-        *out_val = a0 - a1 * (2.0 * PI * x).cos() + a2 * (4.0 * PI * x).cos();
-    }
+    blackman_simd(out);
 }
 
 #[cfg(all(feature = "internal-tests", test))]


### PR DESCRIPTION
## Summary
- vectorize Hann, Hamming and Blackman window generation with `core::simd`
- apply SIMD to stack-based window variants
- add Criterion benchmark comparing SIMD and scalar window implementations

## Testing
- `RUSTC_BOOTSTRAP=1 cargo test -q`
- `target/release/deps/bench_window-fbe48219bdc2e8e6 --bench hamming --sample-size 20 --measurement-time 1`
- `target/release/deps/bench_window-fbe48219bdc2e8e6 --bench blackman --sample-size 20 --measurement-time 1`
- `target/release/deps/bench_window-fbe48219bdc2e8e6 --bench`


------
https://chatgpt.com/codex/tasks/task_e_689e71648240832bab986ff9f3bb14d2