### PR TITLE
Add rustfmt check to lint workflow

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -12,7 +12,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@nightly
         with:
-          components: clippy
+          components: clippy rustfmt
       - uses: actions/cache@v3
         with:
           path: |
@@ -20,5 +20,7 @@ jobs:
             ~/.cargo/git
             target
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+      - name: Format check
+        run: cargo fmt --all -- --check
       - name: Clippy
         run: cargo clippy --all-targets --all-features -- -D warnings


### PR DESCRIPTION
## Summary
- add rustfmt to lint workflow
- run cargo fmt in CI before clippy

## Testing
- `cargo fmt --all -- --check` (fails: shows formatting diffs)
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_689f190fb3cc832ba9353df638f25c0e