### PR TITLE
Add FFT-based stack DCT implementations

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,7 @@ proptest = { version = "1.4", optional = true }
 rand = { version = "0.8", optional = true }
 hashbrown = "0.14"
 num_cpus = { version = "1.16", optional = true }
+rustdct = "0.7"
 
 [features]
 default = ["std"]


### PR DESCRIPTION
## Summary
- add FFT-powered in-place stack DCT-II/III/IV using rustdct planner
- include unit test validating stack FFT DCTs on power-of-two sizes
- depend on rustdct for DCT planner

## Testing
- `cargo test --features internal-tests`


------
https://chatgpt.com/codex/tasks/task_e_689f13a29734832ba664d02a52a18a3b