### PR TITLE
Use HashMap caches in FftPlanner

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,6 @@ libm = "0.2"
 proptest = { version = "1.4", optional = true }
 rand = { version = "0.8", optional = true }
 hashbrown = "0.14"
-once_cell = { version = "1.18", default-features = false, features = ["alloc"] }
 num_cpus = { version = "1.16", optional = true }
 
 [features]


### PR DESCRIPTION
## Summary
- replace length-indexed Vec caches in `FftPlanner` with `HashMap` keyed by transform size
- simplify twiddle, bit-reversal, and Bluestein cache accessors
- drop unused `once_cell` dependency

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_689ef593a270832bbc6a3284b5beb1bd