### PR TITLE
Rewrite small FFT kernels to operate in-place

### DIFF
--- a/src/fft.rs
+++ b/src/fft.rs
@@ -19,7 +19,7 @@ use core::cell::RefCell;
 use core::mem::MaybeUninit;
 use hashbrown::HashMap;
 
-use crate::fft_kernels::{fft16, fft2, fft4, fft8};
+use crate::fft_kernels::{fft2, fft4};
 #[cfg(feature = "parallel")]
 use core::sync::atomic::{AtomicUsize, Ordering};
 #[cfg(feature = "parallel")]
@@ -269,6 +269,7 @@ fn should_parallelize_fft(n: usize, base_threshold: usize) -> bool {
     }
 }
 
+pub use crate::fft_kernels::{fft16, fft8};
 pub use crate::num::{
     copy_from_complex, copy_to_complex, Complex, Complex32, Complex64, Float, SplitComplex,
     SplitComplex32, SplitComplex64,

--- a/src/fft_kernels.rs
+++ b/src/fft_kernels.rs
@@ -31,7 +31,10 @@ pub fn fft4<T: Float>(input: &mut [Complex<T>]) {
 #[inline(always)]
 pub fn fft8<T: Float>(input: &mut [Complex<T>]) {
     debug_assert_eq!(input.len(), 8);
-    // Load inputs
+    let w1 = Complex::new(T::zero(), -T::one());
+    let s = T::from_f32(0.70710677); // sqrt(2)/2
+
+    // load inputs before overwriting
     let x0 = input[0];
     let x1 = input[1];
     let x2 = input[2];
@@ -46,12 +49,11 @@ pub fn fft8<T: Float>(input: &mut [Complex<T>]) {
     let a1 = x0.sub(x4);
     let a2 = x2.add(x6);
     let a3 = x2.sub(x6);
-    let w1 = Complex::new(T::zero(), -T::one());
     let t = a3.mul(w1);
-    let e0 = a0.add(a2);
-    let e2 = a0.sub(a2);
-    let e1 = a1.add(t);
-    let e3 = a1.sub(t);
+    input[0] = a0.add(a2);
+    input[2] = a0.sub(a2);
+    input[1] = a1.add(t);
+    input[3] = a1.sub(t);
 
     // FFT4 on odd indices (1,3,5,7)
     let b0 = x1.add(x5);
@@ -59,20 +61,22 @@ pub fn fft8<T: Float>(input: &mut [Complex<T>]) {
     let b2 = x3.add(x7);
     let b3 = x3.sub(x7);
     let t = b3.mul(w1);
-    let o0 = b0.add(b2);
-    let o2 = b0.sub(b2);
-    let o1 = b1.add(t);
-    let o3 = b1.sub(t);
+    input[4] = b0.add(b2);
+    input[6] = b0.sub(b2);
+    input[5] = b1.add(t);
+    input[7] = b1.sub(t);
 
-    // Twiddle multiplication and final butterflies
-    let s = T::from_f32(0.70710677); // sqrt(2)/2
-    let t0 = o0; // twiddle W0 = 1
-    let t1 = o1.mul(Complex::new(s, -s));
-    let t2 = o2.mul(w1);
-    let t3 = o3.mul(Complex::new(-s, -s));
-
-    input[0] = e0.add(t0);
-    input[4] = e0.sub(t0);
+    // Twiddle multiplication on odd part and final butterflies
+    let t1 = input[5].mul(Complex::new(s, -s));
+    let t2 = input[6].mul(w1);
+    let t3 = input[7].mul(Complex::new(-s, -s));
+    let o0 = input[4];
+    let e0 = input[0];
+    let e1 = input[1];
+    let e2 = input[2];
+    let e3 = input[3];
+    input[0] = e0.add(o0);
+    input[4] = e0.sub(o0);
     input[1] = e1.add(t1);
     input[5] = e1.sub(t1);
     input[2] = e2.add(t2);
@@ -84,7 +88,7 @@ pub fn fft8<T: Float>(input: &mut [Complex<T>]) {
 #[inline(always)]
 pub fn fft16<T: Float>(input: &mut [Complex<T>]) {
     debug_assert_eq!(input.len(), 16);
-    // Load inputs
+    // load all inputs before overwriting
     let x0 = input[0];
     let x1 = input[1];
     let x2 = input[2];
@@ -105,8 +109,7 @@ pub fn fft16<T: Float>(input: &mut [Complex<T>]) {
     let w1 = Complex::new(T::zero(), -T::one());
     let s = T::from_f32(0.70710677); // sqrt(2)/2
 
-    // FFT8 on even indices (0,2,4,6,8,10,12,14)
-    // First 4-point FFT on [x0,x4,x8,x12]
+    // ---- even index FFT8 ----
     let a0 = x0.add(x8);
     let a1 = x0.sub(x8);
     let a2 = x4.add(x12);
@@ -116,7 +119,7 @@ pub fn fft16<T: Float>(input: &mut [Complex<T>]) {
     let ea2 = a0.sub(a2);
     let ea1 = a1.add(t);
     let ea3 = a1.sub(t);
-    // Second 4-point FFT on [x2,x6,x10,x14]
+
     let b0 = x2.add(x10);
     let b1 = x2.sub(x10);
     let b2 = x6.add(x14);
@@ -126,22 +129,21 @@ pub fn fft16<T: Float>(input: &mut [Complex<T>]) {
     let eb2 = b0.sub(b2);
     let eb1 = b1.add(t);
     let eb3 = b1.sub(t);
-    // Combine to get even FFT8 results
-    let t0 = eb0; // W0 = 1
+
+    let t0 = eb0;
     let t1 = eb1.mul(Complex::new(s, -s));
     let t2 = eb2.mul(w1);
     let t3 = eb3.mul(Complex::new(-s, -s));
-    let e0 = ea0.add(t0);
-    let e4 = ea0.sub(t0);
-    let e1 = ea1.add(t1);
-    let e5 = ea1.sub(t1);
-    let e2 = ea2.add(t2);
-    let e6 = ea2.sub(t2);
-    let e3 = ea3.add(t3);
-    let e7 = ea3.sub(t3);
+    input[0] = ea0.add(t0);
+    input[1] = ea1.add(t1);
+    input[2] = ea2.add(t2);
+    input[3] = ea3.add(t3);
+    input[4] = ea0.sub(t0);
+    input[5] = ea1.sub(t1);
+    input[6] = ea2.sub(t2);
+    input[7] = ea3.sub(t3);
 
-    // FFT8 on odd indices (1,3,5,7,9,11,13,15)
-    // First 4-point FFT on [x1,x5,x9,x13]
+    // ---- odd index FFT8 ----
     let c0 = x1.add(x9);
     let c1 = x1.sub(x9);
     let c2 = x5.add(x13);
@@ -151,7 +153,7 @@ pub fn fft16<T: Float>(input: &mut [Complex<T>]) {
     let oa2 = c0.sub(c2);
     let oa1 = c1.add(t);
     let oa3 = c1.sub(t);
-    // Second 4-point FFT on [x3,x7,x11,x15]
+
     let d0 = x3.add(x11);
     let d1 = x3.sub(x11);
     let d2 = x7.add(x15);
@@ -161,21 +163,21 @@ pub fn fft16<T: Float>(input: &mut [Complex<T>]) {
     let ob2 = d0.sub(d2);
     let ob1 = d1.add(t);
     let ob3 = d1.sub(t);
-    // Combine to get odd FFT8 results
+
     let t0 = ob0;
     let t1 = ob1.mul(Complex::new(s, -s));
     let t2 = ob2.mul(w1);
     let t3 = ob3.mul(Complex::new(-s, -s));
-    let o0 = oa0.add(t0);
-    let o4 = oa0.sub(t0);
-    let o1 = oa1.add(t1);
-    let o5 = oa1.sub(t1);
-    let o2 = oa2.add(t2);
-    let o6 = oa2.sub(t2);
-    let o3 = oa3.add(t3);
-    let o7 = oa3.sub(t3);
+    input[8] = oa0.add(t0);
+    input[9] = oa1.add(t1);
+    input[10] = oa2.add(t2);
+    input[11] = oa3.add(t3);
+    input[12] = oa0.sub(t0);
+    input[13] = oa1.sub(t1);
+    input[14] = oa2.sub(t2);
+    input[15] = oa3.sub(t3);
 
-    // Twiddle multiplication for stage 2 (size 16)
+    // ---- twiddle multiply odd half ----
     let c1 = T::from_f32(0.9238795);
     let s1 = T::from_f32(-0.38268343);
     let c2 = T::from_f32(0.70710677);
@@ -185,29 +187,38 @@ pub fn fft16<T: Float>(input: &mut [Complex<T>]) {
     let c4 = T::zero();
     let s4 = T::from_f32(-1.0);
 
-    let t0 = o0; // W0 = 1
-    let t1 = o1.mul(Complex::new(c1, s1));
-    let t2 = o2.mul(Complex::new(c2, s2));
-    let t3 = o3.mul(Complex::new(c3, s3));
-    let t4 = o4.mul(Complex::new(c4, s4));
-    let t5 = o5.mul(Complex::new(-c3, s3));
-    let t6 = o6.mul(Complex::new(-c2, s2));
-    let t7 = o7.mul(Complex::new(-c1, s1));
+    let o0 = input[8];
+    let o1 = input[9].mul(Complex::new(c1, s1));
+    let o2 = input[10].mul(Complex::new(c2, s2));
+    let o3 = input[11].mul(Complex::new(c3, s3));
+    let o4 = input[12].mul(Complex::new(c4, s4));
+    let o5 = input[13].mul(Complex::new(-c3, s3));
+    let o6 = input[14].mul(Complex::new(-c2, s2));
+    let o7 = input[15].mul(Complex::new(-c1, s1));
 
-    input[0] = e0.add(t0);
-    input[8] = e0.sub(t0);
-    input[1] = e1.add(t1);
-    input[9] = e1.sub(t1);
-    input[2] = e2.add(t2);
-    input[10] = e2.sub(t2);
-    input[3] = e3.add(t3);
-    input[11] = e3.sub(t3);
-    input[4] = e4.add(t4);
-    input[12] = e4.sub(t4);
-    input[5] = e5.add(t5);
-    input[13] = e5.sub(t5);
-    input[6] = e6.add(t6);
-    input[14] = e6.sub(t6);
-    input[7] = e7.add(t7);
-    input[15] = e7.sub(t7);
+    let e0 = input[0];
+    let e1 = input[1];
+    let e2 = input[2];
+    let e3 = input[3];
+    let e4 = input[4];
+    let e5 = input[5];
+    let e6 = input[6];
+    let e7 = input[7];
+
+    input[0] = e0.add(o0);
+    input[8] = e0.sub(o0);
+    input[1] = e1.add(o1);
+    input[9] = e1.sub(o1);
+    input[2] = e2.add(o2);
+    input[10] = e2.sub(o2);
+    input[3] = e3.add(o3);
+    input[11] = e3.sub(o3);
+    input[4] = e4.add(o4);
+    input[12] = e4.sub(o4);
+    input[5] = e5.add(o5);
+    input[13] = e5.sub(o5);
+    input[6] = e6.add(o6);
+    input[14] = e6.sub(o6);
+    input[7] = e7.add(o7);
+    input[15] = e7.sub(o7);
 }

--- a/tests/small_kernels.rs
+++ b/tests/small_kernels.rs
@@ -1,4 +1,4 @@
-use kofft::fft::{Complex32, ScalarFftImpl};
+use kofft::fft::{fft16, fft8, Complex32, ScalarFftImpl};
 
 fn dft(input: &[Complex32]) -> Vec<Complex32> {
     let n = input.len();
@@ -33,16 +33,25 @@ fn stockham_small_kernels() {
 
 #[test]
 fn direct_fft8_16_kernels() {
-    let fft = ScalarFftImpl::<f32>::default();
-    for &n in &[8usize, 16] {
-        let mut data: Vec<Complex32> = (0..n)
-            .map(|i| Complex32::new((i as f32).sin(), (i as f32).cos()))
-            .collect();
-        let expected = dft(&data);
-        fft.stockham_fft(&mut data).unwrap();
-        for (a, b) in data.iter().zip(expected.iter()) {
-            assert!((a.re - b.re).abs() < 1e-2);
-            assert!((a.im - b.im).abs() < 1e-2);
-        }
+    // Test fft8
+    let mut data: Vec<Complex32> = (0..8)
+        .map(|i| Complex32::new((i as f32).sin(), (i as f32).cos()))
+        .collect();
+    let expected = dft(&data);
+    fft8(&mut data);
+    for (a, b) in data.iter().zip(expected.iter()) {
+        assert!((a.re - b.re).abs() < 1e-2);
+        assert!((a.im - b.im).abs() < 1e-2);
+    }
+
+    // Test fft16
+    let mut data: Vec<Complex32> = (0..16)
+        .map(|i| Complex32::new((i as f32).sin(), (i as f32).cos()))
+        .collect();
+    let expected = dft(&data);
+    fft16(&mut data);
+    for (a, b) in data.iter().zip(expected.iter()) {
+        assert!((a.re - b.re).abs() < 1e-2);
+        assert!((a.im - b.im).abs() < 1e-2);
     }
 }


### PR DESCRIPTION
## Summary
- Optimize `fft8` and `fft16` kernels to compute directly on the input slice without temporary even/odd arrays
- Re-export small FFT kernels from the `fft` module
- Add tests validating the standalone `fft8` and `fft16` implementations

## Testing
- `cargo fmt --all`
- `cargo clippy --all-targets --all-features`
- `cargo test`
- `cargo tarpaulin --version` *(fails: no such command: `tarpaulin`)*

------
https://chatgpt.com/codex/tasks/task_e_689fbe872378832b91cb76a14ba12f38