### PR TITLE
Treat arm64 like aarch64 in arch detection

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ ifeq ($(findstring x86_64,$(ARCH)),x86_64)
   else ifneq ($(findstring sse4_1,$(CPUFLAGS)),)
     SIMD_FEATURES += sse
   endif
-else ifeq ($(ARCH),aarch64)
+else ifneq ($(filter aarch64 arm64,$(ARCH)),)
   SIMD_FEATURES += aarch64
 endif
 

--- a/tests/arm64_arch_detection.rs
+++ b/tests/arm64_arch_detection.rs
@@ -1,0 +1,35 @@
+use std::process::Command;
+
+fn extract_build_line(output: &str) -> Option<&str> {
+    output.lines().find(|line| line.contains("cargo build"))
+}
+
+#[test]
+fn arm64_triggers_aarch64_feature() {
+    let output = Command::new("make")
+        .args(["ARCH=arm64", "-pn", "build"])
+        .output()
+        .expect("failed to run make");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let build_line = extract_build_line(&stdout).expect("missing build command");
+    assert!(
+        build_line.contains("aarch64"),
+        "aarch64 feature not enabled: {}",
+        build_line
+    );
+}
+
+#[test]
+fn aarch64_triggers_aarch64_feature() {
+    let output = Command::new("make")
+        .args(["ARCH=aarch64", "-pn", "build"])
+        .output()
+        .expect("failed to run make");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let build_line = extract_build_line(&stdout).expect("missing build command");
+    assert!(
+        build_line.contains("aarch64"),
+        "aarch64 feature not enabled: {}",
+        build_line
+    );
+}


### PR DESCRIPTION
## Summary
- detect Apple arm64 architecture and enable `aarch64` SIMD features
- test Makefile arch check with arm64 and aarch64 inputs

## Testing
- `cargo clippy --all-targets --all-features`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_689fc3a1198c832b8bfa63bf646ef5f1