### PR TITLE
Add Makefile and FLAC spectrogram sanity check

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ exclude = [
 
 
 [workspace]
-members = ["kofft-bench"]
+members = ["kofft-bench", "sanity-check"]
 
 [dependencies]
 libm = "0.2"

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,49 @@
+# Simple Makefile for kofft development
+ARCH := $(shell uname -m)
+CPUFLAGS := $(shell lscpu | grep -i flags)
+NPROC := $(shell nproc)
+
+SIMD_FEATURES :=
+RUSTFLAGS_ADD :=
+
+ifeq ($(findstring x86_64,$(ARCH)),x86_64)
+  ifneq ($(findstring avx2,$(CPUFLAGS)),)
+    SIMD_FEATURES += avx2
+    RUSTFLAGS_ADD += -C target-feature=+avx2,+fma
+  else ifneq ($(findstring sse4_1,$(CPUFLAGS)),)
+    SIMD_FEATURES += sse
+  endif
+else ifeq ($(ARCH),aarch64)
+  SIMD_FEATURES += aarch64
+endif
+
+PAR_FEATURE :=
+EXAMPLE := benchmark
+ifneq ($(shell [ $(NPROC) -gt 1 ] && echo yes),)
+  PAR_FEATURE += parallel
+  EXAMPLE := parallel_benchmark
+endif
+
+FEATURES := $(strip $(SIMD_FEATURES) $(PAR_FEATURE))
+
+.PHONY: build test clippy fmt analyze benchmark sanity
+
+build:
+	cargo build $(if $(FEATURES),--features "$(FEATURES)")
+
+test:
+	cargo test $(if $(FEATURES),--features "$(FEATURES)")
+
+clippy:
+	cargo clippy --all-targets --all-features
+
+fmt:
+	cargo fmt --all
+
+analyze: fmt clippy
+
+benchmark:
+	RUSTFLAGS="$(RUSTFLAGS_ADD)" cargo run --example $(EXAMPLE) $(if $(FEATURES),--features "$(FEATURES)") --release
+
+sanity:
+	cargo run -p sanity-check -- $(FLAC)

--- a/sanity-check/Cargo.toml
+++ b/sanity-check/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "sanity-check"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+clap = { version = "4", features = ["derive"] }
+claxon = "0.4"
+image = { version = "0.24", default-features = false, features = ["png"] }
+rustfft = "6"
+num-complex = "0.4"
+kofft = { path = ".." }

--- a/sanity-check/src/main.rs
+++ b/sanity-check/src/main.rs
@@ -1,0 +1,106 @@
+use clap::Parser;
+use claxon::FlacReader;
+use image::{GrayImage, Luma};
+use kofft::fft::ScalarFftImpl;
+use kofft::stft::stft;
+use kofft::window::hann;
+use num_complex::Complex32;
+use rustfft::FftPlanner;
+use std::error::Error;
+use std::path::PathBuf;
+
+/// Compare kofft STFT with rustfft on a FLAC file and save heatmaps.
+#[derive(Parser)]
+struct Args {
+    /// Path to input FLAC file
+    input: PathBuf,
+}
+
+fn read_flac(path: &PathBuf) -> Result<Vec<f32>, Box<dyn Error>> {
+    let mut reader = FlacReader::open(path)?;
+    let mut samples = Vec::new();
+    for s in reader.samples() {
+        let v: i32 = s?;
+        samples.push(v as f32 / i32::MAX as f32);
+    }
+    Ok(samples)
+}
+
+fn main() -> Result<(), Box<dyn Error>> {
+    let args = Args::parse();
+    let samples = read_flac(&args.input)?;
+
+    let win_len = 1024usize;
+    let hop = win_len / 2;
+    let window = hann(win_len);
+    let frames = samples.len().saturating_sub(win_len) / hop + 1;
+
+    // kofft STFT
+    let mut kofft_frames = vec![vec![]; frames];
+    let fft = ScalarFftImpl::<f32>::default();
+    stft(&samples, &window, hop, &mut kofft_frames, &fft).unwrap();
+    let kofft_mag: Vec<Vec<f32>> = kofft_frames
+        .iter()
+        .map(|f| {
+            f.iter()
+                .map(|c| (c.re * c.re + c.im * c.im).sqrt())
+                .collect()
+        })
+        .collect();
+
+    // rustfft STFT
+    let mut planner = FftPlanner::<f32>::new();
+    let fft = planner.plan_fft_forward(win_len);
+    let mut rust_mag: Vec<Vec<f32>> = Vec::with_capacity(frames);
+    for frame in 0..frames {
+        let start = frame * hop;
+        let mut buffer: Vec<Complex32> = (0..win_len)
+            .map(|i| {
+                let x = if start + i < samples.len() {
+                    samples[start + i] * window[i]
+                } else {
+                    0.0
+                };
+                Complex32::new(x, 0.0)
+            })
+            .collect();
+        fft.process(&mut buffer);
+        rust_mag.push(buffer.iter().map(|c| c.norm()).collect());
+    }
+
+    // compute max difference
+    let mut max_diff = 0.0f32;
+    for (a, b) in kofft_mag.iter().zip(rust_mag.iter()) {
+        for (x, y) in a.iter().zip(b.iter()) {
+            let diff = (x - y).abs();
+            if diff > max_diff {
+                max_diff = diff;
+            }
+        }
+    }
+    println!("Max difference between spectrograms: {:.6}", max_diff);
+
+    // save heatmaps for visual inspection (use first half of spectrum)
+    let height = win_len / 2;
+    let width = frames;
+    let mut img_kofft = GrayImage::new(width as u32, height as u32);
+    let mut img_ref = GrayImage::new(width as u32, height as u32);
+    let max_val = kofft_mag
+        .iter()
+        .flat_map(|v| v.iter())
+        .chain(rust_mag.iter().flat_map(|v| v.iter()))
+        .cloned()
+        .fold(0.0f32, f32::max);
+    for (x, (kf, rf)) in kofft_mag.iter().zip(rust_mag.iter()).enumerate() {
+        for y in 0..height {
+            let v1 = (kf[y] / max_val * 255.0).min(255.0) as u8;
+            let v2 = (rf[y] / max_val * 255.0).min(255.0) as u8;
+            img_kofft.put_pixel(x as u32, y as u32, Luma([v1]));
+            img_ref.put_pixel(x as u32, y as u32, Luma([v2]));
+        }
+    }
+    img_kofft.save("kofft_spectrogram.png")?;
+    img_ref.save("reference_spectrogram.png")?;
+    println!("Saved kofft_spectrogram.png and reference_spectrogram.png");
+    Ok(())
+}


### PR DESCRIPTION
## Summary
- Add development Makefile with build, test, clippy, fmt, benchmark, and sanity targets that auto-detect CPU SIMD and parallel capabilities
- Introduce `sanity-check` binary to compare kofft-generated spectrograms with rustfft as a correctness check
- Register the new crate in the workspace

## Testing
- `cargo test`
- `make build`


------
https://chatgpt.com/codex/tasks/task_e_689ef876eb24832bb023262ab34584ae