### PR TITLE
Fix clippy warnings

### DIFF
--- a/examples/dct_usage.rs
+++ b/examples/dct_usage.rs
@@ -14,12 +14,12 @@ fn dct2_naive(input: &[f32]) -> Vec<f32> {
     let n = input.len();
     let mut output = vec![0.0f32; n];
     let factor = std::f32::consts::PI / n as f32;
-    for k in 0..n {
+    for (k, out) in output.iter_mut().enumerate() {
         let mut sum = 0.0;
-        for i in 0..n {
-            sum += input[i] * (factor * (i as f32 + 0.5) * k as f32).cos();
+        for (i, &val) in input.iter().enumerate() {
+            sum += val * (factor * (i as f32 + 0.5) * k as f32).cos();
         }
-        output[k] = sum;
+        *out = sum;
     }
     output
 }
@@ -33,9 +33,9 @@ impl Dct2Planner {
     fn new(n: usize) -> Self {
         let factor = std::f32::consts::PI / n as f32;
         let mut cos_table = vec![vec![0.0f32; n]; n];
-        for k in 0..n {
-            for i in 0..n {
-                cos_table[k][i] = (factor * (i as f32 + 0.5) * k as f32).cos();
+        for (k, row) in cos_table.iter_mut().enumerate() {
+            for (i, val) in row.iter_mut().enumerate() {
+                *val = (factor * (i as f32 + 0.5) * k as f32).cos();
             }
         }
         Self { cos_table }
@@ -44,12 +44,12 @@ impl Dct2Planner {
     fn dct2(&self, input: &[f32]) -> Vec<f32> {
         let n = input.len();
         let mut output = vec![0.0f32; n];
-        for k in 0..n {
+        for (row, out) in self.cos_table.iter().zip(output.iter_mut()) {
             let mut sum = 0.0;
-            for i in 0..n {
-                sum += input[i] * self.cos_table[k][i];
+            for (val, cos_val) in input.iter().zip(row.iter()) {
+                sum += *val * *cos_val;
             }
-            output[k] = sum;
+            *out = sum;
         }
         output
     }

--- a/src/fft.rs
+++ b/src/fft.rs
@@ -116,7 +116,6 @@ fn parallel_fft_threads() -> usize {
                     .ok()
                     .and_then(|v| v.parse::<usize>().ok())
             })
-            .clone()
             .unwrap_or_else(|| *CPU_COUNT.get_or_init(|| num_cpus::get().max(1)))
     }
     #[cfg(not(feature = "std"))]
@@ -139,7 +138,6 @@ fn parallel_fft_block_size() -> usize {
                     .ok()
                     .and_then(|v| v.parse::<usize>().ok())
             })
-            .clone()
             .unwrap_or(1024)
     }
     #[cfg(not(feature = "std"))]
@@ -176,7 +174,6 @@ fn should_parallelize_fft(n: usize) -> bool {
                         .ok()
                         .and_then(|v| v.parse::<usize>().ok())
                 })
-                .clone()
                 .unwrap_or(0)
         }
         #[cfg(not(feature = "std"))]
@@ -206,7 +203,6 @@ fn should_parallelize_fft(n: usize) -> bool {
                             .ok()
                             .and_then(|v| v.parse::<usize>().ok())
                     })
-                    .clone()
                     .unwrap_or(32 * 1024)
             }
             #[cfg(not(feature = "std"))]
@@ -229,7 +225,6 @@ fn should_parallelize_fft(n: usize) -> bool {
                             .ok()
                             .and_then(|v| v.parse::<usize>().ok())
                     })
-                    .clone()
                     .unwrap_or(4096)
             }
             #[cfg(not(feature = "std"))]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,3 @@
-#![allow(clippy::manual_is_multiple_of)]
 //! # kofft - High-performance DSP library for Rust
 //!
 //! A comprehensive Digital Signal Processing (DSP) library featuring FFT, DCT, DST,


### PR DESCRIPTION
## Summary
- remove invalid lint attribute
- eliminate unnecessary clones from FFT configuration
- use iterator-based loops in DCT example to satisfy clippy

## Testing
- `cargo clippy --all-targets --all-features`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_689f39044210832bbedc74f7e955a088