### PR TITLE
Add STFT output length check

### DIFF
--- a/src/stft.rs
+++ b/src/stft.rs
@@ -626,18 +626,20 @@ mod edge_case_tests {
     fn test_all_zero_window() {
         let signal = [1.0, 2.0, 3.0, 4.0];
         let window = [0.0, 0.0, 0.0, 0.0];
-        let mut frames = vec![vec![Complex32::new(0.0, 0.0); 4]];
+        let hop = 2;
+        let num_frames = signal.len().div_ceil(hop);
+        let mut frames = vec![vec![Complex32::new(0.0, 0.0); window.len()]; num_frames];
         let fft = ScalarFftImpl::<f32>::default();
-        stft(&signal, &window, 2, &mut frames, &fft).unwrap();
+        stft(&signal, &window, hop, &mut frames, &fft).unwrap();
         for frame in &frames {
             for c in frame {
                 assert_eq!(c.re, 0.0);
                 assert_eq!(c.im, 0.0);
             }
         }
-        let mut output = vec![0.0f32; 4];
+        let mut output = vec![0.0f32; signal.len()];
         let mut scratch = vec![0.0f32; output.len()];
-        istft(&mut frames, &window, 2, &mut output, &mut scratch, &fft).unwrap();
+        istft(&mut frames, &window, hop, &mut output, &mut scratch, &fft).unwrap();
         for &x in &output {
             assert_eq!(x, 0.0);
         }
@@ -807,18 +809,20 @@ mod coverage_tests {
     fn test_stft_all_zero_window() {
         let signal = [1.0, 2.0, 3.0, 4.0];
         let window = [0.0, 0.0, 0.0, 0.0];
-        let mut frames = vec![vec![Complex32::new(0.0, 0.0); 4]];
+        let hop = 2;
+        let num_frames = signal.len().div_ceil(hop);
+        let mut frames = vec![vec![Complex32::new(0.0, 0.0); window.len()]; num_frames];
         let fft = ScalarFftImpl::<f32>::default();
-        stft(&signal, &window, 2, &mut frames, &fft).unwrap();
+        stft(&signal, &window, hop, &mut frames, &fft).unwrap();
         for frame in &frames {
             for c in frame {
                 assert_eq!(c.re, 0.0);
                 assert_eq!(c.im, 0.0);
             }
         }
-        let mut output = vec![0.0f32; 4];
+        let mut output = vec![0.0f32; signal.len()];
         let mut scratch = vec![0.0f32; output.len()];
-        istft(&mut frames, &window, 2, &mut output, &mut scratch, &fft).unwrap();
+        istft(&mut frames, &window, hop, &mut output, &mut scratch, &fft).unwrap();
         for &x in &output {
             assert_eq!(x, 0.0);
         }

--- a/src/stft.rs
+++ b/src/stft.rs
@@ -63,6 +63,10 @@ pub fn stft<Fft: FftImpl<f32>>(
     if hop_size == 0 {
         return Err(FftError::InvalidHopSize);
     }
+    let required = signal.len().div_ceil(hop_size);
+    if output.len() < required {
+        return Err(FftError::MismatchedLengths);
+    }
     let win_len = window.len();
     for (frame_idx, frame) in output.iter_mut().enumerate() {
         let start = frame_idx * hop_size;

--- a/tests/stft.rs
+++ b/tests/stft.rs
@@ -1,0 +1,14 @@
+use kofft::fft::{FftError, ScalarFftImpl};
+use kofft::stft::stft;
+use kofft::window::hann;
+
+#[test]
+fn stft_errors_on_insufficient_frames() {
+    let signal = vec![0.0; 10];
+    let window = hann(4);
+    let hop = 4;
+    let fft = ScalarFftImpl::<f32>::default();
+    let mut frames = vec![vec![]; 2]; // required = 3
+    let result = stft(&signal, &window, hop, &mut frames, &fft);
+    assert!(matches!(result, Err(FftError::MismatchedLengths)));
+}


### PR DESCRIPTION
## Summary
- validate STFT buffer has enough frames before processing
- test error handling when frame count is insufficient

## Testing
- `cargo fmt --all`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test`
- `cargo tarpaulin --ignore-tests`


------
https://chatgpt.com/codex/tasks/task_e_689f615d105c832b8789649caafb6d1a