### PR TITLE
Fix web spectrogram metadata encoding

### DIFF
--- a/web-spectrogram/Cargo.toml
+++ b/web-spectrogram/Cargo.toml
@@ -26,3 +26,9 @@ http = "1"
 tower = { version = "0.5", features = ["util"] }
 hyper = { version = "1", features = ["client", "http1", "http2"] }
 http-body-util = "0.1"
+
+[package.metadata.wasm-pack.profile.dev]
+wasm-opt = false
+
+[package.metadata.wasm-pack.profile.release]
+wasm-opt = false

--- a/web-spectrogram/app/src/utils/metadata.ts
+++ b/web-spectrogram/app/src/utils/metadata.ts
@@ -10,13 +10,21 @@ export interface TrackMetadata {
   picture: string;
 }
 
+function base64FromBytes(bytes: Uint8Array): string {
+  let binary = "";
+  for (let i = 0; i < bytes.length; i++) {
+    binary += String.fromCharCode(bytes[i]);
+  }
+  return btoa(binary);
+}
+
 export async function extractMetadata(file: File): Promise<TrackMetadata> {
   const metadata = await parseBlob(file);
   const common = metadata.common;
   const pic = common.picture && common.picture[0];
   let picture: string;
   if (pic) {
-    picture = `data:${pic.format};base64,${Buffer.from(pic.data).toString("base64")}`;
+    picture = `data:${pic.format};base64,${base64FromBytes(pic.data)}`;
   } else {
     picture = GENERIC_VINYL;
   }

--- a/web-spectrogram/app/tests/build.test.ts
+++ b/web-spectrogram/app/tests/build.test.ts
@@ -3,7 +3,7 @@ import { existsSync, rmSync } from "fs";
 import path from "path";
 import { test, expect } from "vitest";
 
-test("npm build outputs sw.js", () => {
+test("npm build outputs sw.js", { timeout: 240000 }, () => {
   const root = path.resolve(__dirname, "..", "..");
   const appDir = path.join(root, "app");
   const distDir = path.join(appDir, "dist");


### PR DESCRIPTION
## Summary
- avoid Node-only Buffer to base64 encode album art
- disable wasm-opt in web spectrogram builds
- allow build test longer timeouts

## Testing
- `npm run format`
- `npm test`
- `cargo fmt --all`
- `cargo clippy --all-targets --all-features`
- `cargo test --all`


------
https://chatgpt.com/codex/tasks/task_e_68a12269c8a8832ba5f5c4df1f7e2ea1