### PR TITLE
Optimize parallel FFT stage execution

### DIFF
--- a/tests/parallel_stockham.rs
+++ b/tests/parallel_stockham.rs
@@ -1,0 +1,28 @@
+#![cfg(feature = "parallel")]
+
+use kofft::fft::{set_parallel_fft_threshold, Complex32, ScalarFftImpl};
+
+#[test]
+fn stockham_fft_parallel_matches_serial() {
+    let size = 1 << 12; // 4096
+    let mut input_par: Vec<Complex32> = (0..size)
+        .map(|i| Complex32::new(i as f32, (2 * i) as f32))
+        .collect();
+    let mut input_ser = input_par.clone();
+
+    // Force parallel execution
+    set_parallel_fft_threshold(1);
+    let fft = ScalarFftImpl::<f32>::default();
+    fft.stockham_fft(&mut input_par).unwrap();
+
+    // Force serial execution
+    set_parallel_fft_threshold(usize::MAX);
+    fft.stockham_fft(&mut input_ser).unwrap();
+
+    // Reset threshold
+    set_parallel_fft_threshold(0);
+
+    for (a, b) in input_par.iter().zip(input_ser.iter()) {
+        assert!((a.re - b.re).abs() < 1e-4 && (a.im - b.im).abs() < 1e-4);
+    }
+}


### PR DESCRIPTION
## Summary
- cache `should_parallelize_fft` result and use `par_chunks_mut` for block parallelism
- add integration test covering parallel vs serial Stockham FFT

## Testing
- `cargo fmt --all`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test`
- `cargo test --features parallel`
- `cargo tarpaulin --features parallel --test parallel_stockham --out Xml`
- `cargo run --example parallel_benchmark --features parallel --release`


------
https://chatgpt.com/codex/tasks/task_e_689f6ebdba98832bbb2b0cd0e1aff391