### PR TITLE
Fix clippy warnings

### DIFF
--- a/src/num.rs
+++ b/src/num.rs
@@ -1,5 +1,5 @@
-use core::f32::consts::PI as PI32;
 use alloc::vec::Vec;
+use core::f32::consts::PI as PI32;
 
 // Minimal float trait for generic FFT (no_std, no external deps)
 pub trait Float:
@@ -210,6 +210,9 @@ impl<T: Float> SplitComplex<T> {
     pub fn len(&self) -> usize {
         self.re.len()
     }
+    pub fn is_empty(&self) -> bool {
+        self.re.is_empty()
+    }
     pub fn from_complex_vec(v: &[Complex<T>]) -> Self {
         let mut re = Vec::with_capacity(v.len());
         let mut im = Vec::with_capacity(v.len());
@@ -247,13 +250,23 @@ impl ComplexVec {
         self.re.len()
     }
 
+    pub fn is_empty(&self) -> bool {
+        self.re.is_empty()
+    }
+
     pub fn from_complex_vec(v: &[Complex32]) -> Self {
         let split = SplitComplex::<f32>::from_complex_vec(v);
-        Self { re: split.re, im: split.im }
+        Self {
+            re: split.re,
+            im: split.im,
+        }
     }
 
     pub fn to_complex_vec(&self) -> Vec<Complex32> {
-        let sc = SplitComplex { re: self.re.clone(), im: self.im.clone() };
+        let sc = SplitComplex {
+            re: self.re.clone(),
+            im: self.im.clone(),
+        };
         sc.to_complex_vec()
     }
 
@@ -269,13 +282,19 @@ impl ComplexVec {
 impl From<Vec<Complex32>> for ComplexVec {
     fn from(v: Vec<Complex32>) -> Self {
         let split = SplitComplex::<f32>::from_complex_vec(&v);
-        Self { re: split.re, im: split.im }
+        Self {
+            re: split.re,
+            im: split.im,
+        }
     }
 }
 
 impl From<ComplexVec> for Vec<Complex32> {
     fn from(cv: ComplexVec) -> Self {
-        let sc = SplitComplex { re: cv.re, im: cv.im };
+        let sc = SplitComplex {
+            re: cv.re,
+            im: cv.im,
+        };
         sc.to_complex_vec()
     }
 }

--- a/src/rfft.rs
+++ b/src/rfft.rs
@@ -16,8 +16,11 @@ use crate::num::Float;
 #[cfg(feature = "compile-time-rfft")]
 mod precomputed {
     use crate::fft::{Complex32, Complex64};
-    pub const F32: &[(usize, &'static [Complex32])] = &[];
-    pub const F64: &[(usize, &'static [Complex64])] = &[];
+    // Constants have an implicit `'static` lifetime, so specifying it is redundant.
+    // Remove the explicit `'static` to satisfy clippy's
+    // `redundant_static_lifetimes` lint.
+    pub const F32: &[(usize, &[Complex32])] = &[];
+    pub const F64: &[(usize, &[Complex64])] = &[];
 }
 
 fn build_twiddle_table<T: Float>(m: usize) -> alloc::vec::Vec<Complex<T>> {

--- a/tests/pow2.rs
+++ b/tests/pow2.rs
@@ -3,14 +3,14 @@ use kofft::fft::{Complex32, FftImpl, ScalarFftImpl};
 fn dft(input: &[Complex32]) -> Vec<Complex32> {
     let n = input.len();
     let mut output = vec![Complex32::zero(); n];
-    for k in 0..n {
+    for (k, out) in output.iter_mut().enumerate() {
         let mut sum = Complex32::zero();
         for (n_idx, x) in input.iter().enumerate() {
             let angle = -2.0 * core::f32::consts::PI * (k * n_idx) as f32 / n as f32;
             let tw = Complex32::new(angle.cos(), angle.sin());
             sum = sum.add(x.mul(tw));
         }
-        output[k] = sum;
+        *out = sum;
     }
     output
 }

--- a/tests/split.rs
+++ b/tests/split.rs
@@ -1,10 +1,10 @@
-use kofft::fft::{ScalarFftImpl, FftImpl};
 use kofft::fft::Complex32;
+use kofft::fft::{FftImpl, ScalarFftImpl};
 
 #[test]
 fn fft_split_matches_aos() {
     let n = 16;
-    let mut data: Vec<Complex32> = (0..n).map(|i| Complex32::new(i as f32, 0.0)).collect();
+    let data: Vec<Complex32> = (0..n).map(|i| Complex32::new(i as f32, 0.0)).collect();
     let mut re: Vec<f32> = data.iter().map(|c| c.re).collect();
     let mut im: Vec<f32> = data.iter().map(|c| c.im).collect();
 


### PR DESCRIPTION
## Summary
- remove redundant `'static` lifetimes in precomputed RFFT constants
- add `is_empty` helpers for `SplitComplex` and `ComplexVec`
- address clippy nits in FFT and test helpers

## Testing
- `cargo clippy --all-targets -- -D warnings`
- `cargo test` *(fails: fft_matches_dft_for_powers_of_two)*

------
https://chatgpt.com/codex/tasks/task_e_689e83995d24832b8802cb6b1c62d40f