### PR TITLE
Polyfill Buffer for web spectrogram

### DIFF
--- a/web-spectrogram/app.mjs
+++ b/web-spectrogram/app.mjs
@@ -1,3 +1,18 @@
+export function ensureBuffer() {
+  if (typeof globalThis.Buffer === "undefined") {
+    globalThis.Buffer = class Buffer extends Uint8Array {
+      static from(data) {
+        if (data instanceof ArrayBuffer) {
+          return new Uint8Array(data);
+        }
+        return new Uint8Array(data);
+      }
+    };
+  }
+}
+
+ensureBuffer();
+
 let wasm;
 /* c8 ignore start */
 async function loadWasm() {
@@ -18,7 +33,12 @@ export function magnitudeToDb(mag, maxMag) {
   return 20 * Math.log10(Math.max(ratio, 1e-12));
 }
 
-export function drawSpectrogram(canvas, res, colorFn, colormap = wasm?.Colormap.Rainbow) {
+export function drawSpectrogram(
+  canvas,
+  res,
+  colorFn,
+  colormap = wasm?.Colormap.Rainbow,
+) {
   const ctx = canvas.getContext("2d");
   const { mags, width, height, max_mag } = res;
   canvas.width = width;

--- a/web-spectrogram/tests/app.test.mjs
+++ b/web-spectrogram/tests/app.test.mjs
@@ -1,25 +1,30 @@
-import { test } from 'node:test';
-import assert from 'node:assert';
-import { magnitudeToDb, drawSpectrogram, initApp } from '../app.mjs';
+import { test } from "node:test";
+import assert from "node:assert";
+import {
+  magnitudeToDb,
+  drawSpectrogram,
+  initApp,
+  ensureBuffer,
+} from "../app.mjs";
 
-test('magnitudeToDb converts correctly', () => {
+test("magnitudeToDb converts correctly", () => {
   const db = magnitudeToDb(1, 1);
   assert(Math.abs(db) < 1e-6);
 });
 
-test('drawSpectrogram writes pixels', () => {
+test("drawSpectrogram writes pixels", () => {
   const ctx = {
     createImageData: (w, h) => ({ data: new Uint8ClampedArray(w * h * 4) }),
     putImageData(img) {
       this.last = img;
-    }
+    },
   };
   const canvas = {
     width: 0,
     height: 0,
     getContext() {
       return ctx;
-    }
+    },
   };
   const res = { mags: [1, 1], width: 1, height: 2, max_mag: 1 };
   const colorFn = () => [1, 2, 3];
@@ -29,31 +34,56 @@ test('drawSpectrogram writes pixels', () => {
   assert.equal(ctx.last.data[2], 3);
 });
 
-test('initApp loads and processes file', async () => {
+test("initApp loads and processes file", async () => {
   const ctx = {
     createImageData: (w, h) => ({ data: new Uint8ClampedArray(w * h * 4) }),
     putImageData(img) {
       this.last = img;
-    }
+    },
   };
   const canvas = { getContext: () => ctx };
   const listeners = {};
   global.document = {
     getElementById(id) {
-      if (id === 'file') {
-        return { addEventListener: (ev, cb) => { listeners[ev] = cb; } };
+      if (id === "file") {
+        return {
+          addEventListener: (ev, cb) => {
+            listeners[ev] = cb;
+          },
+        };
       }
-      if (id === 'spec') {
+      if (id === "spec") {
         return canvas;
       }
-    }
+    },
   };
   global.AudioContext = class {
     decodeAudioData() {
-      return Promise.resolve({ getChannelData: () => new Float32Array([1, 1]) });
+      return Promise.resolve({
+        getChannelData: () => new Float32Array([1, 1]),
+      });
     }
   };
   await initApp();
-  await listeners['change']({ target: { files: [{ name: 'x', arrayBuffer: async () => new ArrayBuffer(0) }] } });
+  await listeners["change"]({
+    target: {
+      files: [{ name: "x", arrayBuffer: async () => new ArrayBuffer(0) }],
+    },
+  });
   assert.ok(ctx.last);
+});
+
+test("polyfills Buffer when missing", async () => {
+  const original = global.Buffer;
+  try {
+    // Simulate browser environment without Buffer
+    // eslint-disable-next-line no-global-assign
+    global.Buffer = undefined;
+    ensureBuffer();
+    assert.ok(global.Buffer);
+    const buf = Buffer.from([1, 2, 3]);
+    assert.ok(buf instanceof Uint8Array);
+  } finally {
+    global.Buffer = original;
+  }
 });


### PR DESCRIPTION
## Summary
- polyfill Node's `Buffer` in web-spectrogram so the PWA works in browsers
- test the Buffer polyfill in the frontend test suite

## Testing
- `cargo fmt --all`
- `cargo clippy --all-targets --all-features`
- `npx prettier -w web-spectrogram/app.mjs web-spectrogram/tests/app.test.mjs`
- `node --test --experimental-test-coverage web-spectrogram/tests/app.test.mjs`
- `cargo test -p web-spectrogram`


------
https://chatgpt.com/codex/tasks/task_e_68a1a9fde2c0832b82f8507786c9192b