### PR TITLE
Add Web Spectrogram UI and tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,4 @@ proptest-regressions/
 # Byproducts
 *.profraw
 *.profdata
+node_modules/

--- a/web-spectrogram/static/app.js
+++ b/web-spectrogram/static/app.js
@@ -1,0 +1,69 @@
+export async function decodeAndProcess(file, audioEl, wasm = globalThis) {
+  const AudioCtx = window.AudioContext || window.webkitAudioContext;
+  const ctx = new AudioCtx();
+  const buf = await file.arrayBuffer();
+  const audioBuffer = await ctx.decodeAudioData(buf);
+  const pcm = audioBuffer.getChannelData(0);
+  if (typeof wasm.process_pcm === "function") {
+    wasm.process_pcm(pcm);
+  }
+  audioEl.src = URL.createObjectURL(file);
+  return { ctx, audioBuffer };
+}
+
+export function setupPlayback(audioEl, seekInput) {
+  audioEl.addEventListener("timeupdate", () => {
+    seekInput.max = audioEl.duration || 0;
+    seekInput.value = audioEl.currentTime;
+  });
+  seekInput.addEventListener("input", () => {
+    audioEl.currentTime = Number(seekInput.value);
+  });
+}
+
+export function startRenderLoop(canvas, analyser) {
+  const ctx = canvas.getContext("2d");
+  const data = new Uint8Array(analyser.frequencyBinCount);
+  function render() {
+    analyser.getByteFrequencyData(data);
+    const img = ctx.getImageData(0, 0, canvas.width, canvas.height - 1);
+    ctx.putImageData(img, 0, 1);
+    for (let x = 0; x < Math.min(canvas.width, data.length); x++) {
+      const v = data[x];
+      ctx.fillStyle = `rgb(${v},${v},${v})`;
+      ctx.fillRect(x, 0, 1, 1);
+    }
+    requestAnimationFrame(render);
+  }
+  requestAnimationFrame(render);
+}
+
+export function init(
+  doc = document,
+  deps = { decodeAndProcess, setupPlayback, startRenderLoop },
+) {
+  const fileInput = doc.querySelector("input[type=file]");
+  const audio = doc.querySelector("audio");
+  const seek = doc.querySelector("input[type=range]");
+  const canvas = doc.getElementById("spectrogram");
+  canvas.width = canvas.clientWidth * (window.devicePixelRatio || 1);
+  canvas.height = canvas.clientHeight * (window.devicePixelRatio || 1);
+
+  fileInput.addEventListener("change", async (e) => {
+    const file = e.target.files[0];
+    if (!file) return;
+    const { ctx, audioBuffer } = await deps.decodeAndProcess(file, audio);
+    const source = ctx.createBufferSource();
+    source.buffer = audioBuffer;
+    const analyser = ctx.createAnalyser();
+    source.connect(analyser);
+    analyser.connect(ctx.destination);
+    deps.setupPlayback(audio, seek);
+    deps.startRenderLoop(canvas, analyser);
+    source.start();
+  });
+}
+
+if (typeof document !== "undefined") {
+  document.addEventListener("DOMContentLoaded", () => init());
+}

--- a/web-spectrogram/static/app.test.js
+++ b/web-spectrogram/static/app.test.js
@@ -1,0 +1,123 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { JSDOM } from "jsdom";
+import {
+  decodeAndProcess,
+  setupPlayback,
+  startRenderLoop,
+  init,
+} from "./app.js";
+
+test("decodeAndProcess decodes audio and invokes wasm", async () => {
+  globalThis.window = {
+    AudioContext: class {
+      async decodeAudioData() {
+        return {
+          getChannelData: () => new Float32Array([0, 1, 0, -1]),
+        };
+      }
+    },
+    devicePixelRatio: 1,
+  };
+  const file = { arrayBuffer: async () => new ArrayBuffer(8) };
+  let called = false;
+  const wasm = {
+    process_pcm: (pcm) => {
+      called = pcm.length === 4;
+    },
+  };
+  globalThis.URL = { createObjectURL: () => "blob:url" };
+  const audio = { src: "" };
+  await decodeAndProcess(file, audio, wasm);
+  assert.equal(audio.src, "blob:url");
+  assert.ok(called);
+});
+
+test("setupPlayback syncs seek with audio", () => {
+  const dom = new JSDOM(`<audio></audio><input type="range">`);
+  const audio = dom.window.document.querySelector("audio");
+  const seek = dom.window.document.querySelector("input");
+  audio.currentTime = 0;
+  setupPlayback(audio, seek);
+  Object.defineProperty(audio, "duration", { value: 10 });
+  audio.currentTime = 5;
+  audio.dispatchEvent(new dom.window.Event("timeupdate"));
+  assert.equal(seek.value, "5");
+  seek.value = "2";
+  seek.dispatchEvent(new dom.window.Event("input"));
+  assert.equal(audio.currentTime, 2);
+});
+
+test("startRenderLoop draws to canvas", () => {
+  let put = false;
+  let drawn = 0;
+  const canvas = {
+    width: 2,
+    height: 2,
+    getContext: () => ({
+      getImageData: () => ({ data: new Uint8ClampedArray(4) }),
+      putImageData: () => {
+        put = true;
+      },
+      fillStyle: "#000",
+      fillRect: () => {
+        drawn++;
+      },
+    }),
+  };
+  const analyser = {
+    frequencyBinCount: 2,
+    getByteFrequencyData: (arr) => arr.fill(1),
+  };
+  let rafCalled = false;
+  globalThis.requestAnimationFrame = (cb) => {
+    if (rafCalled) return;
+    rafCalled = true;
+    cb();
+  };
+  startRenderLoop(canvas, analyser);
+  assert.ok(put);
+  assert.equal(drawn, 2);
+});
+
+test("init wires up file input change", async () => {
+  const dom = new JSDOM(
+    `<input type="file"><audio></audio><input type="range"><canvas id="spectrogram" width="10" height="10"></canvas>`,
+  );
+  globalThis.window = dom.window;
+  globalThis.document = dom.window.document;
+  dom.window.URL.createObjectURL = () => "blob:url";
+  const file = { arrayBuffer: async () => new ArrayBuffer(8) };
+  let setupCalled = false;
+  let renderCalled = false;
+  const deps = {
+    decodeAndProcess: async () => ({
+      ctx: {
+        createBufferSource: () => ({
+          buffer: null,
+          connect: () => {},
+          start: () => {},
+        }),
+        createAnalyser: () => ({
+          connect: () => {},
+          frequencyBinCount: 2,
+          getByteFrequencyData: () => {},
+        }),
+        destination: {},
+      },
+      audioBuffer: {},
+    }),
+    setupPlayback: () => {
+      setupCalled = true;
+    },
+    startRenderLoop: () => {
+      renderCalled = true;
+    },
+  };
+  init(dom.window.document, deps);
+  const input = dom.window.document.querySelector("input[type=file]");
+  Object.defineProperty(input, "files", { value: [file] });
+  input.dispatchEvent(new dom.window.Event("change"));
+  await new Promise((r) => setTimeout(r, 0));
+  assert.ok(setupCalled && renderCalled);
+});

--- a/web-spectrogram/static/index.html
+++ b/web-spectrogram/static/index.html
@@ -1,0 +1,18 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Spectrogram</title>
+    <link rel="stylesheet" href="style.css" />
+  </head>
+  <body>
+    <div id="app">
+      <input id="file" type="file" accept="audio/*" />
+      <audio id="player" controls></audio>
+      <input id="seek" type="range" min="0" value="0" step="0.01" />
+      <canvas id="spectrogram"></canvas>
+    </div>
+    <script type="module" src="app.js"></script>
+  </body>
+</html>

--- a/web-spectrogram/static/style.css
+++ b/web-spectrogram/static/style.css
@@ -1,0 +1,24 @@
+body {
+  margin: 0;
+  background: #111;
+  color: #eee;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  font-family: sans-serif;
+}
+
+#app {
+  width: 100%;
+  max-width: 800px;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  padding: 1rem;
+}
+
+canvas {
+  width: 100%;
+  height: 300px;
+  background: #000;
+}


### PR DESCRIPTION
## Summary
- Add static HTML, CSS, and JS files for an audio spectrogram viewer
- Wire up Web Audio playback, range seeking, and waterfall rendering
- Include Node-based tests and ignore node_modules

## Testing
- `cargo fmt --all`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test`
- `node --test web-spectrogram/static/app.test.js --experimental-default-type=module --experimental-test-coverage --test-coverage-lines=90 --test-coverage-include=web-spectrogram/static/app.js`


------
https://chatgpt.com/codex/tasks/task_e_68a0c9c763e4832b8bcfd7888170ad38