### PR TITLE
Use in-place split radix FFT without scratch buffer

### DIFF
--- a/tests/small_kernels.rs
+++ b/tests/small_kernels.rs
@@ -1,4 +1,4 @@
-use kofft::fft::{Complex32, FftImpl, ScalarFftImpl};
+use kofft::fft::{Complex32, ScalarFftImpl};
 
 fn dft(input: &[Complex32]) -> Vec<Complex32> {
     let n = input.len();
@@ -23,8 +23,7 @@ fn split_radix_small_kernels() {
             .map(|i| Complex32::new(i as f32, -(i as f32) * 0.5))
             .collect();
         let expected = dft(&data);
-        let mut scratch = vec![Complex32::zero(); n];
-        fft.split_radix_fft(&mut data, &mut scratch).unwrap();
+        fft.split_radix_fft(&mut data).unwrap();
         for (a, b) in data.iter().zip(expected.iter()) {
             assert!((a.re - b.re).abs() < 1e-2);
             assert!((a.im - b.im).abs() < 1e-2);


### PR DESCRIPTION
## Summary
- Implement in-place split radix FFT using a precomputed bit-reversal table
- Remove temporary scratch buffer and alternating ping-pong copies
- Update tests to use new in-place API

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_689eeb59f6cc832babfd848bcc990bab