### PR TITLE
Add update-bench-readme helper

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -52,6 +52,14 @@ cargo clippy
 cargo fmt
 ```
 
+### Updating Benchmarks
+
+Refresh the benchmark data in the repository:
+
+```bash
+make update-bench-readme
+```
+
 ## Development Guidelines
 
 ### Code Style

--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ endif
 
 FEATURES := $(strip $(SIMD_FEATURES) $(PAR_FEATURE))
 
-.PHONY: build test clippy fmt analyze benchmark bench-libs sanity
+.PHONY: build test clippy fmt analyze benchmark bench-libs update-bench-readme sanity
 
 build:
 	cargo build $(if $(FEATURES),--features "$(FEATURES)")
@@ -48,6 +48,9 @@ benchmark:
 # Run criterion benchmarks comparing kofft with other FFT libraries
 bench-libs:
 	RUSTFLAGS="$(RUSTFLAGS_ADD)" cargo bench --manifest-path kofft-bench/Cargo.toml $(if $(FEATURES),--features "$(FEATURES)")
+
+update-bench-readme:
+	RUSTFLAGS="$(RUSTFLAGS_ADD)" cargo run --manifest-path kofft-bench/Cargo.toml --example update_bench_readme --release $(if $(FEATURES),--features "$(FEATURES)")
 
 sanity:
 	cargo run -p sanity-check -- $(FLAC)


### PR DESCRIPTION
## Summary
- add `update-bench-readme` target to Makefile
- document how to refresh benchmark data in contributing guide

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_689f0848c2f8832bbebb65ddfc27175a