### PR TITLE
refine spectrogram UI with themed palettes

### DIFF
--- a/web-spectrogram/static/index.html
+++ b/web-spectrogram/static/index.html
@@ -8,22 +8,27 @@
   </head>
   <body>
     <div id="app">
-      <input id="file" type="file" accept="audio/*" />
-      <audio id="player" controls></audio>
-      <canvas id="seekbar" height="40"></canvas>
-      <select id="theme">
-        <option value="dark" selected>Dark</option>
-        <option value="light">Light</option>
-      </select>
-      <select id="scale">
-        <option value="linear" selected>Linear</option>
-        <option value="logarithmic">Logarithmic</option>
-      </select>
       <canvas id="spectrogram"></canvas>
       <footer id="controls">
         <input id="file" type="file" accept="audio/*" />
         <audio id="player" controls></audio>
-        <input id="seek" type="range" min="0" value="0" step="0.01" />
+        <canvas id="seekbar" height="40"></canvas>
+        <select id="scale">
+          <option value="linear" selected>Linear</option>
+          <option value="logarithmic">Logarithmic</option>
+        </select>
+        <div id="themes">
+          <button
+            class="theme-btn active"
+            data-theme="rainbow"
+            aria-label="Rainbow theme"
+          >
+            🌈
+          </button>
+          <button class="theme-btn" data-theme="fire" aria-label="Fire theme">
+            🔥
+          </button>
+        </div>
       </footer>
       <p><a href="../README.md">Usage &amp; options</a></p>
     </div>

--- a/web-spectrogram/static/style.css
+++ b/web-spectrogram/static/style.css
@@ -1,61 +1,69 @@
 html,
 body,
-#app 
-:root {
-  --bg-color: #111;
-  --panel-bg: #222;
-  --text-color: #eee;
-  --accent-color: #0abde3;
+#app {
   height: 100%;
+  width: 100%;
+  margin: 0;
 }
 
 body {
-  margin: 0;
-  background: linear-gradient(180deg, var(--bg-color), #000);
-  color: var(--text-color);
+  background: #111;
+  color: #eee;
   font-family: system-ui, sans-serif;
   display: flex;
-  justify-content: center;
-}
-
-body[data-theme="light"] {
-  background: #fff;
-  color: #000;
+  flex-direction: column;
 }
 
 #app {
   display: flex;
   flex-direction: column;
-  width: 100%;
-  max-width: 800px;
+  flex: 1;
 }
 
 #spectrogram {
   flex: 1;
   width: 100%;
-  height: 100%;
   background: #000;
 }
 
 #controls {
+  position: fixed;
+  bottom: 0;
+  left: 0;
+  right: 0;
   display: flex;
-  gap: 0.5rem;
   align-items: center;
-  padding: 0.5rem 1rem;
-  background: var(--panel-bg);
+  gap: 0.5rem;
+  padding: 0.5rem;
+  background: #222;
 }
 
-#seek {
+#seekbar {
   flex: 1;
 }
 
+#themes {
+  display: flex;
+  gap: 0.25rem;
+}
+
+.theme-btn {
+  background: transparent;
+  border: none;
+  color: #eee;
+  cursor: pointer;
+  font-size: 1.2rem;
+}
+
+.theme-btn.active {
+  color: #0abde3;
+}
+
 a {
-  color: var(--accent-color);
+  color: #0abde3;
 }
 
 p {
   text-align: center;
   margin: 0.5rem 0;
-body[data-theme="light"] canvas {
-  background: #fff;
 }


### PR DESCRIPTION
## Summary
- Consolidate spectrogram controls into a full-width bottom toolbar and add theme buttons
- Introduce rainbow and fire palettes and wire them to the new theme selector
- Expand test suite to cover palette rendering and updated layout

## Testing
- `npx prettier -w web-spectrogram/static/index.html web-spectrogram/static/style.css web-spectrogram/static/app.js web-spectrogram/static/app.test.js`
- `cd web-spectrogram && npx c8 node --test static/app.test.js`

------
https://chatgpt.com/codex/tasks/task_e_68a0fc1fb350832b9d460b9b58cf26ed