### PR TITLE
Add logarithmic frequency scale option to web spectrogram

### DIFF
--- a/web-spectrogram/README.md
+++ b/web-spectrogram/README.md
@@ -50,4 +50,16 @@ Light and dark themes are available.
 document.body.dataset.theme = "light"; // or "dark"
 ```
 
+## Frequency Scale
+
+Frequencies can be displayed on a linear or logarithmic scale.
+
+**UI:** Use the scale selector to choose between linear and logarithmic modes.
+
+**API:** Pass the desired scale when starting the render loop:
+
+```js
+startRenderLoop(canvas, analyser, "logarithmic"); // or "linear"
+```
+
 Refer back to this file whenever you need details on the available options and how to use them.

--- a/web-spectrogram/static/index.html
+++ b/web-spectrogram/static/index.html
@@ -15,6 +15,10 @@
         <option value="dark" selected>Dark</option>
         <option value="light">Light</option>
       </select>
+      <select id="scale">
+        <option value="linear" selected>Linear</option>
+        <option value="logarithmic">Logarithmic</option>
+      </select>
       <canvas id="spectrogram"></canvas>
       <p><a href="../README.md">Usage &amp; options</a></p>
     </div>


### PR DESCRIPTION
## Summary
- add scale selector to choose linear or logarithmic frequency display
- render loop maps bins for logarithmic scale and handles selection
- document scale option and add regression test

## Testing
- `npx prettier -w web-spectrogram/static/index.html web-spectrogram/static/app.js web-spectrogram/static/app.test.js web-spectrogram/README.md`
- `npx eslint -c /tmp/eslint.config.mjs web-spectrogram/static/app.js web-spectrogram/static/app.test.js`
- `node --experimental-test-coverage web-spectrogram/static/app.test.js`

------
https://chatgpt.com/codex/tasks/task_e_68a0ef230fc4832bb5ae9d86255b0eee