### PR TITLE
Use parallel STFT in sanity-check

### DIFF
--- a/sanity-check/Cargo.toml
+++ b/sanity-check/Cargo.toml
@@ -13,3 +13,11 @@ kofft = { path = ".." }
 indicatif = "0.17"
 colorous = "1"
 svg = "0.10"
+
+[features]
+default = []
+parallel = ["kofft/parallel"]
+x86_64 = ["kofft/x86_64"]
+aarch64 = ["kofft/aarch64"]
+avx2 = ["kofft/avx2"]
+avx512 = ["kofft/avx512"]


### PR DESCRIPTION
## Summary
- allow enabling kofft's optional features in sanity-check
- run parallel STFT when the `parallel` feature is active
- test STFT helper for parity with sequential version

## Testing
- `cargo clippy --workspace --all-targets`
- `cargo clippy --workspace --all-targets --features parallel`
- `cargo test --workspace`
- `cargo test --workspace --features parallel`
- `cargo test -p sanity-check --features parallel`


------
https://chatgpt.com/codex/tasks/task_e_68a0a1bd8a30832bbfeb38d96477b6d3