### PR TITLE
Use DstPlanner for DST transforms

### DIFF
--- a/README.md
+++ b/README.md
@@ -362,6 +362,7 @@ parallel(&signal, &window, hop_size, &mut frames)?;
 
 ```rust
 use kofft::{dct, dst, hartley, wavelet, goertzel, czt, hilbert, cepstrum};
+use dst::DstPlanner;
 
 // DCT variants
 let dct2_result = dct::dct2(&input);
@@ -370,8 +371,9 @@ let dct4_result = dct::dct4(&input);
 
 // DST variants
 let dst1_result = dst::dst1(&input);
-let dst2_result = dst::dst2(&input);
-let dst3_result = dst::dst3(&input);
+let mut planner = DstPlanner::new();
+let dst2_result = planner.dst2(&input);
+let dst3_result = planner.dst3(&input);
 
 // Hartley Transform
 let hartley_result = hartley::dht(&input);

--- a/examples/basic_usage.rs
+++ b/examples/basic_usage.rs
@@ -6,7 +6,7 @@
 use kofft::cepstrum::real_cepstrum;
 use kofft::czt::czt_f32;
 use kofft::dct::dct2;
-use kofft::dst::dst2;
+use kofft::dst::DstPlanner;
 use kofft::fft::{FftImpl, ScalarFftImpl};
 use kofft::goertzel::goertzel_f32;
 use kofft::hartley::dht;
@@ -177,7 +177,8 @@ fn main() {
     // 8. Discrete Sine Transform (DST-II)
     println!("8. Discrete Sine Transform (DST-II)");
     let dst_input = vec![1.0, 2.0, 3.0, 4.0];
-    let dst_result = dst2(&dst_input);
+    let mut dst_planner = DstPlanner::new();
+    let dst_result = dst_planner.dst2(&dst_input);
     println!("   Input: {:?}", dst_input);
     println!(
         "   DST-II: {:?}",


### PR DESCRIPTION
## Summary
- add `DstPlanner` with cached sine tables for DST-II/III/IV
- refactor dst2/3/4 and batch/multi-channel helpers to use the planner
- update example and README to construct and reuse `DstPlanner`

## Testing
- `cargo test`
- `cargo test --examples`


------
https://chatgpt.com/codex/tasks/task_e_689f13a03adc832b8f487ac36271efc0