### PR TITLE
Replace split-radix FFT with iterative kernel

### DIFF
--- a/tests/small_kernels.rs
+++ b/tests/small_kernels.rs
@@ -16,14 +16,14 @@ fn dft(input: &[Complex32]) -> Vec<Complex32> {
 }
 
 #[test]
-fn split_radix_small_kernels() {
+fn stockham_small_kernels() {
     let fft = ScalarFftImpl::<f32>::default();
     for &n in &[2usize, 4, 8, 16] {
         let mut data: Vec<Complex32> = (0..n)
             .map(|i| Complex32::new(i as f32, -(i as f32) * 0.5))
             .collect();
         let expected = dft(&data);
-        fft.split_radix_fft(&mut data).unwrap();
+        fft.stockham_fft(&mut data).unwrap();
         for (a, b) in data.iter().zip(expected.iter()) {
             assert!((a.re - b.re).abs() < 1e-2);
             assert!((a.im - b.im).abs() < 1e-2);

--- a/tests/twiddle.rs
+++ b/tests/twiddle.rs
@@ -12,9 +12,6 @@ fn planner_twiddles_f32_f64() {
     assert!((t32[1].re - expected32.re).abs() < 1e-6);
     assert!((t32[1].im - expected32.im).abs() < 1e-6);
 
-    // Ensure bit-reversal table is correct
-    let bitrev = p32.get_bitrev(8);
-    assert_eq!(&*bitrev, &[1, 4, 3, 6]);
 
     // Ensure Bluestein cache lengths are correct for non-power-of-two
     #[cfg(feature = "std")]


### PR DESCRIPTION
## Summary
- add iterative FFT kernel and use it for power-of-two sizes
- drop bit-reversal table infrastructure
- update tests for new FFT path

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_689f04d84d00832ba3afe0dc6a25cb02