### PR TITLE
refactor: streamline CI workflows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,6 +7,7 @@ on:
 
 jobs:
   build:
+    name: Build
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
@@ -27,18 +28,18 @@ jobs:
             target: wasm32-unknown-unknown
           - os: macos-latest
             target: ""
-          - os: windows-latest
-            target: ""
         exclude:
           - os: ubuntu-latest
             target: wasm32-unknown-unknown
             features: "--all-features"
     steps:
-      - uses: actions/checkout@v4
-      - uses: ./.github/actions/setup-rust
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Setup Rust
+        uses: ./.github/actions/setup-rust
         with:
           targets: ${{ matrix.target }}
-      - name: Build all targets
+      - name: Build
         shell: bash
         run: |
           TARGET_ARG=""

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,4 +1,4 @@
-name: Test
+name: Tests
 
 on:
   push:
@@ -6,11 +6,12 @@ on:
   pull_request:
 
 jobs:
-  test:
+  unit-tests:
+    name: Unit tests
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [ubuntu-latest, macos-latest]
         features:
           - ''
           - '--no-default-features'
@@ -19,12 +20,15 @@ jobs:
           - '--features "simd soa internal-tests"'
           - '--all-features'
     steps:
-      - uses: actions/checkout@v4
-      - uses: ./.github/actions/setup-rust
-      - name: Test
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Setup Rust
+        uses: ./.github/actions/setup-rust
+      - name: Run tests
         shell: bash
         run: cargo test --all --verbose ${{ matrix.features }}
-  check:
+  feature-checks:
+    name: Feature checks
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -34,8 +38,10 @@ jobs:
           - '--features "wasm"'
           - '--features "aarch64"'
     steps:
-      - uses: actions/checkout@v4
-      - uses: ./.github/actions/setup-rust
-      - name: Check
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Setup Rust
+        uses: ./.github/actions/setup-rust
+      - name: Run checks
         shell: bash
         run: cargo check --all --verbose ${{ matrix.features }}


### PR DESCRIPTION
## Summary
- remove Windows jobs from build and test workflows
- clarify job and step names for readability

## Testing
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68a19ef116bc832ba367c48b5f956238