### PR TITLE
docs: document web spectrogram options

### DIFF
--- a/README.md
+++ b/README.md
@@ -608,4 +608,5 @@ cargo xtask sanity -- <path-to-flac>  # Run the sanity check example
 - [API Documentation](https://docs.rs/kofft)
 - [Repository](https://github.com/kianostad/kofft)
 - [Crates.io](https://crates.io/crates/kofft)
+- [Web Spectrogram Demo](web-spectrogram/README.md)
 

--- a/web-spectrogram/README.md
+++ b/web-spectrogram/README.md
@@ -1,0 +1,53 @@
+# Web Spectrogram
+
+The `web-spectrogram` package provides a WebAssembly-powered spectrogram viewer. It exposes several runtime options that can be controlled from the demo UI or programmatically from JavaScript.
+
+## Colormaps
+
+The spectrogram supports multiple colour palettes:
+
+- `fire`
+- `legacy`
+- `gray`
+- `viridis`
+- `plasma`
+- `inferno`
+- `rainbow`
+
+**UI:** Use the colormap selector in the demo to choose a palette.
+
+**API:** Call `set_colormap` with one of the above names after initialising the wasm module:
+
+```js
+import init, { set_colormap } from "web_spectrogram";
+
+await init();
+set_colormap("viridis");
+```
+
+## Orientation
+
+Time can run horizontally (left→right) or vertically (top→bottom).
+
+**UI:** Toggle the orientation control to switch between horizontal and vertical layouts.
+
+**API:** Apply a CSS class or transform to the `<canvas>` element:
+
+```js
+// rotate 90deg to make time advance vertically
+canvas.classList.toggle("vertical");
+```
+
+## Theme Switching
+
+Light and dark themes are available.
+
+**UI:** Use the theme switcher to toggle between light and dark modes.
+
+**API:** Set the document's theme attribute:
+
+```js
+document.body.dataset.theme = "light"; // or "dark"
+```
+
+Refer back to this file whenever you need details on the available options and how to use them.

--- a/web-spectrogram/static/index.html
+++ b/web-spectrogram/static/index.html
@@ -12,6 +12,7 @@
       <audio id="player" controls></audio>
       <input id="seek" type="range" min="0" value="0" step="0.01" />
       <canvas id="spectrogram"></canvas>
+      <p><a href="../README.md">Usage &amp; options</a></p>
     </div>
     <script type="module" src="app.js"></script>
   </body>


### PR DESCRIPTION
## Summary
- add README for web spectrogram explaining colormap, orientation, and theme options
- link web spectrogram docs from root README and demo index

## Testing
- no tests run (documentation-only changes)

------
https://chatgpt.com/codex/tasks/task_e_68a0e836f824832bae305457b8e7e264