### PR TITLE
feat(web): modernize spectrogram layout

### DIFF
--- a/web-spectrogram/static/index.html
+++ b/web-spectrogram/static/index.html
@@ -8,10 +8,12 @@
   </head>
   <body>
     <div id="app">
-      <input id="file" type="file" accept="audio/*" />
-      <audio id="player" controls></audio>
-      <input id="seek" type="range" min="0" value="0" step="0.01" />
       <canvas id="spectrogram"></canvas>
+      <footer id="controls">
+        <input id="file" type="file" accept="audio/*" />
+        <audio id="player" controls></audio>
+        <input id="seek" type="range" min="0" value="0" step="0.01" />
+      </footer>
       <p><a href="../README.md">Usage &amp; options</a></p>
     </div>
     <script type="module" src="app.js"></script>

--- a/web-spectrogram/static/style.css
+++ b/web-spectrogram/static/style.css
@@ -1,24 +1,54 @@
+:root {
+  --bg-color: #111;
+  --panel-bg: #222;
+  --text-color: #eee;
+  --accent-color: #0abde3;
+}
+
+html,
+body {
+  height: 100%;
+}
+
 body {
   margin: 0;
-  background: #111;
-  color: #eee;
+  background: linear-gradient(180deg, var(--bg-color), #000);
+  color: var(--text-color);
+  font-family: system-ui, sans-serif;
   display: flex;
-  flex-direction: column;
-  align-items: center;
-  font-family: sans-serif;
+  justify-content: center;
 }
 
 #app {
-  width: 100%;
-  max-width: 800px;
   display: flex;
   flex-direction: column;
-  gap: 0.5rem;
-  padding: 1rem;
+  width: 100%;
+  max-width: 800px;
 }
 
-canvas {
+#spectrogram {
+  flex: 1;
   width: 100%;
-  height: 300px;
   background: #000;
+}
+
+#controls {
+  display: flex;
+  gap: 0.5rem;
+  align-items: center;
+  padding: 0.5rem 1rem;
+  background: var(--panel-bg);
+}
+
+#seek {
+  flex: 1;
+}
+
+a {
+  color: var(--accent-color);
+}
+
+p {
+  text-align: center;
+  margin: 0.5rem 0;
 }


### PR DESCRIPTION
## Summary
- Move file selection, playback controls and seek bar into bottom footer
- Adopt flexbox layout with modern theming and canvas filling viewport

## Testing
- `cargo fmt --all`
- `cargo clippy --all-targets --all-features --workspace -- -D warnings` *(fails: unnecessary-map-or in sanity-check/src/lib.rs)*
- `cargo test --workspace`
- `python -m webbrowser web-spectrogram/static/index.html` *(manual check)*
- `xdg-open web-spectrogram/static/index.html` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a0eafddf2c832ba9844bb4704f9c8f