### PR TITLE
Implement half-size real FFT with shared twiddles and add parity benchmarks

### DIFF
--- a/kofft-bench/Cargo.toml
+++ b/kofft-bench/Cargo.toml
@@ -25,6 +25,10 @@ harness = false
 name = "aos_vs_soa"
 harness = false
 
+[[bench]]
+name = "bench_rfft"
+harness = false
+
 [[example]]
 name = "update_bench_readme"
 path = "examples/update_bench_readme.rs"

--- a/kofft-bench/benches/bench_rfft.rs
+++ b/kofft-bench/benches/bench_rfft.rs
@@ -1,0 +1,35 @@
+use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
+use kofft::fft::{Complex32, FftPlanner, ScalarFftImpl};
+use kofft::rfft::RealFftImpl;
+use realfft::RealFftPlanner as RustRealFftPlanner;
+
+fn bench_rfft(c: &mut Criterion) {
+    let mut group = c.benchmark_group("rfft_parity");
+    for &size in &[1024usize, 2048, 4096] {
+        let mut input: Vec<f32> = (0..size).map(|i| i as f32).collect();
+        let mut output = vec![Complex32::new(0.0, 0.0); size / 2 + 1];
+        let mut scratch = vec![Complex32::new(0.0, 0.0); size / 2];
+        let planner = FftPlanner::<f32>::new();
+        let fft = ScalarFftImpl::with_planner(planner);
+        group.bench_function(BenchmarkId::new("kofft", size), |b| {
+            b.iter(|| {
+                fft.rfft_with_scratch(&mut input, &mut output, &mut scratch)
+                    .unwrap();
+            })
+        });
+
+        let mut planner = RustRealFftPlanner::<f32>::new();
+        let rfft = planner.plan_fft_forward(size);
+        let mut in_data = input.clone();
+        let mut out_data = rfft.make_output_vec();
+        group.bench_function(BenchmarkId::new("realfft", size), |b| {
+            b.iter(|| {
+                rfft.process(&mut in_data, &mut out_data).unwrap();
+            })
+        });
+    }
+    group.finish();
+}
+
+criterion_group!(benches, bench_rfft);
+criterion_main!(benches);


### PR DESCRIPTION
## Summary
- Rework `rfft_direct`/`irfft_direct` to compute real FFTs via half-size complex FFT plus post-processing, reusing planner twiddles
- Wire scratch buffers through planner and `RealFftImpl` trait
- Add Criterion benchmark comparing `kofft` real FFTs against `realfft`

## Testing
- `cargo test`
- `cargo bench --no-run -p kofft-bench`


------
https://chatgpt.com/codex/tasks/task_e_689e76caafbc832bbffdc336aa279e27