### PR TITLE
Add SoA ComplexVec support and FFT helpers

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,6 +45,8 @@ avx512 = []
 slow = []
 internal-tests = ["proptest", "rand"]
 compile-time-rfft = []
+simd = []
+soa = []
 
 [dependencies.rayon]
 version = "1.7"

--- a/src/fft.rs
+++ b/src/fft.rs
@@ -2388,6 +2388,22 @@ impl<T: Float> FftPlan<T> {
         }
         self.fft.ifft_split(re, im)
     }
+
+    #[cfg(any(feature = "simd", feature = "soa"))]
+    pub fn fft_complex_vec(&self, data: &mut crate::num::ComplexVec) -> Result<(), FftError> {
+        if data.len() != self.n {
+            return Err(FftError::MismatchedLengths);
+        }
+        self.fft.fft_split(&mut data.re, &mut data.im)
+    }
+
+    #[cfg(any(feature = "simd", feature = "soa"))]
+    pub fn ifft_complex_vec(&self, data: &mut crate::num::ComplexVec) -> Result<(), FftError> {
+        if data.len() != self.n {
+            return Err(FftError::MismatchedLengths);
+        }
+        self.fft.ifft_split(&mut data.re, &mut data.im)
+    }
 }
 
 /// Compute FFT using the default planner. When the `parallel` feature is
@@ -2410,6 +2426,16 @@ pub fn fft_split<T: Float>(re: &mut [T], im: &mut [T]) -> Result<(), FftError> {
 
 pub fn ifft_split<T: Float>(re: &mut [T], im: &mut [T]) -> Result<(), FftError> {
     ScalarFftImpl::<T>::default().ifft_split(re, im)
+}
+
+#[cfg(any(feature = "simd", feature = "soa"))]
+pub fn fft_complex_vec(data: &mut crate::num::ComplexVec) -> Result<(), FftError> {
+    ScalarFftImpl::<f32>::default().fft_split(&mut data.re, &mut data.im)
+}
+
+#[cfg(any(feature = "simd", feature = "soa"))]
+pub fn ifft_complex_vec(data: &mut crate::num::ComplexVec) -> Result<(), FftError> {
+    ScalarFftImpl::<f32>::default().ifft_split(&mut data.re, &mut data.im)
 }
 
 /// Batch FFT: process a batch of mutable slices in-place

--- a/src/num.rs
+++ b/src/num.rs
@@ -231,6 +231,55 @@ impl<T: Float> SplitComplex<T> {
 pub type SplitComplex32 = SplitComplex<f32>;
 pub type SplitComplex64 = SplitComplex<f64>;
 
+#[derive(Clone, Debug, PartialEq)]
+pub struct ComplexVec {
+    pub re: Vec<f32>,
+    pub im: Vec<f32>,
+}
+
+impl ComplexVec {
+    pub fn new(re: Vec<f32>, im: Vec<f32>) -> Self {
+        assert_eq!(re.len(), im.len());
+        Self { re, im }
+    }
+
+    pub fn len(&self) -> usize {
+        self.re.len()
+    }
+
+    pub fn from_complex_vec(v: &[Complex32]) -> Self {
+        let split = SplitComplex::<f32>::from_complex_vec(v);
+        Self { re: split.re, im: split.im }
+    }
+
+    pub fn to_complex_vec(&self) -> Vec<Complex32> {
+        let sc = SplitComplex { re: self.re.clone(), im: self.im.clone() };
+        sc.to_complex_vec()
+    }
+
+    pub fn as_slices(&self) -> (&[f32], &[f32]) {
+        (&self.re, &self.im)
+    }
+
+    pub fn as_mut_slices(&mut self) -> (&mut [f32], &mut [f32]) {
+        (&mut self.re, &mut self.im)
+    }
+}
+
+impl From<Vec<Complex32>> for ComplexVec {
+    fn from(v: Vec<Complex32>) -> Self {
+        let split = SplitComplex::<f32>::from_complex_vec(&v);
+        Self { re: split.re, im: split.im }
+    }
+}
+
+impl From<ComplexVec> for Vec<Complex32> {
+    fn from(cv: ComplexVec) -> Self {
+        let sc = SplitComplex { re: cv.re, im: cv.im };
+        sc.to_complex_vec()
+    }
+}
+
 pub fn copy_from_complex<T: Float>(input: &[Complex<T>], re: &mut [T], im: &mut [T]) {
     assert_eq!(input.len(), re.len());
     assert_eq!(input.len(), im.len());


### PR DESCRIPTION
## Summary
- add `ComplexVec` structure for split f32 real/imag vectors
- expose FFT helpers to operate on `ComplexVec` when `simd` or `soa` features are used
- wire up new `simd` and `soa` cargo features

## Testing
- `cargo test`
- `cargo bench -p kofft-bench --bench aos_vs_soa -- --quick`


------
https://chatgpt.com/codex/tasks/task_e_689e76cc1aec832b895cc4e927307116