### PR TITLE
Add spectrogram WASM tests and coverage gating

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -17,7 +17,9 @@ jobs:
       - name: Install cargo-llvm-cov
         uses: taiki-e/install-action@cargo-llvm-cov
       - name: Run coverage
-        run: cargo llvm-cov --features internal-tests ${{ matrix.features }} --lcov --output-path lcov.info
+        run: >
+          cargo llvm-cov --features internal-tests ${{ matrix.features }} \
+            --fail-under-lines 90 --lcov --output-path lcov.info
       - name: Upload coverage to Codecov
         if: ${{ secrets.CODECOV_TOKEN != '' }}
         uses: codecov/codecov-action@v4

--- a/web-spectrogram/Cargo.toml
+++ b/web-spectrogram/Cargo.toml
@@ -4,17 +4,24 @@ version = "0.1.0"
 edition = "2021"
 
 [lib]
-crate-type = ["cdylib"]
+crate-type = ["cdylib", "rlib"]
+
 
 [dependencies]
 wasm-bindgen = "0.2"
 web-sys = "0.3"
 kofft = { path = "..", features = ["wasm", "simd"], default-features = true }
+
+[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 axum = "0.7"
 tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
 tower-http = { version = "0.5", features = ["fs", "cors"] }
 
 [dev-dependencies]
+wasm-bindgen-test = "0.3"
+
+[target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
 tempfile = "3"
 http = "1"
 tower = { version = "0.5", features = ["util"] }
+hyper = { version = "1", features = ["client", "http1", "http2"] }

--- a/web-spectrogram/Cargo.toml
+++ b/web-spectrogram/Cargo.toml
@@ -25,3 +25,4 @@ tempfile = "3"
 http = "1"
 tower = { version = "0.5", features = ["util"] }
 hyper = { version = "1", features = ["client", "http1", "http2"] }
+http-body-util = "0.1"

--- a/web-spectrogram/src/main.rs
+++ b/web-spectrogram/src/main.rs
@@ -13,7 +13,7 @@ fn app(static_dir: impl AsRef<Path>) -> Router {
     let service = get_service(
         ServeDir::new(dir)
             .append_index_html_on_directories(true)
-            .not_found_service(ServeFile::new(dir.join("index.html"))),
+            .fallback(ServeFile::new(dir.join("index.html"))),
     );
 
     Router::new()

--- a/web-spectrogram/src/main.rs
+++ b/web-spectrogram/src/main.rs
@@ -37,7 +37,7 @@ mod tests {
     use super::*;
     use axum::body::Body;
     use http::{header, Request};
-    use hyper::body::to_bytes;
+    use http_body_util::BodyExt;
     use std::fs;
     use tempfile::tempdir;
     use tower::util::ServiceExt;
@@ -101,7 +101,7 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(res.status(), StatusCode::OK);
-        let body = to_bytes(res.into_body()).await.unwrap();
-        assert_eq!(&body[..], b"index");
+        let body = res.into_body().collect().await.unwrap().to_bytes();
+        assert_eq!(body.as_ref(), b"index");
     }
 }

--- a/web-spectrogram/tests/wasm.rs
+++ b/web-spectrogram/tests/wasm.rs
@@ -1,0 +1,57 @@
+#![cfg(target_arch = "wasm32")]
+
+use kofft::visual::spectrogram::{
+    color_from_magnitude_u8 as core_color_from_magnitude_u8, Colormap as KColormap,
+};
+use wasm_bindgen_test::wasm_bindgen_test;
+use web_spectrogram::{
+    color_from_magnitude_u8, compute_frame, reset_state, stft_magnitudes, Colormap,
+};
+
+const WIN_LEN: usize = 1024;
+const HOP: usize = WIN_LEN / 2;
+
+#[wasm_bindgen_test]
+fn color_mapping_for_sample_magnitude() {
+    let mag = 0.25;
+    let max_mag = 1.0;
+    let floor_db = -60.0;
+    let wasm_color = color_from_magnitude_u8(mag, max_mag, floor_db, Colormap::Viridis);
+    let core_color = core_color_from_magnitude_u8(mag, max_mag, floor_db, KColormap::Viridis);
+    assert_eq!(wasm_color, core_color.to_vec());
+}
+
+#[wasm_bindgen_test]
+fn frame_synchronization_when_seeking_or_pausing() {
+    reset_state();
+    let full = compute_frame(&vec![1.0; WIN_LEN]);
+
+    reset_state();
+    let partial = compute_frame(&vec![1.0; HOP]);
+    assert!(partial.is_empty());
+    let resumed = compute_frame(&vec![1.0; HOP]);
+    assert_eq!(full, resumed);
+
+    reset_state();
+    let after_seek = compute_frame(&vec![1.0; WIN_LEN]);
+    assert_eq!(full, after_seek);
+}
+
+#[wasm_bindgen_test]
+fn stft_output_stable_for_sine_wave() {
+    let k = 5; // frequency bin
+    let samples: Vec<f32> = (0..WIN_LEN)
+        .map(|n| (2.0 * std::f32::consts::PI * k as f32 * n as f32 / WIN_LEN as f32).sin())
+        .collect();
+    let res = stft_magnitudes(&samples, WIN_LEN, HOP).unwrap();
+    assert_eq!(res.width(), 1);
+    let mags = res.mags();
+    let height = res.height();
+    let max_idx = mags[..height]
+        .iter()
+        .enumerate()
+        .max_by(|a, b| a.1.partial_cmp(b.1).unwrap())
+        .unwrap()
+        .0;
+    assert_eq!(max_idx, k);
+}


### PR DESCRIPTION
## Summary
- add wasm-bindgen tests for color mapping, frame sync, and sine STFT
- exercise index fallback in web server tests
- require at least 90% coverage via cargo llvm-cov

## Testing
- `cargo clippy --all-targets --all-features`
- `cargo test`
- `cargo test -p web-spectrogram --target wasm32-unknown-unknown --lib` *(fails: could not execute `.wasm` test binary)*


------
https://chatgpt.com/codex/tasks/task_e_68a0d4d9e4c8832b9ad156a1fa2fa260