### PR TITLE
Integrate WASM spectrogram with React

### DIFF
--- a/web-spectrogram/app/src/App.tsx
+++ b/web-spectrogram/app/src/App.tsx
@@ -3,16 +3,20 @@ import { Sidebar } from "./components/Sidebar";
 import { SpectrogramCanvas } from "./components/SpectrogramCanvas";
 import { PlaybackControls } from "./components/PlaybackControls";
 import { extractMetadata, TrackMetadata } from "./utils/metadata";
+import { SpectrogramData, generateSpectrogram } from "./utils/spectrogram";
 
 export default function App() {
   const [metadata, setMetadata] = useState<TrackMetadata | null>(null);
   const [playing, setPlaying] = useState(false);
+  const [spec, setSpec] = useState<SpectrogramData | null>(null);
 
   async function handleFile(files: FileList | null) {
     if (!files?.[0]) return;
-    const md = await extractMetadata(files[0]);
+    const file = files[0];
+    const md = await extractMetadata(file);
     setMetadata(md);
-    // TODO: load audio and render spectrogram
+    const s = await generateSpectrogram(file);
+    setSpec(s);
   }
 
   return (
@@ -23,7 +27,11 @@ export default function App() {
         onChange={(e) => handleFile(e.target.files)}
       />
       <Sidebar metadata={metadata} />
-      <SpectrogramCanvas />
+      <SpectrogramCanvas
+        pixels={spec?.pixels}
+        width={spec?.width ?? 0}
+        height={spec?.height ?? 0}
+      />
       <PlaybackControls
         playing={playing}
         onPlay={() => setPlaying(true)}

--- a/web-spectrogram/app/src/components/SpectrogramCanvas.tsx
+++ b/web-spectrogram/app/src/components/SpectrogramCanvas.tsx
@@ -1,11 +1,24 @@
 import React, { useRef, useEffect } from "react";
 
-export function SpectrogramCanvas() {
+interface Props {
+  pixels?: Uint8ClampedArray;
+  width: number;
+  height: number;
+}
+
+export function SpectrogramCanvas({ pixels, width, height }: Props) {
   const canvasRef = useRef<HTMLCanvasElement>(null);
 
   useEffect(() => {
-    // Placeholder for WASM spectrogram drawing
-  }, []);
+    const canvas = canvasRef.current;
+    if (!canvas || !pixels || width === 0 || height === 0) return;
+    canvas.width = width;
+    canvas.height = height;
+    const ctx = canvas.getContext("2d");
+    if (!ctx) return;
+    const image = new ImageData(pixels, width, height);
+    ctx.putImageData(image, 0, 0);
+  }, [pixels, width, height]);
 
   return <canvas ref={canvasRef} className="spectrogram" />;
 }

--- a/web-spectrogram/app/src/utils/spectrogram.ts
+++ b/web-spectrogram/app/src/utils/spectrogram.ts
@@ -1,0 +1,44 @@
+import init, {
+  stft_magnitudes,
+  color_from_magnitude_u8,
+  Colormap,
+} from "@wasm";
+
+const WIN_LEN = 1024;
+const HOP = WIN_LEN / 2;
+const FLOOR_DB = -80;
+
+export interface SpectrogramData {
+  pixels: Uint8ClampedArray;
+  width: number;
+  height: number;
+}
+
+export async function generateSpectrogram(
+  file: File,
+): Promise<SpectrogramData> {
+  await init();
+  const audioCtx = new AudioContext();
+  const buf = await file.arrayBuffer();
+  const audioBuf = await audioCtx.decodeAudioData(buf);
+  const samples = audioBuf.getChannelData(0);
+  const res = stft_magnitudes(samples, WIN_LEN, HOP);
+  const mags: number[] = res.mags;
+  const width = res.width;
+  const height = res.height;
+  const maxMag = res.max_mag;
+  const pixels = new Uint8ClampedArray(width * height * 4);
+  for (let x = 0; x < width; x++) {
+    for (let y = 0; y < height; y++) {
+      const mag = mags[x * height + y];
+      const color = color_from_magnitude_u8(
+        mag,
+        maxMag,
+        FLOOR_DB,
+        Colormap.Rainbow,
+      );
+      pixels.set(color, 4 * (y * width + x));
+    }
+  }
+  return { pixels, width, height };
+}

--- a/web-spectrogram/app/tests/app.test.tsx
+++ b/web-spectrogram/app/tests/app.test.tsx
@@ -1,0 +1,33 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, fireEvent, waitFor } from "@testing-library/react";
+import App from "../src/App";
+
+vi.mock("../src/utils/metadata", () => ({
+  extractMetadata: vi.fn(async () => null),
+}));
+
+vi.mock("../src/utils/spectrogram", () => ({
+  generateSpectrogram: vi.fn(async () => ({
+    pixels: new Uint8ClampedArray([1, 2, 3, 255]),
+    width: 1,
+    height: 1,
+  })),
+}));
+
+describe("App", () => {
+  it("processes uploaded file", async () => {
+    const putImageData = vi.fn();
+    HTMLCanvasElement.prototype.getContext = vi.fn(() => ({
+      putImageData,
+    })) as any;
+    const { container } = render(<App />);
+    const input = container.querySelector(
+      'input[type="file"]',
+    ) as HTMLInputElement;
+    const file = new File([new Uint8Array([0])], "t.wav", {
+      type: "audio/wav",
+    });
+    fireEvent.change(input, { target: { files: [file] } });
+    await waitFor(() => expect(putImageData).toHaveBeenCalled());
+  });
+});

--- a/web-spectrogram/app/tests/setup.ts
+++ b/web-spectrogram/app/tests/setup.ts
@@ -2,3 +2,17 @@ import { expect } from "vitest";
 import * as matchers from "@testing-library/jest-dom/matchers";
 
 expect.extend(matchers);
+
+class FakeImageData {
+  data: Uint8ClampedArray;
+  width: number;
+  height: number;
+  constructor(data: Uint8ClampedArray, width: number, height: number) {
+    this.data = data;
+    this.width = width;
+    this.height = height;
+  }
+}
+
+// @ts-ignore
+globalThis.ImageData = FakeImageData;

--- a/web-spectrogram/app/tests/spectrogram.test.ts
+++ b/web-spectrogram/app/tests/spectrogram.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect, vi } from "vitest";
+import { generateSpectrogram } from "../src/utils/spectrogram";
+
+vi.mock("@wasm", () => ({
+  default: vi.fn().mockResolvedValue(undefined),
+  stft_magnitudes: vi.fn(() => ({
+    mags: [0.1, 0.2],
+    width: 1,
+    height: 2,
+    max_mag: 1,
+  })),
+  color_from_magnitude_u8: vi.fn(() => new Uint8Array([1, 2, 3, 255])),
+  Colormap: { Rainbow: 0 },
+}));
+
+class MockAudioBuffer {
+  getChannelData() {
+    return new Float32Array(4);
+  }
+}
+
+class MockAudioContext {
+  decodeAudioData = vi.fn(async () => new MockAudioBuffer());
+}
+
+// @ts-ignore
+globalThis.AudioContext = MockAudioContext;
+
+describe("generateSpectrogram", () => {
+  it("produces pixel data using WASM", async () => {
+    const file = { arrayBuffer: async () => new ArrayBuffer(8) } as File;
+    const res = await generateSpectrogram(file);
+    expect(res.width).toBe(1);
+    expect(res.height).toBe(2);
+    expect(res.pixels.length).toBe(8);
+  });
+});

--- a/web-spectrogram/app/tests/spectrogramCanvas.test.tsx
+++ b/web-spectrogram/app/tests/spectrogramCanvas.test.tsx
@@ -1,0 +1,15 @@
+import { describe, it, expect, vi } from "vitest";
+import { render } from "@testing-library/react";
+import { SpectrogramCanvas } from "../src/components/SpectrogramCanvas";
+
+describe("SpectrogramCanvas", () => {
+  it("draws provided pixels", () => {
+    const putImageData = vi.fn();
+    HTMLCanvasElement.prototype.getContext = vi.fn(() => ({
+      putImageData,
+    })) as any;
+    const pixels = new Uint8ClampedArray([1, 2, 3, 255]);
+    render(<SpectrogramCanvas pixels={pixels} width={1} height={1} />);
+    expect(putImageData).toHaveBeenCalled();
+  });
+});

--- a/web-spectrogram/vite.config.ts
+++ b/web-spectrogram/vite.config.ts
@@ -1,10 +1,16 @@
 import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
 import { VitePWA } from 'vite-plugin-pwa';
+import path from 'path';
 
 export default defineConfig({
   root: 'app',
   publicDir: 'app/public',
+  resolve: {
+    alias: {
+      '@wasm': path.resolve(__dirname, './pkg/web_spectrogram.js')
+    }
+  },
   test: {
     environment: 'jsdom',
     setupFiles: 'tests/setup.ts'


### PR DESCRIPTION
## Summary
- render spectrogram pixels on canvas
- generate spectrogram image in React using WASM
- add tests for spectrogram generation and rendering

## Testing
- `npm run format`
- `npm test`
- `cargo fmt --all`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68a115bd48dc832bb8e87941e741c3ec