### PR TITLE
Add AVX2/AVX512 FFT kernels with runtime detection

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,6 +39,8 @@ x86_64 = []
 sse = []
 aarch64 = []
 wasm = []
+avx2 = []
+avx512 = []
 slow = []
 internal-tests = ["proptest", "rand"]
 

--- a/kofft-bench/Cargo.toml
+++ b/kofft-bench/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-kofft = { path = "..", features = ["parallel", "slow"] }
+kofft = { path = "..", features = ["parallel", "slow", "avx2"] }
 criterion = { version = "0.7", features = ["html_reports"] }
 rustfft = "6"
 realfft = "3"

--- a/src/fft.rs
+++ b/src/fft.rs
@@ -989,41 +989,40 @@ impl ScalarFftImpl<f32> {
 // SIMD FFT implementations (feature-gated)
 
 // x86_64 SIMD implementations
-#[cfg(all(
-    target_arch = "x86_64",
-    any(
-        feature = "x86_64",
-        feature = "sse",
-        target_feature = "avx2",
-        target_feature = "sse2"
-    )
-))]
+#[cfg(target_arch = "x86_64")]
 use core::arch::x86_64::*;
 
-// x86_64 AVX2/FMA
-#[cfg(all(
-    target_arch = "x86_64",
-    any(feature = "x86_64", target_feature = "avx2")
-))]
+#[cfg(target_arch = "x86_64")]
 #[derive(Default)]
 pub struct SimdFftX86_64Impl;
-#[cfg(all(
-    target_arch = "x86_64",
-    any(feature = "x86_64", target_feature = "avx2")
-))]
+
+#[cfg(target_arch = "x86_64")]
 impl FftImpl<f32> for SimdFftX86_64Impl {
     fn fft(&self, input: &mut [Complex32]) -> Result<(), FftError> {
+        #[cfg(all(target_arch = "x86_64", feature = "std"))]
+        {
+            #[cfg(any(feature = "avx512", target_feature = "avx512f"))]
+            if std::arch::is_x86_feature_detected!("avx512f") {
+                unsafe { return fft_avx512(input); }
+            }
+            if std::arch::is_x86_feature_detected!("avx2")
+                && std::arch::is_x86_feature_detected!("fma")
+            {
+                unsafe { return fft_avx2(input); }
+            }
+        }
+
+        // Fallback to SSE2 implementation
         let n = input.len();
         if n <= 1 {
             return Ok(());
         }
-        // SIMD-accelerated bit-reversal permutation for n >= 8
-        let aligned = (input.as_ptr() as usize) % 32 == 0;
-        if n >= 8 {
+        let aligned = (input.as_ptr() as usize) % 16 == 0;
+        if n >= 4 {
             unsafe {
                 let mut j = 0;
                 let mut i = 1;
-                while i + 7 < n {
+                while i + 3 < n {
                     let mut bit = n >> 1;
                     while j & bit != 0 {
                         j ^= bit;
@@ -1034,26 +1033,26 @@ impl FftImpl<f32> for SimdFftX86_64Impl {
                         let ptr_i = input.as_mut_ptr().add(i);
                         let ptr_j = input.as_mut_ptr().add(j);
                         if aligned {
-                            let re_i = _mm256_load_ps(ptr_i as *const f32);
-                            let im_i = _mm256_load_ps(ptr_i.add(1) as *const f32);
-                            let re_j = _mm256_load_ps(ptr_j as *const f32);
-                            let im_j = _mm256_load_ps(ptr_j.add(1) as *const f32);
-                            _mm256_store_ps(ptr_i as *mut f32, re_j);
-                            _mm256_store_ps(ptr_i.add(1) as *mut f32, im_j);
-                            _mm256_store_ps(ptr_j as *mut f32, re_i);
-                            _mm256_store_ps(ptr_j.add(1) as *mut f32, im_i);
+                            let re_i = _mm_load_ps(ptr_i as *const f32);
+                            let im_i = _mm_load_ps(ptr_i.add(1) as *const f32);
+                            let re_j = _mm_load_ps(ptr_j as *const f32);
+                            let im_j = _mm_load_ps(ptr_j.add(1) as *const f32);
+                            _mm_store_ps(ptr_i as *mut f32, re_j);
+                            _mm_store_ps(ptr_i.add(1) as *mut f32, im_j);
+                            _mm_store_ps(ptr_j as *mut f32, re_i);
+                            _mm_store_ps(ptr_j.add(1) as *mut f32, im_i);
                         } else {
-                            let re_i = _mm256_loadu_ps(ptr_i as *const f32);
-                            let im_i = _mm256_loadu_ps(ptr_i.add(1) as *const f32);
-                            let re_j = _mm256_loadu_ps(ptr_j as *const f32);
-                            let im_j = _mm256_loadu_ps(ptr_j.add(1) as *const f32);
-                            _mm256_storeu_ps(ptr_i as *mut f32, re_j);
-                            _mm256_storeu_ps(ptr_i.add(1) as *mut f32, im_j);
-                            _mm256_storeu_ps(ptr_j as *mut f32, re_i);
-                            _mm256_storeu_ps(ptr_j.add(1) as *mut f32, im_i);
+                            let re_i = _mm_loadu_ps(ptr_i as *const f32);
+                            let im_i = _mm_loadu_ps(ptr_i.add(1) as *const f32);
+                            let re_j = _mm_loadu_ps(ptr_j as *const f32);
+                            let im_j = _mm_loadu_ps(ptr_j.add(1) as *const f32);
+                            _mm_storeu_ps(ptr_i as *mut f32, re_j);
+                            _mm_storeu_ps(ptr_i.add(1) as *mut f32, im_j);
+                            _mm_storeu_ps(ptr_j as *mut f32, re_i);
+                            _mm_storeu_ps(ptr_j.add(1) as *mut f32, im_i);
                         }
                     }
-                    i += 8;
+                    i += 4;
                 }
                 for k in i..n {
                     let mut bit = n >> 1;
@@ -1067,22 +1066,8 @@ impl FftImpl<f32> for SimdFftX86_64Impl {
                     }
                 }
             }
-        } else {
-            // Scalar bit-reversal
-            let mut j = 0;
-            for i in 1..n {
-                let mut bit = n >> 1;
-                while j & bit != 0 {
-                    j ^= bit;
-                    bit >>= 1;
-                }
-                j ^= bit;
-                if i < j {
-                    input.swap(i, j);
-                }
-            }
         }
-        // Only use SIMD for lengths that are multiples of 4
+
         if n % 4 != 0 {
             let scalar = ScalarFftImpl::<f32>::default();
             scalar.fft(input)?;
@@ -1235,6 +1220,322 @@ impl FftImpl<f32> for SimdFftX86_64Impl {
         let scalar = ScalarFftImpl::<f32>::default();
         scalar.fft_with_strategy(input, strategy)
     }
+}
+
+#[cfg(target_arch = "x86_64")]
+#[target_feature(enable = "avx2,fma")]
+unsafe fn fft_avx2(input: &mut [Complex32]) -> Result<(), FftError> {
+    let n = input.len();
+    if n <= 1 {
+        return Ok(());
+    }
+    let aligned = (input.as_ptr() as usize) % 32 == 0;
+    if n >= 8 {
+        let mut j = 0;
+        let mut i = 1;
+        while i + 7 < n {
+            let mut bit = n >> 1;
+            while j & bit != 0 {
+                j ^= bit;
+                bit >>= 1;
+            }
+            j ^= bit;
+            if i < j {
+                let ptr_i = input.as_mut_ptr().add(i);
+                let ptr_j = input.as_mut_ptr().add(j);
+                if aligned {
+                    let re_i = _mm256_load_ps(ptr_i as *const f32);
+                    let im_i = _mm256_load_ps(ptr_i.add(1) as *const f32);
+                    let re_j = _mm256_load_ps(ptr_j as *const f32);
+                    let im_j = _mm256_load_ps(ptr_j.add(1) as *const f32);
+                    _mm256_store_ps(ptr_i as *mut f32, re_j);
+                    _mm256_store_ps(ptr_i.add(1) as *mut f32, im_j);
+                    _mm256_store_ps(ptr_j as *mut f32, re_i);
+                    _mm256_store_ps(ptr_j.add(1) as *mut f32, im_i);
+                } else {
+                    let re_i = _mm256_loadu_ps(ptr_i as *const f32);
+                    let im_i = _mm256_loadu_ps(ptr_i.add(1) as *const f32);
+                    let re_j = _mm256_loadu_ps(ptr_j as *const f32);
+                    let im_j = _mm256_loadu_ps(ptr_j.add(1) as *const f32);
+                    _mm256_storeu_ps(ptr_i as *mut f32, re_j);
+                    _mm256_storeu_ps(ptr_i.add(1) as *mut f32, im_j);
+                    _mm256_storeu_ps(ptr_j as *mut f32, re_i);
+                    _mm256_storeu_ps(ptr_j.add(1) as *mut f32, im_i);
+                }
+            }
+            i += 8;
+        }
+        for k in i..n {
+            let mut bit = n >> 1;
+            while j & bit != 0 {
+                j ^= bit;
+                bit >>= 1;
+            }
+            j ^= bit;
+            if k < j {
+                input.swap(k, j);
+            }
+        }
+    } else {
+        let mut j = 0;
+        for i in 1..n {
+            let mut bit = n >> 1;
+            while j & bit != 0 {
+                j ^= bit;
+                bit >>= 1;
+            }
+            j ^= bit;
+            if i < j {
+                input.swap(i, j);
+            }
+        }
+    }
+    if n % 8 != 0 {
+        let scalar = ScalarFftImpl::<f32>::default();
+        scalar.fft(input)?;
+        return Ok(());
+    }
+    let mut len = 2;
+    while len <= n {
+        let ang = -2.0 * PI / (len as f32);
+        let wlen = Complex32::expi(ang);
+        let mut i = 0;
+        while i < n {
+            let mut w = Complex32::new(1.0, 0.0);
+            let half = len / 2;
+            let simd_width = 8;
+            let simd_iters = half / simd_width;
+            for s in 0..simd_iters {
+                let j = s * simd_width;
+                let mut w_re = [0.0f32; 8];
+                let mut w_im = [0.0f32; 8];
+                let mut wj = w;
+                for k in 0..simd_width {
+                    w_re[k] = wj.re;
+                    w_im[k] = wj.im;
+                    wj = wj.mul(wlen);
+                }
+                let w_re_v = if aligned {
+                    _mm256_load_ps(w_re.as_ptr())
+                } else {
+                    _mm256_loadu_ps(w_re.as_ptr())
+                };
+                let w_im_v = if aligned {
+                    _mm256_load_ps(w_im.as_ptr())
+                } else {
+                    _mm256_loadu_ps(w_im.as_ptr())
+                };
+                let u_re = if aligned {
+                    _mm256_load_ps(&input[i + j].re as *const f32)
+                } else {
+                    _mm256_loadu_ps(&input[i + j].re as *const f32)
+                };
+                let u_im = if aligned {
+                    _mm256_load_ps(&input[i + j].im as *const f32)
+                } else {
+                    _mm256_loadu_ps(&input[i + j].im as *const f32)
+                };
+                let v_re = if aligned {
+                    _mm256_load_ps(&input[i + j + half].re as *const f32)
+                } else {
+                    _mm256_loadu_ps(&input[i + j + half].re as *const f32)
+                };
+                let v_im = if aligned {
+                    _mm256_load_ps(&input[i + j + half].im as *const f32)
+                } else {
+                    _mm256_loadu_ps(&input[i + j + half].im as *const f32)
+                };
+                let vw_re = _mm256_fmsub_ps(v_re, w_re_v, _mm256_mul_ps(v_im, w_im_v));
+                let vw_im = _mm256_fmadd_ps(v_re, w_im_v, _mm256_mul_ps(v_im, w_re_v));
+                let out_re = _mm256_add_ps(u_re, vw_re);
+                let out_im = _mm256_add_ps(u_im, vw_im);
+                let out2_re = _mm256_sub_ps(u_re, vw_re);
+                let out2_im = _mm256_sub_ps(u_im, vw_im);
+                if aligned {
+                    _mm256_store_ps(&mut input[i + j].re as *mut f32, out_re);
+                    _mm256_store_ps(&mut input[i + j].im as *mut f32, out_im);
+                    _mm256_store_ps(&mut input[i + j + half].re as *mut f32, out2_re);
+                    _mm256_store_ps(&mut input[i + j + half].im as *mut f32, out2_im);
+                } else {
+                    _mm256_storeu_ps(&mut input[i + j].re as *mut f32, out_re);
+                    _mm256_storeu_ps(&mut input[i + j].im as *mut f32, out_im);
+                    _mm256_storeu_ps(&mut input[i + j + half].re as *mut f32, out2_re);
+                    _mm256_storeu_ps(&mut input[i + j + half].im as *mut f32, out2_im);
+                }
+                for _ in 0..simd_width {
+                    w = w.mul(wlen);
+                }
+            }
+            for j in (simd_iters * simd_width)..half {
+                let u = input[i + j];
+                let v = input[i + j + half].mul(w);
+                input[i + j] = u.add(v);
+                input[i + j + half] = u.sub(v);
+                w = w.mul(wlen);
+            }
+            i += len;
+        }
+        len <<= 1;
+    }
+    Ok(())
+}
+
+#[cfg(all(target_arch = "x86_64", any(feature = "avx512", target_feature = "avx512f")))]
+#[target_feature(enable = "avx512f")]
+unsafe fn fft_avx512(input: &mut [Complex32]) -> Result<(), FftError> {
+    let n = input.len();
+    if n <= 1 {
+        return Ok(());
+    }
+    let aligned = (input.as_ptr() as usize) % 64 == 0;
+    if n >= 16 {
+        let mut j = 0;
+        let mut i = 1;
+        while i + 15 < n {
+            let mut bit = n >> 1;
+            while j & bit != 0 {
+                j ^= bit;
+                bit >>= 1;
+            }
+            j ^= bit;
+            if i < j {
+                let ptr_i = input.as_mut_ptr().add(i);
+                let ptr_j = input.as_mut_ptr().add(j);
+                if aligned {
+                    let re_i = _mm512_load_ps(ptr_i as *const f32);
+                    let im_i = _mm512_load_ps(ptr_i.add(1) as *const f32);
+                    let re_j = _mm512_load_ps(ptr_j as *const f32);
+                    let im_j = _mm512_load_ps(ptr_j.add(1) as *const f32);
+                    _mm512_store_ps(ptr_i as *mut f32, re_j);
+                    _mm512_store_ps(ptr_i.add(1) as *mut f32, im_j);
+                    _mm512_store_ps(ptr_j as *mut f32, re_i);
+                    _mm512_store_ps(ptr_j.add(1) as *mut f32, im_i);
+                } else {
+                    let re_i = _mm512_loadu_ps(ptr_i as *const f32);
+                    let im_i = _mm512_loadu_ps(ptr_i.add(1) as *const f32);
+                    let re_j = _mm512_loadu_ps(ptr_j as *const f32);
+                    let im_j = _mm512_loadu_ps(ptr_j.add(1) as *const f32);
+                    _mm512_storeu_ps(ptr_i as *mut f32, re_j);
+                    _mm512_storeu_ps(ptr_i.add(1) as *mut f32, im_j);
+                    _mm512_storeu_ps(ptr_j as *mut f32, re_i);
+                    _mm512_storeu_ps(ptr_j.add(1) as *mut f32, im_i);
+                }
+            }
+            i += 16;
+        }
+        for k in i..n {
+            let mut bit = n >> 1;
+            while j & bit != 0 {
+                j ^= bit;
+                bit >>= 1;
+            }
+            j ^= bit;
+            if k < j {
+                input.swap(k, j);
+            }
+        }
+    } else {
+        let mut j = 0;
+        for i in 1..n {
+            let mut bit = n >> 1;
+            while j & bit != 0 {
+                j ^= bit;
+                bit >>= 1;
+            }
+            j ^= bit;
+            if i < j {
+                input.swap(i, j);
+            }
+        }
+    }
+    if n % 16 != 0 {
+        let scalar = ScalarFftImpl::<f32>::default();
+        scalar.fft(input)?;
+        return Ok(());
+    }
+    let mut len = 2;
+    while len <= n {
+        let ang = -2.0 * PI / (len as f32);
+        let wlen = Complex32::expi(ang);
+        let mut i = 0;
+        while i < n {
+            let mut w = Complex32::new(1.0, 0.0);
+            let half = len / 2;
+            let simd_width = 16;
+            let simd_iters = half / simd_width;
+            for s in 0..simd_iters {
+                let j = s * simd_width;
+                let mut w_re = [0.0f32; 16];
+                let mut w_im = [0.0f32; 16];
+                let mut wj = w;
+                for k in 0..simd_width {
+                    w_re[k] = wj.re;
+                    w_im[k] = wj.im;
+                    wj = wj.mul(wlen);
+                }
+                let w_re_v = if aligned {
+                    _mm512_load_ps(w_re.as_ptr())
+                } else {
+                    _mm512_loadu_ps(w_re.as_ptr())
+                };
+                let w_im_v = if aligned {
+                    _mm512_load_ps(w_im.as_ptr())
+                } else {
+                    _mm512_loadu_ps(w_im.as_ptr())
+                };
+                let u_re = if aligned {
+                    _mm512_load_ps(&input[i + j].re as *const f32)
+                } else {
+                    _mm512_loadu_ps(&input[i + j].re as *const f32)
+                };
+                let u_im = if aligned {
+                    _mm512_load_ps(&input[i + j].im as *const f32)
+                } else {
+                    _mm512_loadu_ps(&input[i + j].im as *const f32)
+                };
+                let v_re = if aligned {
+                    _mm512_load_ps(&input[i + j + half].re as *const f32)
+                } else {
+                    _mm512_loadu_ps(&input[i + j + half].re as *const f32)
+                };
+                let v_im = if aligned {
+                    _mm512_load_ps(&input[i + j + half].im as *const f32)
+                } else {
+                    _mm512_loadu_ps(&input[i + j + half].im as *const f32)
+                };
+                let vw_re = _mm512_fmsub_ps(v_re, w_re_v, _mm512_mul_ps(v_im, w_im_v));
+                let vw_im = _mm512_fmadd_ps(v_re, w_im_v, _mm512_mul_ps(v_im, w_re_v));
+                let out_re = _mm512_add_ps(u_re, vw_re);
+                let out_im = _mm512_add_ps(u_im, vw_im);
+                let out2_re = _mm512_sub_ps(u_re, vw_re);
+                let out2_im = _mm512_sub_ps(u_im, vw_im);
+                if aligned {
+                    _mm512_store_ps(&mut input[i + j].re as *mut f32, out_re);
+                    _mm512_store_ps(&mut input[i + j].im as *mut f32, out_im);
+                    _mm512_store_ps(&mut input[i + j + half].re as *mut f32, out2_re);
+                    _mm512_store_ps(&mut input[i + j + half].im as *mut f32, out2_im);
+                } else {
+                    _mm512_storeu_ps(&mut input[i + j].re as *mut f32, out_re);
+                    _mm512_storeu_ps(&mut input[i + j].im as *mut f32, out_im);
+                    _mm512_storeu_ps(&mut input[i + j + half].re as *mut f32, out2_re);
+                    _mm512_storeu_ps(&mut input[i + j + half].im as *mut f32, out2_im);
+                }
+                for _ in 0..simd_width {
+                    w = w.mul(wlen);
+                }
+            }
+            for j in (simd_iters * simd_width)..half {
+                let u = input[i + j];
+                let v = input[i + j + half].mul(w);
+                input[i + j] = u.add(v);
+                input[i + j + half] = u.sub(v);
+                w = w.mul(wlen);
+            }
+            i += len;
+        }
+        len <<= 1;
+    }
+    Ok(())
 }
 
 // x86_64 SSE SIMD implementation
@@ -1871,53 +2172,30 @@ impl FftImpl<f32> for SimdFftWasmImpl {
 
 /// Returns the best available FFT implementation for the current platform and enabled features.
 pub fn new_fft_impl() -> Box<dyn FftImpl<f32>> {
-    #[cfg(all(
-        target_arch = "x86_64",
-        any(feature = "x86_64", target_feature = "avx2")
-    ))]
+    #[cfg(all(target_arch = "x86_64", feature = "std"))]
     {
-        Box::new(SimdFftX86_64Impl)
+        #[cfg(any(feature = "avx512", target_feature = "avx512f"))]
+        if std::arch::is_x86_feature_detected!("avx512f") {
+            return Box::new(SimdFftX86_64Impl);
+        }
+        if std::arch::is_x86_feature_detected!("avx2")
+            && std::arch::is_x86_feature_detected!("fma")
+        {
+            return Box::new(SimdFftX86_64Impl);
+        }
+        if std::arch::is_x86_feature_detected!("sse2") {
+            return Box::new(SimdFftSseImpl);
+        }
     }
-    #[cfg(all(
-        target_arch = "x86_64",
-        any(feature = "sse", target_feature = "sse2"),
-        not(any(feature = "x86_64", target_feature = "avx2"))
-    ))]
+    #[cfg(target_arch = "aarch64")]
     {
-        Box::new(SimdFftSseImpl)
+        return Box::new(SimdFftAArch64Impl);
     }
-    #[cfg(all(
-        target_arch = "aarch64",
-        any(feature = "aarch64", target_feature = "neon")
-    ))]
+    #[cfg(target_arch = "wasm32")]
     {
-        Box::new(SimdFftAArch64Impl)
+        return Box::new(SimdFftWasmImpl);
     }
-    #[cfg(all(
-        target_arch = "wasm32",
-        any(feature = "wasm", target_feature = "simd128")
-    ))]
-    {
-        Box::new(SimdFftWasmImpl)
-    }
-    #[cfg(not(any(
-        all(
-            target_arch = "x86_64",
-            any(feature = "x86_64", target_feature = "avx2")
-        ),
-        all(target_arch = "x86_64", any(feature = "sse", target_feature = "sse2")),
-        all(
-            target_arch = "aarch64",
-            any(feature = "aarch64", target_feature = "neon")
-        ),
-        all(
-            target_arch = "wasm32",
-            any(feature = "wasm", target_feature = "simd128")
-        )
-    )))]
-    {
-        Box::new(ScalarFftImpl::<f32>::default())
-    }
+    Box::new(ScalarFftImpl::<f32>::default())
 }
 
 /// Plan-based FFT: precompute twiddles and bit-reversal for repeated transforms.


### PR DESCRIPTION
## Summary
- add AVX2 and optional AVX512 FFT kernels using fused multiply-add
- detect CPU features at runtime to select the widest SIMD implementation
- expose new `avx2`/`avx512` cargo features and hook benchmarks to use AVX2

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_689e715b92cc832b90f284c27d687f0a