### PR TITLE
Handle CPU feature detection for aarch64

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,6 +57,7 @@ optional = true
 [dev-dependencies]
 hound = "3.5"
 image = "0.24"
+tempfile = "3.10"
 
 [[example]]
 name = "basic_usage"

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # Simple Makefile for kofft development
 ARCH := $(shell uname -m)
 # Detect CPU feature flags across platforms
-CPUFLAGS := $(shell lscpu 2>/dev/null | grep -i flags \
+CPUFLAGS := $(shell lscpu 2>/dev/null | grep -iE 'flags|features' \
         || sysctl -n machdep.cpu.features 2>/dev/null \
         || echo)
 # Detect number of processors on both Linux and macOS

--- a/tests/cpuflags_neon.rs
+++ b/tests/cpuflags_neon.rs
@@ -1,0 +1,36 @@
+use std::fs::{self, Permissions};
+use std::os::unix::fs::PermissionsExt;
+use std::process::Command;
+
+#[test]
+fn cpuflags_detects_neon_features() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let lscpu_path = dir.path().join("lscpu");
+    fs::write(
+        &lscpu_path,
+        "#!/bin/sh\necho 'Architecture: aarch64'\necho 'Features: fp asimd evtstrm crc32'\n",
+    )
+    .expect("write script");
+    fs::set_permissions(&lscpu_path, Permissions::from_mode(0o755)).expect("perm");
+
+    let path_env = format!(
+        "{}:{}",
+        dir.path().display(),
+        std::env::var("PATH").unwrap()
+    );
+    let output = Command::new("make")
+        .args(["-pn", "build"])
+        .env("PATH", path_env)
+        .output()
+        .expect("run make");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let cpuflags_line = stdout
+        .lines()
+        .find(|l| l.starts_with("CPUFLAGS :="))
+        .expect("missing CPUFLAGS");
+    assert!(
+        cpuflags_line.contains("asimd"),
+        "NEON feature missing: {}",
+        cpuflags_line
+    );
+}


### PR DESCRIPTION
## Summary
- detect CPU features by matching both `flags` and `features`
- test that NEON (asimd) appears in `CPUFLAGS`

## Testing
- `cargo fmt --all`
- `cargo clippy --all-targets --all-features`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_689fdf368bc8832b92724cf109095813