### PR TITLE
Add comparison benchmark Makefile target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ endif
 
 FEATURES := $(strip $(SIMD_FEATURES) $(PAR_FEATURE))
 
-.PHONY: build test clippy fmt analyze benchmark sanity
+.PHONY: build test clippy fmt analyze benchmark bench-libs sanity
 
 build:
 	cargo build $(if $(FEATURES),--features "$(FEATURES)")
@@ -43,7 +43,11 @@ fmt:
 analyze: fmt clippy
 
 benchmark:
-	RUSTFLAGS="$(RUSTFLAGS_ADD)" cargo run --example $(EXAMPLE) $(if $(FEATURES),--features "$(FEATURES)") --release
+        RUSTFLAGS="$(RUSTFLAGS_ADD)" cargo run --example $(EXAMPLE) $(if $(FEATURES),--features "$(FEATURES)") --release
+
+# Run criterion benchmarks comparing kofft with other FFT libraries
+bench-libs:
+	RUSTFLAGS="$(RUSTFLAGS_ADD)" cargo bench --manifest-path kofft-bench/Cargo.toml $(if $(FEATURES),--features "$(FEATURES)")
 
 sanity:
 	cargo run -p sanity-check -- $(FLAC)

--- a/kofft-bench/Cargo.toml
+++ b/kofft-bench/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-kofft = { path = "..", features = ["parallel", "slow", "avx2"] }
+kofft = { path = "..", default-features = false, features = ["std", "slow"] }
 criterion = { version = "0.7", features = ["html_reports"] }
 rustfft = "6"
 realfft = "3"
@@ -12,6 +12,13 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 once_cell = "1"
 chrono = { version = "0.4", default-features = false, features = ["clock"] }
+
+[features]
+default = []
+parallel = ["kofft/parallel"]
+sse = ["kofft/sse"]
+aarch64 = ["kofft/aarch64"]
+avx2 = ["kofft/avx2"]
 
 [[bench]]
 name = "bench_fft"


### PR DESCRIPTION
## Summary
- Add `bench-libs` Makefile target to run criterion benchmarks comparing kofft with other FFT libraries
- Ensure `bench-libs` compiles KOFFT with SIMD and parallel features when available

## Testing
- `cargo test`
- `KOFFT_BENCH_POWERS=10 make bench-libs` *(interrupted after compilation due to runtime)*

------
https://chatgpt.com/codex/tasks/task_e_689efcc39be4832b80f175d964b50c76