### PR TITLE
Add feature-gated SIMD RFFT kernels for x86_64 and aarch64

### DIFF
--- a/kofft-bench/benches/bench_rfft.rs
+++ b/kofft-bench/benches/bench_rfft.rs
@@ -3,6 +3,11 @@ use kofft::fft::{Complex32, FftPlanner, ScalarFftImpl};
 use kofft::rfft::RealFftImpl;
 use realfft::RealFftPlanner as RustRealFftPlanner;
 
+#[cfg(feature = "aarch64")]
+use kofft::fft::SimdFftAarch64Impl;
+#[cfg(feature = "x86_64")]
+use kofft::fft::SimdFftX86_64Impl;
+
 fn bench_rfft(c: &mut Criterion) {
     let mut group = c.benchmark_group("rfft_parity");
     for &size in &[1024usize, 2048, 4096] {
@@ -17,6 +22,22 @@ fn bench_rfft(c: &mut Criterion) {
                     .unwrap();
             })
         });
+
+        #[cfg(any(feature = "x86_64", feature = "aarch64"))]
+        {
+            let mut simd_out = vec![Complex32::new(0.0, 0.0); size / 2 + 1];
+            #[cfg(feature = "x86_64")]
+            let fft_simd = SimdFftX86_64Impl::default();
+            #[cfg(feature = "aarch64")]
+            let fft_simd = SimdFftAarch64Impl::default();
+            group.bench_function(BenchmarkId::new("kofft_simd", size), |b| {
+                b.iter(|| {
+                    fft_simd
+                        .rfft_with_scratch(&mut input, &mut simd_out, &mut scratch)
+                        .unwrap();
+                })
+            });
+        }
 
         let mut planner = RustRealFftPlanner::<f32>::new();
         let rfft = planner.plan_fft_forward(size);

--- a/tests/rfft_arch_parity.rs
+++ b/tests/rfft_arch_parity.rs
@@ -1,0 +1,43 @@
+#![cfg(any(feature = "x86_64", feature = "aarch64"))]
+use kofft::fft::{Complex32, ScalarFftImpl};
+#[allow(unused_imports)]
+use kofft::rfft::RealFftImpl;
+use kofft::rfft::RfftPlanner;
+
+#[test]
+fn rfft_matches_scalar() {
+    let size = 32usize;
+    let input: Vec<f32> = (0..size).map(|i| (i as f32).sin()).collect();
+    let mut scalar_out = vec![Complex32::new(0.0, 0.0); size / 2 + 1];
+    let mut simd_out = vec![Complex32::new(0.0, 0.0); size / 2 + 1];
+    let mut scratch = vec![Complex32::new(0.0, 0.0); size / 2];
+    let fft_scalar = ScalarFftImpl::<f32>::default();
+    let mut planner = RfftPlanner::<f32>::new();
+    planner
+        .rfft_with_scratch(
+            &fft_scalar,
+            &mut input.clone(),
+            &mut scalar_out,
+            &mut scratch,
+        )
+        .unwrap();
+    #[cfg(feature = "x86_64")]
+    {
+        use kofft::fft::SimdFftX86_64Impl;
+        let fft_simd = SimdFftX86_64Impl;
+        planner
+            .rfft_with_scratch(&fft_simd, &mut input.clone(), &mut simd_out, &mut scratch)
+            .unwrap();
+    }
+    #[cfg(feature = "aarch64")]
+    {
+        use kofft::fft::SimdFftAarch64Impl;
+        let fft_simd = SimdFftAarch64Impl;
+        planner
+            .rfft_with_scratch(&fft_simd, &mut input.clone(), &mut simd_out, &mut scratch)
+            .unwrap();
+    }
+    for (a, b) in scalar_out.iter().zip(simd_out.iter()) {
+        assert!((a.re - b.re).abs() < 1e-5 && (a.im - b.im).abs() < 1e-5);
+    }
+}


### PR DESCRIPTION
## Summary
- add AVX/AVX2 and NEON real FFT kernels with feature-gated dispatch and scalar fallback
- add parity test exercising architecture-specific kernels
- extend RFFT benchmark to cover SIMD backends

## Testing
- `cargo fmt`
- `cargo clippy --all-targets --features x86_64` (fails: items after test module warning in `src/dct.rs`)
- `cargo test --features x86_64`


------
https://chatgpt.com/codex/tasks/task_e_689fa6939740832b94defb7e4ddb0150