### PR TITLE
Optimize CI workflows with caching and concurrency

### DIFF
--- a/.github/actions/setup-rust/action.yml
+++ b/.github/actions/setup-rust/action.yml
@@ -22,3 +22,5 @@ runs:
         components: ${{ inputs.components }}
         targets: ${{ inputs.targets }}
     - uses: swatinem/rust-cache@v2
+      with:
+        cache-on-failure: true

--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -5,13 +5,16 @@ on:
     branches: [main]
   pull_request:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   audit:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/setup-rust
-      - name: Install cargo-audit
-        run: cargo install cargo-audit
+      - uses: taiki-e/install-action@cargo-audit
       - name: Run cargo audit
         run: cargo audit --deny warnings

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,6 +5,10 @@ on:
     branches: [main]
   pull_request:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
     name: Build

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -5,6 +5,10 @@ on:
     branches: [main]
   pull_request:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   coverage:
     runs-on: ubuntu-latest

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -5,6 +5,10 @@ on:
     branches: [main]
   pull_request:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   lint:
     runs-on: ubuntu-latest

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -5,6 +5,10 @@ on:
     tags:
       - 'v*'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   publish:
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,28 +5,42 @@ on:
     branches: [main]
   pull_request:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   unit-tests:
     name: Unit tests
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest]
-        features:
-          - ''
-          - '--no-default-features'
-          - '--features "sse std internal-tests"'
-          - '--features "parallel internal-tests"'
-          - '--features "simd soa internal-tests"'
-          - '--all-features'
+        include:
+          - os: ubuntu-latest
+            features: ''
+          - os: ubuntu-latest
+            features: '--no-default-features'
+          - os: ubuntu-latest
+            features: '--features "sse std internal-tests"'
+          - os: ubuntu-latest
+            features: '--features "parallel internal-tests"'
+          - os: ubuntu-latest
+            features: '--features "simd soa internal-tests"'
+          - os: ubuntu-latest
+            features: '--all-features'
+          - os: macos-latest
+            features: ''
+          - os: macos-latest
+            features: '--all-features'
     steps:
       - name: Checkout
         uses: actions/checkout@v4
       - name: Setup Rust
         uses: ./.github/actions/setup-rust
+      - uses: taiki-e/install-action@nextest
       - name: Run tests
         shell: bash
-        run: cargo test --all --verbose ${{ matrix.features }}
+        run: cargo nextest run --all ${{ matrix.features }}
   feature-checks:
     name: Feature checks
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- speed up audit job by using prebuilt `cargo-audit`
- cancel redundant CI runs via workflow concurrency groups
- trim macOS test matrix and run tests with `cargo nextest`
- persist Rust cache on failure for faster retries

## Testing
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all`


------
https://chatgpt.com/codex/tasks/task_e_68a1a338a6c8832ba1be6073d4f21bad