### PR TITLE
feat: resize spectrogram canvas on window changes

### DIFF
--- a/web-spectrogram/static/app.js
+++ b/web-spectrogram/static/app.js
@@ -54,8 +54,13 @@ export function init(
   const seek = doc.querySelector("input[type=range]");
   const canvas = doc.getElementById("spectrogram");
   const themeSelect = doc.getElementById("theme");
-  canvas.width = canvas.clientWidth * (window.devicePixelRatio || 1);
-  canvas.height = canvas.clientHeight * (window.devicePixelRatio || 1);
+  const resize = () => {
+    const ratio = window.devicePixelRatio || 1;
+    canvas.width = canvas.clientWidth * ratio;
+    canvas.height = canvas.clientHeight * ratio;
+  };
+  resize();
+  window.addEventListener("resize", resize);
 
   deps.setupPlayback(audio, seek);
 

--- a/web-spectrogram/static/app.test.js
+++ b/web-spectrogram/static/app.test.js
@@ -214,3 +214,39 @@ test("theme selector updates body dataset", () => {
   select.dispatchEvent(new dom.window.Event("change"));
   assert.equal(dom.window.document.body.dataset.theme, "light");
 });
+
+test("canvas resizes with window", () => {
+  const dom = new JSDOM(
+    `<input type="file"><audio></audio><input type="range"><canvas id="spectrogram"></canvas>`,
+  );
+  globalThis.window = dom.window;
+  globalThis.document = dom.window.document;
+  dom.window.devicePixelRatio = 1;
+  const canvas = dom.window.document.getElementById("spectrogram");
+  Object.defineProperty(canvas, "clientWidth", {
+    value: 100,
+    configurable: true,
+  });
+  Object.defineProperty(canvas, "clientHeight", {
+    value: 50,
+    configurable: true,
+  });
+  init(dom.window.document, {
+    decodeAndProcess: async () => ({}),
+    setupPlayback: () => {},
+    startRenderLoop: () => {},
+  });
+  assert.equal(canvas.width, 100);
+  assert.equal(canvas.height, 50);
+  Object.defineProperty(canvas, "clientWidth", {
+    value: 200,
+    configurable: true,
+  });
+  Object.defineProperty(canvas, "clientHeight", {
+    value: 75,
+    configurable: true,
+  });
+  dom.window.dispatchEvent(new dom.window.Event("resize"));
+  assert.equal(canvas.width, 200);
+  assert.equal(canvas.height, 75);
+});

--- a/web-spectrogram/static/style.css
+++ b/web-spectrogram/static/style.css
@@ -1,3 +1,9 @@
+html,
+body,
+#app {
+  height: 100%;
+}
+
 body {
   margin: 0;
   background: #111;
@@ -24,7 +30,7 @@ body[data-theme="light"] {
 
 canvas {
   width: 100%;
-  height: 300px;
+  height: 100%;
   background: #000;
 }
 


### PR DESCRIPTION
## Summary
- adjust canvas dimensions when the window is resized
- use percentage-based CSS sizing so the canvas fills its container
- test that canvas size updates on resize

## Testing
- `npx prettier -w web-spectrogram/static/app.js web-spectrogram/static/style.css web-spectrogram/static/app.test.js`
- `npx eslint web-spectrogram/static/app.js web-spectrogram/static/app.test.js` (fails: ESLint couldn't find a config)
- `node --test --experimental-test-coverage --test-coverage-lines=90 web-spectrogram/static/app.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68a0ef255614832b9bac043062930083