### PR TITLE
Detect AVX-512 flags and allow extra build features

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,11 @@ SIMD_FEATURES :=
 RUSTFLAGS_ADD :=
 
 ifeq ($(findstring x86_64,$(ARCH)),x86_64)
-  ifneq ($(findstring avx2,$(CPUFLAGS)),)
+  SIMD_FEATURES += x86_64
+  ifneq ($(findstring avx512f,$(CPUFLAGS)),)
+    SIMD_FEATURES += avx512
+    RUSTFLAGS_ADD += -C target-feature=+avx512f,+fma
+  else ifneq ($(findstring avx2,$(CPUFLAGS)),)
     SIMD_FEATURES += avx2
     RUSTFLAGS_ADD += -C target-feature=+avx2,+fma
   else ifneq ($(findstring sse4_1,$(CPUFLAGS)),)
@@ -30,7 +34,8 @@ ifneq ($(shell [ $(NPROC) -gt 1 ] && echo yes),)
   EXAMPLE := parallel_benchmark
 endif
 
-FEATURES := $(strip $(SIMD_FEATURES) $(PAR_FEATURE))
+EXTRA_FEATURES := $(strip $(KOFFT_FEATURES))
+FEATURES := $(strip $(SIMD_FEATURES) $(PAR_FEATURE) $(EXTRA_FEATURES))
 
 .PHONY: build test clippy fmt analyze benchmark bench-libs update-bench-readme sanity
 

--- a/README.md
+++ b/README.md
@@ -355,6 +355,14 @@ automatically select the best implementation.
 SIMD backends are also enabled automatically when compiling with the
 appropriate `target-feature` flags (e.g., `RUSTFLAGS="-C target-feature=+avx2"`).
 
+To opt into additional optional features for local builds, set the
+`KOFFT_FEATURES` environment variable. Any features listed there are appended
+to those detected by the Makefile:
+
+```bash
+KOFFT_FEATURES="simd compile-time-rfft" make test
+```
+
 ### Parallel Processing
 
 Enable the `parallel` feature (using Rayon) as shown above:


### PR DESCRIPTION
## Summary
- auto-enable x86_64 feature and detect AVX-512 CPUs for proper RFFT gating
- allow extra features via `KOFFT_FEATURES` and document usage

## Testing
- `cargo fmt --all`
- `cargo clippy --all-targets --all-features`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68a03b47abec832bb9eab4daec9141c7