### PR TITLE
Avoid unreachable code in SIMD FFT implementations

### DIFF
--- a/src/fft.rs
+++ b/src/fft.rs
@@ -10,6 +10,8 @@ use core::f32::consts::PI;
 
 use alloc::boxed::Box;
 use alloc::sync::Arc;
+#[cfg(all(feature = "parallel", feature = "std"))]
+use alloc::vec;
 use alloc::vec::Vec;
 use core::any::Any;
 #[cfg(feature = "precomputed-twiddles")]

--- a/src/fft.rs
+++ b/src/fft.rs
@@ -10,7 +10,6 @@ use core::f32::consts::PI;
 
 use alloc::boxed::Box;
 use alloc::sync::Arc;
-use alloc::vec;
 use alloc::vec::Vec;
 use core::any::Any;
 #[cfg(feature = "precomputed-twiddles")]
@@ -1731,13 +1730,16 @@ impl FftImpl<f32> for SimdFftX86_64Impl {
     fn fft(&self, input: &mut [Complex32]) -> Result<(), FftError> {
         #[cfg(any(target_feature = "avx2", target_feature = "avx512f"))]
         {
-            return self.fft_simd(input);
+            self.fft_simd(input)
         }
-        let scalar = ScalarFftImpl::<f32>::default();
-        if input.len().is_power_of_two() {
-            scalar.stockham_fft(input)
-        } else {
-            scalar.fft(input)
+        #[cfg(not(any(target_feature = "avx2", target_feature = "avx512f")))]
+        {
+            let scalar = ScalarFftImpl::<f32>::default();
+            if input.len().is_power_of_two() {
+                scalar.stockham_fft(input)
+            } else {
+                scalar.fft(input)
+            }
         }
     }
     fn ifft(&self, input: &mut [Complex32]) -> Result<(), FftError> {
@@ -1807,13 +1809,16 @@ impl FftImpl<f32> for SimdFftAarch64Impl {
     fn fft(&self, input: &mut [Complex32]) -> Result<(), FftError> {
         #[cfg(target_feature = "neon")]
         {
-            return self.fft_simd(input);
+            self.fft_simd(input)
         }
-        let scalar = ScalarFftImpl::<f32>::default();
-        if input.len().is_power_of_two() {
-            scalar.stockham_fft(input)
-        } else {
-            scalar.fft(input)
+        #[cfg(not(target_feature = "neon"))]
+        {
+            let scalar = ScalarFftImpl::<f32>::default();
+            if input.len().is_power_of_two() {
+                scalar.stockham_fft(input)
+            } else {
+                scalar.fft(input)
+            }
         }
     }
     fn ifft(&self, input: &mut [Complex32]) -> Result<(), FftError> {
@@ -1883,13 +1888,16 @@ impl FftImpl<f32> for SimdFftWasmImpl {
     fn fft(&self, input: &mut [Complex32]) -> Result<(), FftError> {
         #[cfg(target_feature = "simd128")]
         {
-            return self.fft_simd(input);
+            self.fft_simd(input)
         }
-        let scalar = ScalarFftImpl::<f32>::default();
-        if input.len().is_power_of_two() {
-            scalar.stockham_fft(input)
-        } else {
-            scalar.fft(input)
+        #[cfg(not(target_feature = "simd128"))]
+        {
+            let scalar = ScalarFftImpl::<f32>::default();
+            if input.len().is_power_of_two() {
+                scalar.stockham_fft(input)
+            } else {
+                scalar.fft(input)
+            }
         }
     }
     fn ifft(&self, input: &mut [Complex32]) -> Result<(), FftError> {

--- a/tests/fft_arch_parity.rs
+++ b/tests/fft_arch_parity.rs
@@ -1,0 +1,39 @@
+#![cfg(any(
+    target_arch = "x86_64",
+    target_arch = "aarch64",
+    target_arch = "wasm32"
+))]
+use kofft::fft::{Complex32, FftImpl, ScalarFftImpl};
+
+#[test]
+fn fft_matches_scalar() {
+    let input: Vec<Complex32> = (0..16).map(|i| Complex32::new(i as f32, 0.0)).collect();
+    let mut simd_input = input.clone();
+    let mut scalar_input = input.clone();
+
+    let scalar = ScalarFftImpl::<f32>::default();
+    scalar.fft(&mut scalar_input).unwrap();
+
+    #[cfg(target_arch = "x86_64")]
+    {
+        use kofft::fft::SimdFftX86_64Impl;
+        let simd = SimdFftX86_64Impl;
+        simd.fft(&mut simd_input).unwrap();
+    }
+    #[cfg(target_arch = "aarch64")]
+    {
+        use kofft::fft::SimdFftAarch64Impl;
+        let simd = SimdFftAarch64Impl;
+        simd.fft(&mut simd_input).unwrap();
+    }
+    #[cfg(target_arch = "wasm32")]
+    {
+        use kofft::fft::SimdFftWasmImpl;
+        let simd = SimdFftWasmImpl;
+        simd.fft(&mut simd_input).unwrap();
+    }
+
+    for (a, b) in scalar_input.iter().zip(simd_input.iter()) {
+        assert!((a.re - b.re).abs() < 1e-5 && (a.im - b.im).abs() < 1e-5);
+    }
+}


### PR DESCRIPTION
## Summary
- gate scalar fallback code to prevent unreachable statements in SIMD FFT implementations
- add cross-architecture test ensuring SIMD FFT matches scalar FFT

## Testing
- `cargo fmt`
- `cargo clippy`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68a0b22eec6c832b8370a3b20fc7ab5c