### PR TITLE
Add streaming spectrogram helpers for wasm

### DIFF
--- a/web-spectrogram/Cargo.toml
+++ b/web-spectrogram/Cargo.toml
@@ -9,7 +9,7 @@ crate-type = ["cdylib"]
 [dependencies]
 wasm-bindgen = "0.2"
 web-sys = "0.3"
-kofft = { path = "..", features = ["wasm"], default-features = true }
+kofft = { path = "..", features = ["wasm", "simd"], default-features = true }
 axum = "0.7"
 tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
 tower-http = { version = "0.5", features = ["fs", "cors"] }


### PR DESCRIPTION
## Summary
- export `compute_frame`, `set_colormap`, and `reset_state` for streaming spectrograms
- maintain FFT window state and use configurable colormaps
- enable `wasm`/`simd` features for kofft in web-spectrogram

## Testing
- `cargo fmt --all`
- `cargo clippy --all-targets --all-features`
- `cargo test --all`
- `cargo tarpaulin --manifest-path web-spectrogram/Cargo.toml --ignore-tests --exclude-files '../*' --fail-under 90` *(fails: Coverage is below the failure threshold 13.15% < 90.00%)*

------
https://chatgpt.com/codex/tasks/task_e_68a0cd0c0a70832bba4c23e63924cdb5