### PR TITLE
Orient spectrogram vertically

### DIFF
--- a/web-spectrogram/static/app.js
+++ b/web-spectrogram/static/app.js
@@ -24,14 +24,21 @@ export function setupPlayback(audioEl, seekInput) {
 export function startRenderLoop(canvas, analyser) {
   const ctx = canvas.getContext("2d");
   const data = new Uint8Array(analyser.frequencyBinCount);
+  // Ensure the canvas height matches the frequency bin count while
+  // preserving the original aspect ratio.
+  const aspect = canvas.width / canvas.height;
+  if (canvas.height !== data.length) {
+    canvas.height = data.length;
+    canvas.width = Math.round(canvas.height * aspect);
+  }
   function render() {
     analyser.getByteFrequencyData(data);
-    const img = ctx.getImageData(0, 0, canvas.width, canvas.height - 1);
-    ctx.putImageData(img, 0, 1);
-    for (let x = 0; x < Math.min(canvas.width, data.length); x++) {
-      const v = data[x];
+    const img = ctx.getImageData(1, 0, canvas.width - 1, canvas.height);
+    ctx.putImageData(img, 0, 0);
+    for (let y = 0; y < Math.min(canvas.height, data.length); y++) {
+      const v = data[y];
       ctx.fillStyle = `rgb(${v},${v},${v})`;
-      ctx.fillRect(x, 0, 1, 1);
+      ctx.fillRect(canvas.width - 1, y, 1, 1);
     }
     requestAnimationFrame(render);
   }


### PR DESCRIPTION
## Summary
- orient spectrogram so time advances left-to-right and frequencies map vertically
- keep canvas aspect ratio when aligning to analyser bins
- test render loop draws vertical column and shifts existing image left

## Testing
- `npx prettier web-spectrogram/static/app.test.js web-spectrogram/static/app.js -w`
- `npx eslint web-spectrogram/static/app.js web-spectrogram/static/app.test.js` *(fails: ESLint couldn't find an eslint.config file)*
- `node --test --experimental-test-coverage web-spectrogram/static/app.test.js`
- `node web-spectrogram/static/app.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68a0ea84dabc832b9e3e16ea2ae7400f