### PR TITLE
Fix web spectrogram init without seek bar

### DIFF
--- a/web-spectrogram/static/app.js
+++ b/web-spectrogram/static/app.js
@@ -71,7 +71,7 @@ export function init(
   const fileInput = doc.querySelector("input[type=file]");
   const audio = doc.querySelector("audio");
   const seekCanvas = doc.getElementById("seekbar");
-  const seek = new SeekBar(seekCanvas);
+  const seek = seekCanvas ? new SeekBar(seekCanvas) : null;
   const canvas = doc.getElementById("spectrogram");
   const themeSelect = doc.getElementById("theme");
   const resize = () => {
@@ -85,7 +85,9 @@ export function init(
   canvas.width = canvas.clientWidth * (window.devicePixelRatio || 1);
   canvas.height = canvas.clientHeight * (window.devicePixelRatio || 1);
 
-  deps.setupPlayback(audio, seek);
+  if (seek) {
+    deps.setupPlayback(audio, seek);
+  }
 
   let ctx;
   if (themeSelect) {
@@ -103,7 +105,9 @@ export function init(
     }
     let amplitudes;
     ({ ctx, amplitudes } = await deps.decodeAndProcess(file, audio));
-    seek.setAmplitudes(amplitudes);
+    if (seek) {
+      seek.setAmplitudes(amplitudes);
+    }
     const analyser = ctx.createAnalyser();
     const source = ctx.createMediaElementSource(audio);
     source.connect(analyser);


### PR DESCRIPTION
## Summary
- Avoid crashing when `#seekbar` canvas is missing by guarding SeekBar setup
- Add test for initializing and selecting files without a seek bar

## Testing
- `npx c8 node --test static/app.test.js`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68a0f2b40e20832bb31b130122ad7e85