### PR TITLE
Fallback to scalar FFT on non-x86 targets

### DIFF
--- a/src/fft.rs
+++ b/src/fft.rs
@@ -1280,14 +1280,8 @@ pub fn new_fft_impl() -> Box<dyn FftImpl<f32>> {
             return Box::new(SimdFftX86_64Impl);
         }
     }
-    #[cfg(target_arch = "aarch64")]
-    {
-        return Box::new(SimdFftAArch64Impl);
-    }
-    #[cfg(target_arch = "wasm32")]
-    {
-        return Box::new(SimdFftWasmImpl);
-    }
+    // TODO: Add optimized implementations for other architectures (e.g., AArch64, WASM).
+    // For now, fall back to the portable scalar version on non-x86_64 targets.
     Box::new(ScalarFftImpl::<f32>::default())
 }
 

--- a/src/rfft.rs
+++ b/src/rfft.rs
@@ -9,8 +9,9 @@ use alloc::{sync::Arc, vec::Vec};
 
 use hashbrown::HashMap;
 
-use core::any::TypeId;
 use core::mem::MaybeUninit;
+#[cfg(all(target_arch = "x86_64", any(feature = "sse", target_feature = "sse2")))]
+use core::any::TypeId;
 
 use crate::fft::{fft_inplace_stack, ifft_inplace_stack, Complex, Complex32, FftError, FftImpl};
 use crate::num::Float;


### PR DESCRIPTION
## Summary
- remove references to undefined AArch64 and WASM SIMD FFT implementations
- conditionally import `TypeId` for SIMD RFFT helpers

## Testing
- `cargo check`
- `cargo check --target aarch64-unknown-linux-gnu`
- `cargo check --target wasm32-unknown-unknown`


------
https://chatgpt.com/codex/tasks/task_e_689f0fcf9e8c832b89ac94fc1a76a13e