### PR TITLE
Reuse Bluestein scratch buffers and add allocation benchmarks

### DIFF
--- a/kofft-bench/benches/bench_bluestein.rs
+++ b/kofft-bench/benches/bench_bluestein.rs
@@ -1,0 +1,66 @@
+use std::alloc::{GlobalAlloc, Layout, System};
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::time::{Duration, Instant};
+
+use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
+use kofft::fft::{Complex32, FftImpl, FftPlanner, ScalarFftImpl};
+
+struct CountingAlloc;
+
+static ALLOC: AtomicUsize = AtomicUsize::new(0);
+
+unsafe impl GlobalAlloc for CountingAlloc {
+    unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
+        let ptr = System.alloc(layout);
+        if !ptr.is_null() {
+            ALLOC.fetch_add(1, Ordering::Relaxed);
+        }
+        ptr
+    }
+    unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout) {
+        System.dealloc(ptr, layout);
+    }
+}
+
+#[global_allocator]
+static GLOBAL: CountingAlloc = CountingAlloc;
+
+fn reset_alloc() {
+    ALLOC.store(0, Ordering::Relaxed);
+}
+fn allocs() -> usize {
+    ALLOC.load(Ordering::Relaxed)
+}
+
+fn bench_bluestein(c: &mut Criterion) {
+    let mut group = c.benchmark_group("bluestein_alloc");
+    let sizes = [3usize, 5, 6, 7, 9, 10, 12, 15, 18, 20, 30, 33];
+    for &size in &sizes {
+        group.bench_with_input(BenchmarkId::from_parameter(size), &size, |b, &n| {
+            let input: Vec<Complex32> = (0..n)
+                .map(|i| Complex32::new(i as f32, -(i as f32)))
+                .collect();
+            let planner = FftPlanner::<f32>::new();
+            let fft = ScalarFftImpl::with_planner(planner);
+            let mut data = input.clone();
+            fft.fft(&mut data).unwrap();
+            b.iter_custom(|iters| {
+                let mut data = input.clone();
+                reset_alloc();
+                let mut total = Duration::ZERO;
+                for _ in 0..iters {
+                    data.clone_from_slice(&input);
+                    let start = Instant::now();
+                    fft.fft(&mut data).unwrap();
+                    total += start.elapsed();
+                    assert_eq!(allocs(), 0);
+                }
+                total
+            });
+        });
+    }
+    group.finish();
+}
+
+criterion_group!(benches, bench_bluestein);
+criterion_main!(benches);

--- a/tests/bluestein.rs
+++ b/tests/bluestein.rs
@@ -1,0 +1,66 @@
+use kofft::fft::{Complex32, FftImpl, FftPlanner, ScalarFftImpl};
+use std::alloc::{GlobalAlloc, Layout, System};
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+struct CountingAlloc;
+
+static ALLOC: AtomicUsize = AtomicUsize::new(0);
+
+unsafe impl GlobalAlloc for CountingAlloc {
+    unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
+        let ptr = System.alloc(layout);
+        if !ptr.is_null() {
+            ALLOC.fetch_add(1, Ordering::Relaxed);
+        }
+        ptr
+    }
+    unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout) {
+        System.dealloc(ptr, layout);
+    }
+}
+
+#[global_allocator]
+static GLOBAL: CountingAlloc = CountingAlloc;
+
+fn reset_alloc() {
+    ALLOC.store(0, Ordering::Relaxed);
+}
+fn allocs() -> usize {
+    ALLOC.load(Ordering::Relaxed)
+}
+
+fn dft(input: &[Complex32]) -> Vec<Complex32> {
+    let len = input.len();
+    (0..len)
+        .map(|k| {
+            let mut sum = Complex32::new(0.0, 0.0);
+            for (n, &x) in input.iter().enumerate() {
+                let angle = -2.0 * std::f32::consts::PI * k as f32 * n as f32 / len as f32;
+                let tw = Complex32::new(angle.cos(), angle.sin());
+                sum = sum + x * tw;
+            }
+            sum
+        })
+        .collect()
+}
+
+#[test]
+fn bluestein_fft_matches_dft_and_reuses_scratch() {
+    let n = 15;
+    let input: Vec<Complex32> = (0..n)
+        .map(|i| Complex32::new(i as f32, -(i as f32)))
+        .collect();
+    let expected = dft(&input);
+
+    let planner = FftPlanner::<f32>::new();
+    let fft = ScalarFftImpl::with_planner(planner);
+    let mut data = input.clone();
+    fft.fft(&mut data).unwrap();
+    for (a, b) in data.iter().zip(expected.iter()) {
+        assert!((a.re - b.re).abs() < 1e-3 && (a.im - b.im).abs() < 1e-3);
+    }
+
+    reset_alloc();
+    fft.fft(&mut data).unwrap();
+    assert_eq!(allocs(), 0);
+}


### PR DESCRIPTION
## Summary
- cache Bluestein scratch buffers in `FftPlanner`
- avoid per-call Vec allocation in `fft` by reusing planner scratch
- add test and benchmark covering non-power-of-two sizes

## Testing
- `cargo clippy --all-targets --all-features`
- `cargo test`
- `cargo clippy --all-targets --all-features --manifest-path kofft-bench/Cargo.toml`
- `cargo test --manifest-path kofft-bench/Cargo.toml`


------
https://chatgpt.com/codex/tasks/task_e_689fbe88d258832b8d6414a43612cec9