### PR TITLE
chore: gate Codecov upload

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -16,7 +16,9 @@ jobs:
       - name: Run Tarpaulin
         run: cargo tarpaulin --out Xml --features internal-tests
       - name: Upload coverage to Codecov
+        if: ${{ secrets.CODECOV_TOKEN != '' }}
         uses: codecov/codecov-action@v4
         with:
           files: tarpaulin-report.xml
           token: ${{ secrets.CODECOV_TOKEN }}
+        continue-on-error: true


### PR DESCRIPTION
## Summary
- upload coverage to Codecov only when `CODECOV_TOKEN` is available
- keep the workflow green if Codecov upload fails

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_689f1324fb70832b86e8324875e33134