### PR TITLE
Use Stockham autosort FFT with double buffering

### DIFF
--- a/kofft-bench/benches/stockham_fft.rs
+++ b/kofft-bench/benches/stockham_fft.rs
@@ -1,0 +1,21 @@
+use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
+use kofft::fft::{Complex32, FftImpl, ScalarFftImpl};
+
+fn bench_stockham(c: &mut Criterion) {
+    let fft = ScalarFftImpl::<f32>::default();
+    for &n in &[256usize, 1024, 4096] {
+        let mut group = c.benchmark_group(format!("stockham_{n}"));
+        let input: Vec<Complex32> = (0..n).map(|i| Complex32::new(i as f32, 0.0)).collect();
+        let mut data = input.clone();
+        group.bench_function(BenchmarkId::new("stockham", n), |b| {
+            b.iter(|| {
+                data.copy_from_slice(&input);
+                fft.stockham_fft(&mut data).unwrap();
+            });
+        });
+        group.finish();
+    }
+}
+
+criterion_group!(benches, bench_stockham);
+criterion_main!(benches);

--- a/tests/stockham_parity.rs
+++ b/tests/stockham_parity.rs
@@ -1,0 +1,18 @@
+use kofft::fft::{Complex32, FftImpl, ScalarFftImpl};
+
+#[test]
+fn stockham_matches_fft_for_large_powers_of_two() {
+    let fft = ScalarFftImpl::<f32>::default();
+    for &n in &[32usize, 64, 128, 256] {
+        let mut data: Vec<Complex32> = (0..n)
+            .map(|i| Complex32::new(i as f32, -(i as f32) * 0.25))
+            .collect();
+        let mut expected = data.clone();
+        fft.fft(&mut expected).unwrap();
+        fft.stockham_fft(&mut data).unwrap();
+        for (a, b) in data.iter().zip(expected.iter()) {
+            assert!((a.re - b.re).abs() < 1e-3);
+            assert!((a.im - b.im).abs() < 1e-3);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- replace bit-reversal FFT core with Stockham autosort algorithm using alternating buffers
- add parity tests to verify Stockham FFT output matches standard FFT for larger sizes
- introduce stockham_fft benchmark for performance tracking

## Testing
- `cargo clippy --all-targets --all-features`
- `cargo test`
- `cargo llvm-cov --features internal-tests`


------
https://chatgpt.com/codex/tasks/task_e_689f6ebc53f4832b868fb944e4890e63