### PR TITLE
Speed up DCT-II using real FFT

### DIFF
--- a/tests/dct.rs
+++ b/tests/dct.rs
@@ -1,0 +1,15 @@
+#![cfg(feature = "slow")]
+
+use kofft::dct;
+
+#[test]
+fn dct2_matches_slow() {
+    for n in 1..16 {
+        let input: Vec<f32> = (0..n).map(|i| (i as f32 * 0.12345).sin()).collect();
+        let fast = dct::dct2(&input);
+        let slow = dct::slow::dct2(&input);
+        for (a, b) in fast.iter().zip(slow.iter()) {
+            assert!((a - b).abs() < 1e-4, "n={n}, fast={a}, slow={b}");
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Implement DCT-II via an even-symmetric extension and RFFT
- Preserve naive DCT implementations behind the `slow` feature
- Add tests comparing fast DCT-II against slow reference

## Testing
- `cargo test --features slow`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_689f138d989c832ba05c6eedb431b3e4