### PR TITLE
Optimize twiddle access and add complex repr

### DIFF
--- a/src/num.rs
+++ b/src/num.rs
@@ -102,6 +102,7 @@ impl Float for f64 {
     }
 }
 
+#[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct Complex<T: Float> {
     pub re: T,

--- a/tests/complex_repr.rs
+++ b/tests/complex_repr.rs
@@ -1,0 +1,18 @@
+use kofft::num::{Complex32, Complex64};
+
+#[test]
+fn complex_repr_c_transmutable() {
+    use core::mem::{align_of, size_of, transmute};
+
+    // Verify size and alignment match an array of two floats
+    assert_eq!(size_of::<Complex32>(), size_of::<[f32; 2]>());
+    assert_eq!(align_of::<Complex32>(), align_of::<[f32; 2]>());
+    assert_eq!(size_of::<Complex64>(), size_of::<[f64; 2]>());
+    assert_eq!(align_of::<Complex64>(), align_of::<[f64; 2]>());
+
+    // Transmute from an array to Complex32 safely
+    let arr = [1.0_f32, 2.0_f32];
+    let c: Complex32 = unsafe { transmute(arr) };
+    assert_eq!(c.re, 1.0);
+    assert_eq!(c.im, 2.0);
+}

--- a/tests/twiddle.rs
+++ b/tests/twiddle.rs
@@ -11,6 +11,10 @@ fn planner_twiddles_f32_f64() {
     let expected32 = Complex32::expi(-2.0 * std::f32::consts::PI / 8.0);
     assert!((t32[1].re - expected32.re).abs() < 1e-6);
     assert!((t32[1].im - expected32.im).abs() < 1e-6);
+    // Ensure cached reference is reused.
+    let ptr1 = t32.as_ptr();
+    let ptr2 = p32.get_twiddles(8).as_ptr();
+    assert_eq!(ptr1, ptr2);
 
     // Ensure Bluestein cache lengths are correct for non-power-of-two
     #[cfg(feature = "std")]


### PR DESCRIPTION
## Summary
- avoid cloning twiddle tables by returning `Arc` slices and reusing pointers
- remove temporary index vectors in parallel FFT execution
- mark `Complex` with `#[repr(C)]` and add layout test

## Testing
- `cargo fmt --all`
- `cargo clippy --all-targets --all-features`
- `cargo test --all-features`
- `cargo tarpaulin --tests --all-features --timeout 120` *(75% coverage)*

------
https://chatgpt.com/codex/tasks/task_e_689f5299b5a4832b96270d6291173246