### PR TITLE
Add precomputed FFT twiddle tables

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ exclude = [
   "tests/*",
   "examples/*",
 ]
+build = "build.rs"
 
 
 [workspace]
@@ -49,6 +50,7 @@ internal-tests = ["proptest", "rand"]
 compile-time-rfft = []
 simd = []
 soa = []
+precomputed-twiddles = ["std"]
 
 [dependencies.rayon]
 version = "1.7"

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,95 @@
+use std::env;
+use std::fs::File;
+use std::io::Write;
+use std::path::PathBuf;
+
+fn main() {
+    const SIZES: &[usize] = &[2, 4, 8, 16, 32, 64, 128, 256, 512, 1024];
+
+    let out_dir = env::var("OUT_DIR").unwrap();
+    let dest_path = PathBuf::from(out_dir).join("precomputed_twiddles.rs");
+    let mut f = File::create(&dest_path).unwrap();
+
+    writeln!(f, "use crate::num::{{Complex32, Complex64}};").unwrap();
+    writeln!(f, "use alloc::sync::Arc;").unwrap();
+    writeln!(f, "use std::sync::OnceLock;").unwrap();
+
+    for &n in SIZES {
+        let half = n / 2;
+        // f32 data and once lock
+        writeln!(
+            f,
+            "pub static TWIDDLES_F32_{n}_DATA: [Complex32; {half}] = ["
+        )
+        .unwrap();
+        for k in 0..half {
+            let angle = -2.0f32 * std::f32::consts::PI * k as f32 / n as f32;
+            let re = angle.cos();
+            let im = angle.sin();
+            writeln!(
+                f,
+                "    Complex32 {{ re: {:.10}f32, im: {:.10}f32 }},",
+                re, im
+            )
+            .unwrap();
+        }
+        writeln!(f, "];\n").unwrap();
+        writeln!(
+            f,
+            "static TWIDDLES_F32_{n}: OnceLock<Arc<[Complex32]>> = OnceLock::new();\n"
+        )
+        .unwrap();
+
+        // f64 data and once lock
+        writeln!(
+            f,
+            "pub static TWIDDLES_F64_{n}_DATA: [Complex64; {half}] = ["
+        )
+        .unwrap();
+        for k in 0..half {
+            let angle = -2.0f64 * std::f64::consts::PI * k as f64 / n as f64;
+            let re = angle.cos();
+            let im = angle.sin();
+            writeln!(
+                f,
+                "    Complex64 {{ re: {:.16}f64, im: {:.16}f64 }},",
+                re, im
+            )
+            .unwrap();
+        }
+        writeln!(f, "];\n").unwrap();
+        writeln!(
+            f,
+            "static TWIDDLES_F64_{n}: OnceLock<Arc<[Complex64]>> = OnceLock::new();\n"
+        )
+        .unwrap();
+    }
+
+    writeln!(
+        f,
+        "pub fn lookup_f32(n: usize) -> Option<Arc<[Complex32]>> {{ match n {{"
+    )
+    .unwrap();
+    for &n in SIZES {
+        writeln!(
+            f,
+            "    {n} => Some(TWIDDLES_F32_{n}.get_or_init(|| Arc::from(TWIDDLES_F32_{n}_DATA.to_vec())).clone()),"
+        )
+        .unwrap();
+    }
+    writeln!(f, "    _ => None, }} }}").unwrap();
+
+    writeln!(
+        f,
+        "pub fn lookup_f64(n: usize) -> Option<Arc<[Complex64]>> {{ match n {{"
+    )
+    .unwrap();
+    for &n in SIZES {
+        writeln!(
+            f,
+            "    {n} => Some(TWIDDLES_F64_{n}.get_or_init(|| Arc::from(TWIDDLES_F64_{n}_DATA.to_vec())).clone()),"
+        )
+        .unwrap();
+    }
+    writeln!(f, "    _ => None, }} }}").unwrap();
+}

--- a/src/fft.rs
+++ b/src/fft.rs
@@ -24,6 +24,7 @@ use core::mem::MaybeUninit;
 use hashbrown::HashMap;
 
 #[cfg(feature = "precomputed-twiddles")]
+#[allow(clippy::excessive_precision)]
 mod precomputed_twiddles {
     include!(concat!(env!("OUT_DIR"), "/precomputed_twiddles.rs"));
 }

--- a/src/fft.rs
+++ b/src/fft.rs
@@ -24,7 +24,7 @@ use core::mem::MaybeUninit;
 use hashbrown::HashMap;
 
 #[cfg(feature = "precomputed-twiddles")]
-#[allow(clippy::excessive_precision)]
+#[allow(clippy::excessive_precision, clippy::approx_constant)]
 mod precomputed_twiddles {
     include!(concat!(env!("OUT_DIR"), "/precomputed_twiddles.rs"));
 }

--- a/tests/static_twiddles.rs
+++ b/tests/static_twiddles.rs
@@ -1,0 +1,35 @@
+use kofft::fft::FftPlanner;
+
+#[cfg(feature = "precomputed-twiddles")]
+#[test]
+fn precomputed_twiddles_share_memory() {
+    let mut p1 = FftPlanner::<f32>::new();
+    let mut p2 = FftPlanner::<f32>::new();
+    let t1 = p1.get_twiddles(16);
+    let t2 = p2.get_twiddles(16);
+    assert_eq!(t1.as_ptr(), t2.as_ptr());
+
+    // f64 coverage
+    let mut q1 = FftPlanner::<f64>::new();
+    let mut q2 = FftPlanner::<f64>::new();
+    let s1 = q1.get_twiddles(32);
+    let s2 = q2.get_twiddles(32);
+    assert_eq!(s1.as_ptr(), s2.as_ptr());
+}
+
+#[cfg(not(feature = "precomputed-twiddles"))]
+#[test]
+fn runtime_twiddles_are_unique() {
+    let mut p1 = FftPlanner::<f32>::new();
+    let mut p2 = FftPlanner::<f32>::new();
+    let t1 = p1.get_twiddles(16);
+    let t2 = p2.get_twiddles(16);
+    assert_ne!(t1.as_ptr(), t2.as_ptr());
+
+    // f64 runtime
+    let mut q1 = FftPlanner::<f64>::new();
+    let mut q2 = FftPlanner::<f64>::new();
+    let s1 = q1.get_twiddles(32);
+    let s2 = q2.get_twiddles(32);
+    assert_ne!(s1.as_ptr(), s2.as_ptr());
+}


### PR DESCRIPTION
## Summary
- generate power-of-two twiddle tables at build time
- load static tables in `FftPlanner` when `precomputed-twiddles` is enabled
- cover static and runtime twiddle paths with tests

## Testing
- `cargo clippy --all-targets -- -A clippy::items-after-test-module -D warnings`
- `cargo clippy --all-targets --features precomputed-twiddles -- -A clippy::items-after-test-module -A clippy::excessive_precision -A clippy::approx_constant -D warnings`
- `cargo test`
- `cargo test --features precomputed-twiddles`
- `cargo tarpaulin --features precomputed-twiddles`

------
https://chatgpt.com/codex/tasks/task_e_68a01d3794bc832b97782c9a3fd48bdb