### PR TITLE
Use DctPlanner for DCT transforms

### DIFF
--- a/README.md
+++ b/README.md
@@ -361,12 +361,13 @@ parallel(&signal, &window, hop_size, &mut frames)?;
 - **Cepstrum** – ([Wikipedia](https://en.wikipedia.org/wiki/Cepstrum))
 
 ```rust
-use kofft::{dct, dst, hartley, wavelet, goertzel, czt, hilbert, cepstrum};
+use kofft::{dct::{self, DctPlanner}, dst, hartley, wavelet, goertzel, czt, hilbert, cepstrum};
 
 // DCT variants
-let dct2_result = dct::dct2(&input);
-let dct3_result = dct::dct3(&input);
-let dct4_result = dct::dct4(&input);
+let mut planner = DctPlanner::new();
+let dct2_result = dct::dct2(&mut planner, &input);
+let dct3_result = dct::dct3(&mut planner, &input);
+let dct4_result = dct::dct4(&mut planner, &input);
 
 // DST variants
 let dst1_result = dst::dst1(&input);

--- a/examples/basic_usage.rs
+++ b/examples/basic_usage.rs
@@ -5,7 +5,7 @@
 
 use kofft::cepstrum::real_cepstrum;
 use kofft::czt::czt_f32;
-use kofft::dct::dct2;
+use kofft::dct::{dct2, DctPlanner};
 use kofft::dst::dst2;
 use kofft::fft::{FftImpl, ScalarFftImpl};
 use kofft::goertzel::goertzel_f32;
@@ -96,7 +96,8 @@ fn main() {
     // 3. Discrete Cosine Transform (DCT)
     println!("3. Discrete Cosine Transform (DCT-II)");
     let dct_input = vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0];
-    let dct_result = dct2(&dct_input);
+    let mut planner = DctPlanner::new();
+    let dct_result = dct2(&mut planner, &dct_input);
     println!("   Input: {:?}", dct_input);
     println!(
         "   DCT-II: {:?}",

--- a/kofft-bench/benches/bench_dct.rs
+++ b/kofft-bench/benches/bench_dct.rs
@@ -1,16 +1,18 @@
 use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
-use kofft::dct;
 use kofft::dct::slow as dct_slow;
+use kofft::dct::{self, DctPlanner};
 
 fn bench_dct2(c: &mut Criterion) {
     let mut group = c.benchmark_group("dct2");
     for &size in &[64usize, 256, 1024] {
         let data: Vec<f32> = (0..size).map(|i| i as f32).collect();
         group.bench_with_input(BenchmarkId::new("fast", size), &data, |b, input| {
-            b.iter(|| dct::dct2(input));
+            let mut planner = DctPlanner::new();
+            b.iter(|| dct::dct2(&mut planner, input));
         });
         group.bench_with_input(BenchmarkId::new("slow", size), &data, |b, input| {
-            b.iter(|| dct_slow::dct2(input));
+            let mut planner = DctPlanner::new();
+            b.iter(|| dct_slow::dct2(&mut planner, input));
         });
     }
     group.finish();
@@ -21,10 +23,12 @@ fn bench_dct3(c: &mut Criterion) {
     for &size in &[64usize, 256, 1024] {
         let data: Vec<f32> = (0..size).map(|i| i as f32).collect();
         group.bench_with_input(BenchmarkId::new("fast", size), &data, |b, input| {
-            b.iter(|| dct::dct3(input));
+            let mut planner = DctPlanner::new();
+            b.iter(|| dct::dct3(&mut planner, input));
         });
         group.bench_with_input(BenchmarkId::new("slow", size), &data, |b, input| {
-            b.iter(|| dct_slow::dct3(input));
+            let mut planner = DctPlanner::new();
+            b.iter(|| dct_slow::dct3(&mut planner, input));
         });
     }
     group.finish();
@@ -35,10 +39,12 @@ fn bench_dct4(c: &mut Criterion) {
     for &size in &[64usize, 256, 1024] {
         let data: Vec<f32> = (0..size).map(|i| i as f32).collect();
         group.bench_with_input(BenchmarkId::new("fast", size), &data, |b, input| {
-            b.iter(|| dct::dct4(input));
+            let mut planner = DctPlanner::new();
+            b.iter(|| dct::dct4(&mut planner, input));
         });
         group.bench_with_input(BenchmarkId::new("slow", size), &data, |b, input| {
-            b.iter(|| dct_slow::dct4(input));
+            let mut planner = DctPlanner::new();
+            b.iter(|| dct_slow::dct4(&mut planner, input));
         });
     }
     group.finish();

--- a/src/cepstrum.rs
+++ b/src/cepstrum.rs
@@ -83,7 +83,8 @@ pub fn mfcc(
         return Err(FftError::InvalidValue);
     }
     let log_mel: Vec<f32> = mel_energies.iter().map(|&x| logf(x + 1e-12)).collect();
-    let dct = crate::dct::dct2(&log_mel);
+    let mut planner = crate::dct::DctPlanner::new();
+    let dct = crate::dct::dct2(&mut planner, &log_mel);
     Ok(dct[..num_coeffs].to_vec())
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -140,6 +140,7 @@ pub mod cepstrum;
 /// Extended collection of window functions for specialized applications.
 pub mod window_more;
 
+pub use dct::DctPlanner;
 pub use fft::FftPlanner;
 pub use num::{Complex, Complex32, Complex64, Float};
 


### PR DESCRIPTION
## Summary
- add DctPlanner for caching cosine tables
- require DctPlanner in dct2/dct3/dct4 and update call sites
- hook DctPlanner into MFCC computation and examples

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_689f139e6918832b9902b951a5be6fdb