### PR TITLE
Add web spectrogram xtask command

### DIFF
--- a/xtask/src/lib.rs
+++ b/xtask/src/lib.rs
@@ -189,6 +189,15 @@ pub fn sanity_command(input: &str, output: &str) -> Command {
     cmd
 }
 
+pub fn web_spectrogram_command() -> Command {
+    let mut cmd = Command::new("sh");
+    cmd.args([
+        "-c",
+        "cd web-spectrogram && ./build.sh && cargo run -p web-spectrogram",
+    ]);
+    cmd
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -286,6 +295,16 @@ mod tests {
         assert!(args.contains(&"sanity-check".to_string()));
         assert!(args.contains(&"in.flac".to_string()));
         assert!(args.contains(&"out.png".to_string()));
+        let wcmd = web_spectrogram_command();
+        assert_eq!(wcmd.get_program(), "sh");
+        let wargs: Vec<_> = wcmd
+            .get_args()
+            .map(|a| a.to_str().unwrap().to_string())
+            .collect();
+        assert!(wargs.contains(&"-c".to_string()));
+        assert!(wargs
+            .iter()
+            .any(|a| a.contains("cd web-spectrogram && ./build.sh && cargo run")));
     }
 
     #[test]

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -21,6 +21,8 @@ enum Commands {
     BenchLibs,
     #[command(name = "update-bench-readme")]
     UpdateBenchReadme,
+    #[command(name = "web-spectrogram")]
+    WebSpectrogram,
     Sanity {
         /// Path to input audio file
         input: String,
@@ -50,8 +52,23 @@ fn main() -> std::io::Result<()> {
         Commands::Benchmark => benchmark_command(&cfg).status(),
         Commands::BenchLibs => bench_libs_command(&cfg).status(),
         Commands::UpdateBenchReadme => update_bench_readme_command(&cfg).status(),
+        Commands::WebSpectrogram => web_spectrogram_command().status(),
         Commands::Sanity { input, output } => sanity_command(&input, &output).status(),
     }?;
 
     std::process::exit(status.code().unwrap_or(1));
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_web_spectrogram_command() {
+        let cli = Cli::parse_from(["xtask", "web-spectrogram"]);
+        match cli.command {
+            Commands::WebSpectrogram => {}
+            _ => panic!("parsed wrong command"),
+        }
+    }
 }


### PR DESCRIPTION
## Summary
- add `web-spectrogram` subcommand to xtask to build wasm and run server
- support building and serving with `web_spectrogram_command`
- test command construction and CLI parsing

## Testing
- `cargo fmt --all`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68a0d8979198832bae5de92378f721e8