### PR TITLE
Add spectrogram overlays and drawing options

### DIFF
--- a/sanity-check/Cargo.toml
+++ b/sanity-check/Cargo.toml
@@ -13,3 +13,4 @@ kofft = { path = ".." }
 indicatif = "0.17"
 colorous = "1"
 svg = "0.10"
+imageproc = "0.23"


### PR DESCRIPTION
## Summary
- add CLI toggles for time ruler, frequency scale, waveform overlay, and status bar
- render simple axis rulers, waveform overlay, and status bar on spectrograms
- include tests for drawing helpers

## Testing
- `cargo clippy -p sanity-check --all-targets --no-deps -- -D warnings`
- `cargo test -p sanity-check`


------
https://chatgpt.com/codex/tasks/task_e_68a0465e07b8832b9502f93f6449d7fc