### PR TITLE
fix(audio): resume playback at paused position

### DIFF
--- a/react-spectrogram/TECHNOTES.md
+++ b/react-spectrogram/TECHNOTES.md
@@ -1,0 +1,14 @@
+# Technical Notes
+
+## Issues Found
+- **Pause/Resume Reset**: `AudioPlayerEngine.resumePlayback` restarted tracks from the beginning instead of the paused position, violating the expectation that seeking and pausing preserve playback position.
+
+## Key Fixes
+- Added offset support to `playTrack` and updated `resumePlayback` to start from the stored `pausedTime`. This ensures playback resumes exactly where it was paused and aligns audio with the seek bar.
+- Extended unit tests for `audioPlayer` to cover resume behavior, ensuring regression coverage.
+
+## Performance
+- Changes keep hot path in TypeScript, as the fix involves state handling only and introduces no additional allocations.
+
+## Follow‑ups
+- Additional integration tests around rapid pause/resume cycles and track switching could further harden timing behavior.

--- a/react-spectrogram/src/utils/__tests__/audioPlayer.test.ts
+++ b/react-spectrogram/src/utils/__tests__/audioPlayer.test.ts
@@ -77,4 +77,18 @@ describe('audioPlayer overlap handling', () => {
     expect(startSpy).not.toHaveBeenCalled()
     expect(audioPlayer.isPlaying()).toBe(false)
   })
+
+  it('resumes from paused position', async () => {
+    const track = { file: { arrayBuffer: () => Promise.resolve(new ArrayBuffer(8)) } }
+    const startSpy = vi.spyOn(MockAudioBufferSourceNode.prototype, 'start')
+
+    await audioPlayer.playTrack(track)
+    const ctx = audioPlayer.getAudioContext() as any
+    ctx.currentTime = 5
+    audioPlayer.pausePlayback()
+    audioPlayer.resumePlayback()
+
+    expect(startSpy).toHaveBeenCalledTimes(2)
+    expect(startSpy.mock.calls[1][1]).toBeCloseTo(5)
+  })
 })

--- a/react-spectrogram/src/utils/audioPlayer.ts
+++ b/react-spectrogram/src/utils/audioPlayer.ts
@@ -185,7 +185,7 @@ class AudioPlayerEngine {
   }
 
   // Play a track
-  async playTrack(track: any): Promise<void> {
+  async playTrack(track: any, startAt = 0): Promise<void> {
     const requestId = ++this.playRequestId
     try {
       const context = await this.initAudioContext()
@@ -217,9 +217,9 @@ class AudioPlayerEngine {
         this.handleTrackEnded()
       }
 
-      // Start playback
-      this.source.start(0)
-      this.startTime = context.currentTime
+      // Start playback at the requested offset
+      this.source.start(0, startAt)
+      this.startTime = context.currentTime - startAt
 
       // Start time update loop
       this.updateTime()
@@ -256,7 +256,8 @@ class AudioPlayerEngine {
   // Resume playback
   resumePlayback(): void {
     if (this.isPaused && this.currentBuffer && this.currentTrack) {
-      this.playTrack(this.currentTrack)
+      const offset = this.pausedTime
+      this.playTrack(this.currentTrack, offset)
     }
   }
 


### PR DESCRIPTION
## Summary
- ensure AudioPlayer resumes from pause without restarting track
- add regression test covering pause/resume offset
- document behavior in TECHNOTES

## Testing
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*
- `npm run type-check` *(fails: TypeScript compilation errors)*
- `npm test` *(fails: missing dependencies and runtime errors)*

------
https://chatgpt.com/codex/tasks/task_e_68a3ab3bb008832bad545ee0221b41a0