### PR TITLE
ci: run rustfmt in lint workflow

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -12,6 +12,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@nightly
         with:
-          components: clippy
+          components: clippy rustfmt
+      - run: cargo fmt --all -- --check
       - name: Clippy
         run: cargo clippy --all-targets --all-features -- -D warnings


### PR DESCRIPTION
## Summary
- install rustfmt component alongside clippy in lint workflow
- check formatting with `cargo fmt --all -- --check`

## Testing
- `cargo +nightly fmt --all -- --check` *(fails: formatting differences)*
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_689f1332c1e8832b8ab9f5b6b3ae2e5a