### PR TITLE
Switch default colormap to Rainbow and add web theme selector

### DIFF
--- a/web-spectrogram/src/lib.rs
+++ b/web-spectrogram/src/lib.rs
@@ -122,7 +122,7 @@ impl State {
             buf: Vec::new(),
             fft: new_fft_impl(),
             window: hann(WIN_LEN),
-            cmap: KColormap::Fire,
+            cmap: KColormap::Rainbow,
             max_mag: 1e-12,
         }
     }
@@ -133,8 +133,8 @@ impl State {
             return Vec::new();
         }
         let mut frame = vec![Complex32::new(0.0, 0.0); WIN_LEN];
-        for i in 0..WIN_LEN {
-            frame[i] = Complex32::new(self.buf[i] * self.window[i], 0.0);
+        for (f, (&s, &w)) in frame.iter_mut().zip(self.buf.iter().zip(&self.window)) {
+            *f = Complex32::new(s * w, 0.0);
         }
         let _ = self.fft.fft(&mut frame);
         let half = WIN_LEN / 2;
@@ -246,15 +246,17 @@ mod tests {
         for chunk in frame.chunks_exact(4) {
             assert_eq!(chunk[3], 255);
         }
+        // default colormap should be rainbow
         reset_state();
-        set_colormap("gray");
-        let gray_frame = compute_frame(&vec![1.0; WIN_LEN]);
+        let default_frame = compute_frame(&vec![1.0; WIN_LEN]);
         reset_state();
-        let fire_frame = {
-            set_colormap("fire");
-            compute_frame(&vec![1.0; WIN_LEN])
-        };
-        assert_ne!(gray_frame, fire_frame);
+        set_colormap("rainbow");
+        let rainbow_frame = compute_frame(&vec![1.0; WIN_LEN]);
+        reset_state();
+        set_colormap("fire");
+        let fire_frame = compute_frame(&vec![1.0; WIN_LEN]);
+        assert_eq!(default_frame, rainbow_frame);
+        assert_ne!(default_frame, fire_frame);
     }
 
     #[test]

--- a/web-spectrogram/static/app.js
+++ b/web-spectrogram/static/app.js
@@ -46,8 +46,16 @@ export function init(
   const audio = doc.querySelector("audio");
   const seek = doc.querySelector("input[type=range]");
   const canvas = doc.getElementById("spectrogram");
+  const themeSelect = doc.getElementById("theme");
   canvas.width = canvas.clientWidth * (window.devicePixelRatio || 1);
   canvas.height = canvas.clientHeight * (window.devicePixelRatio || 1);
+
+  if (themeSelect) {
+    doc.body.dataset.theme = themeSelect.value;
+    themeSelect.addEventListener("change", () => {
+      doc.body.dataset.theme = themeSelect.value;
+    });
+  }
 
   fileInput.addEventListener("change", async (e) => {
     const file = e.target.files[0];

--- a/web-spectrogram/static/app.test.js
+++ b/web-spectrogram/static/app.test.js
@@ -82,7 +82,7 @@ test("startRenderLoop draws to canvas", () => {
 
 test("init wires up file input change", async () => {
   const dom = new JSDOM(
-    `<input type="file"><audio></audio><input type="range"><canvas id="spectrogram" width="10" height="10"></canvas>`,
+    `<input type="file"><audio></audio><input type="range"><canvas id="spectrogram" width="10" height="10"></canvas><select id="theme"><option value="dark">dark</option><option value="light">light</option></select>`,
   );
   globalThis.window = dom.window;
   globalThis.document = dom.window.document;
@@ -120,4 +120,37 @@ test("init wires up file input change", async () => {
   input.dispatchEvent(new dom.window.Event("change"));
   await new Promise((r) => setTimeout(r, 0));
   assert.ok(setupCalled && renderCalled);
+});
+
+test("theme selector updates body dataset", () => {
+  const dom = new JSDOM(
+    `<input type="file"><audio></audio><input type="range"><canvas id="spectrogram"></canvas><select id="theme"><option value="dark">dark</option><option value="light">light</option></select>`,
+  );
+  globalThis.window = dom.window;
+  globalThis.document = dom.window.document;
+  const deps = {
+    decodeAndProcess: async () => ({
+      ctx: {
+        createBufferSource: () => ({
+          buffer: null,
+          connect: () => {},
+          start: () => {},
+        }),
+        createAnalyser: () => ({
+          connect: () => {},
+          frequencyBinCount: 2,
+          getByteFrequencyData: () => {},
+        }),
+        destination: {},
+      },
+      audioBuffer: {},
+    }),
+    setupPlayback: () => {},
+    startRenderLoop: () => {},
+  };
+  init(dom.window.document, deps);
+  const select = dom.window.document.getElementById("theme");
+  select.value = "light";
+  select.dispatchEvent(new dom.window.Event("change"));
+  assert.equal(dom.window.document.body.dataset.theme, "light");
 });

--- a/web-spectrogram/static/index.html
+++ b/web-spectrogram/static/index.html
@@ -11,6 +11,10 @@
       <input id="file" type="file" accept="audio/*" />
       <audio id="player" controls></audio>
       <input id="seek" type="range" min="0" value="0" step="0.01" />
+      <select id="theme">
+        <option value="dark" selected>Dark</option>
+        <option value="light">Light</option>
+      </select>
       <canvas id="spectrogram"></canvas>
       <p><a href="../README.md">Usage &amp; options</a></p>
     </div>

--- a/web-spectrogram/static/style.css
+++ b/web-spectrogram/static/style.css
@@ -8,6 +8,11 @@ body {
   font-family: sans-serif;
 }
 
+body[data-theme="light"] {
+  background: #fff;
+  color: #000;
+}
+
 #app {
   width: 100%;
   max-width: 800px;
@@ -21,4 +26,8 @@ canvas {
   width: 100%;
   height: 300px;
   background: #000;
+}
+
+body[data-theme="light"] canvas {
+  background: #fff;
 }


### PR DESCRIPTION
## Summary
- Use the Rainbow palette as the default spectrogram colormap
- Enable light/dark theme switching on the web demo
- Cover new behavior with tests and resolve clippy warning

## Testing
- `node --test web-spectrogram/static/app.test.js`
- `cargo clippy -p web-spectrogram -- -D warnings`
- `cargo test -p web-spectrogram`


------
https://chatgpt.com/codex/tasks/task_e_68a0ea3898cc832bafb92bb39a7a0a76