### PR TITLE
Use media element audio source in spectrogram demo

### DIFF
--- a/web-spectrogram/static/app.js
+++ b/web-spectrogram/static/app.js
@@ -49,18 +49,21 @@ export function init(
   canvas.width = canvas.clientWidth * (window.devicePixelRatio || 1);
   canvas.height = canvas.clientHeight * (window.devicePixelRatio || 1);
 
+  deps.setupPlayback(audio, seek);
+
+  let ctx;
   fileInput.addEventListener("change", async (e) => {
     const file = e.target.files[0];
     if (!file) return;
-    const { ctx, audioBuffer } = await deps.decodeAndProcess(file, audio);
-    const source = ctx.createBufferSource();
-    source.buffer = audioBuffer;
+    if (ctx) {
+      await ctx.close();
+    }
+    ({ ctx } = await deps.decodeAndProcess(file, audio));
     const analyser = ctx.createAnalyser();
+    const source = ctx.createMediaElementSource(audio);
     source.connect(analyser);
     analyser.connect(ctx.destination);
-    deps.setupPlayback(audio, seek);
     deps.startRenderLoop(canvas, analyser);
-    source.start();
   });
 }
 


### PR DESCRIPTION
## Summary
- use `createMediaElementSource` for spectrogram demo audio playback
- close previous AudioContexts when loading new files
- test that only one audio source plays and seek bar stays synchronized

## Testing
- `npx eslint web-spectrogram/static/app.js web-spectrogram/static/app.test.js` *(fails: ESLint couldn't find an eslint.config file)*
- `npx prettier --write web-spectrogram/static/app.js web-spectrogram/static/app.test.js`
- `node static/app.test.js`
- `npx -y c8 node static/app.test.js`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68a0eab953e0832b84cb832afa77e3f3