### PR TITLE
fix: prevent overlapping audio by cancelling stale decodes

### DIFF
--- a/react-spectrogram/ALIGNMENT_CHECKLIST.md
+++ b/react-spectrogram/ALIGNMENT_CHECKLIST.md
@@ -1,0 +1,17 @@
+# Alignment Checklist
+
+This checklist maps high-level requirements from `design.md` and `expectation.md` to the current implementation status of the React Spectrogram app.
+
+| Requirement | Status | Notes |
+| --- | --- | --- |
+| Responsive layout with header, spectrogram, sidebars, and footer | ✅ | Implemented with Flexbox panels and mobile breakpoints.
+| Seek bar with amplitude bars and precise hover/drag | ⚠️ | Basic waveform seekbar exists but lacks full amplitude spec and some interactions.
+| Single AudioContext reused across tracks | ✅ | `audioPlayer` maintains one shared context.
+| Prevent overlapping audio when switching tracks rapidly | ✅ | Pending decode operations are cancelled using a request token.
+| Event listeners cleaned up on unmount | ✅ | Hooks like `useKeyboardShortcuts` and `useScreenSize` remove listeners in cleanup.
+| Playlist navigation (next/prev, repeat/shuffle) robust at boundaries | ⚠️ | Basic next/prev available; repeat/shuffle not implemented.
+| Spectrogram resizes/redraws on container resize | ⚠️ | Canvas resizes but redraw lag exists on extreme resize.
+| Keyboard shortcuts documented and overridable | ✅ | Shortcuts implemented with `useKeyboardShortcuts` and toast hint.
+| Accessibility with ARIA labels and focus order | ⚠️ | Many controls labeled, but comprehensive audit pending.
+
+✅ = fully implemented, ⚠️ = partial / needs work, ❌ = missing.

--- a/react-spectrogram/src/utils/__tests__/audioPlayer.test.ts
+++ b/react-spectrogram/src/utils/__tests__/audioPlayer.test.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { audioPlayer } from '../audioPlayer'
+
+class MockAudioBuffer { constructor(public duration: number) {} }
+
+class MockAudioBufferSourceNode {
+  buffer: any = null
+  connect() {}
+  start() {}
+  stop() {}
+  disconnect() {}
+  onended: (() => void) | null = null
+}
+
+class MockGainNode { gain = { value: 0.5 }; connect() {} }
+class MockAnalyserNode { fftSize = 0; connect() {} }
+
+let decodeCall = 0
+
+class MockAudioContext {
+  currentTime = 0
+  state: 'running' | 'suspended' = 'running'
+  createGain() { return new MockGainNode() }
+  createAnalyser() { return new MockAnalyserNode() }
+  createBufferSource() { return new MockAudioBufferSourceNode() }
+  decodeAudioData(_: ArrayBuffer) {
+    decodeCall++
+    const duration = decodeCall
+    const delay = duration === 1 ? 20 : 0
+    return new Promise<MockAudioBuffer>(resolve => setTimeout(() => resolve(new MockAudioBuffer(duration)), delay))
+  }
+  resume() { return Promise.resolve() }
+  close() {}
+}
+
+beforeEach(() => {
+  decodeCall = 0
+  ;(globalThis as any).requestAnimationFrame = vi.fn()
+  ;(globalThis as any).cancelAnimationFrame = vi.fn()
+  ;(window as any).AudioContext = MockAudioContext as any
+  ;(window as any).webkitAudioContext = MockAudioContext as any
+  audioPlayer.cleanup()
+})
+
+afterEach(() => {
+  audioPlayer.cleanup()
+  vi.clearAllMocks()
+})
+
+describe('audioPlayer overlap handling', () => {
+  it('prevents previous track from playing when a new track is started', async () => {
+    const track1 = { file: { arrayBuffer: () => Promise.resolve(new ArrayBuffer(8)) } }
+    const track2 = { file: { arrayBuffer: () => Promise.resolve(new ArrayBuffer(8)) } }
+
+    const startSpy = vi.spyOn(MockAudioBufferSourceNode.prototype, 'start')
+
+    const p1 = audioPlayer.playTrack(track1)
+    const p2 = audioPlayer.playTrack(track2)
+
+    await new Promise(resolve => setTimeout(resolve, 30))
+    await Promise.all([p1, p2])
+
+    expect(startSpy).toHaveBeenCalledTimes(1)
+    expect(audioPlayer.getDuration()).toBe(2)
+  })
+
+  it('cancels pending playback when stop is called before decode completes', async () => {
+    const track = { file: { arrayBuffer: () => Promise.resolve(new ArrayBuffer(8)) } }
+    const startSpy = vi.spyOn(MockAudioBufferSourceNode.prototype, 'start')
+
+    const p = audioPlayer.playTrack(track)
+    audioPlayer.stopPlayback()
+
+    await new Promise(resolve => setTimeout(resolve, 30))
+    await p
+
+    expect(startSpy).not.toHaveBeenCalled()
+    expect(audioPlayer.isPlaying()).toBe(false)
+  })
+})

--- a/react-spectrogram/src/utils/audioPlayer.ts
+++ b/react-spectrogram/src/utils/audioPlayer.ts
@@ -27,6 +27,7 @@ class AudioPlayerEngine {
   private callbacks: Set<AudioPlayerCallback> = new Set()
   private currentTrack: any = null
   private currentTime: number = 0
+  private playRequestId = 0
 
   // Microphone-related properties
   private microphoneSource: MediaStreamAudioSourceNode | null = null
@@ -169,6 +170,11 @@ class AudioPlayerEngine {
       } catch (e) {
         // Source might already be stopped
       }
+      try {
+        this.source.disconnect()
+      } catch (e) {
+        // Source might already be disconnected
+      }
       this.source = null
     }
     
@@ -180,13 +186,14 @@ class AudioPlayerEngine {
 
   // Play a track
   async playTrack(track: any): Promise<void> {
+    const requestId = ++this.playRequestId
     try {
       const context = await this.initAudioContext()
-      
+
       // Stop any current playback and microphone
       this.stopCurrentPlayback()
       this.stopMicrophone()
-      
+
       // Reset state
       this.isPaused = false
       this.pausedTime = 0
@@ -194,7 +201,11 @@ class AudioPlayerEngine {
 
       // Load audio buffer
       const arrayBuffer = await track.file.arrayBuffer()
-      this.currentBuffer = await context.decodeAudioData(arrayBuffer)
+      const decodedBuffer = await context.decodeAudioData(arrayBuffer)
+      if (requestId !== this.playRequestId) {
+        return
+      }
+      this.currentBuffer = decodedBuffer
 
       // Create new source
       this.source = context.createBufferSource()
@@ -209,7 +220,7 @@ class AudioPlayerEngine {
       // Start playback
       this.source.start(0)
       this.startTime = context.currentTime
-      
+
       // Start time update loop
       this.updateTime()
 
@@ -251,13 +262,14 @@ class AudioPlayerEngine {
 
   // Stop playback
   stopPlayback(): void {
+    this.playRequestId++
     this.stopCurrentPlayback()
     this.stopMicrophone()
     this.isPaused = false
     this.pausedTime = 0
     this.currentTime = 0
     this.currentTrack = null
-    
+
     this.notifySubscribers()
   }
 


### PR DESCRIPTION
## Summary
- avoid overlapping audio by tracking play requests and ignoring stale decodes
- disconnect previous AudioBufferSourceNode on stop
- document current alignment with design/expectation requirements
- add unit tests for audio overlap handling

## Testing
- `npx vitest run src/utils/__tests__/audioPlayer.test.ts --threads=false`
- `npm run lint:fix` *(fails: ESLint couldn't find a configuration file)*
- `npm test` *(fails: numerous missing dependencies like @playwright/test and wasm bindings)*

------
https://chatgpt.com/codex/tasks/task_e_68a3a22cdd80832bac68270bc8a03b2f