### PR TITLE
fix: stabilize audio playback and cleanup resources

### DIFF
--- a/react-spectrogram/src/App.tsx
+++ b/react-spectrogram/src/App.tsx
@@ -12,6 +12,7 @@ import { useSettingsStore } from '@/stores/settingsStore'
 import { useKeyboardShortcuts } from '@/hooks/useKeyboardShortcuts'
 import { useScreenSize } from '@/hooks/useScreenSize'
 import { initWASM } from '@/utils/wasm'
+import { audioPlayer } from '@/utils/audioPlayer'
 import { cn } from '@/utils/cn'
 
 function App() {
@@ -53,6 +54,13 @@ function App() {
     initWASM().catch(error => {
       // Silently handle WASM initialization error
     })
+  }, [])
+
+  // Clean up audio resources on unmount
+  useEffect(() => {
+    return () => {
+      audioPlayer.cleanup()
+    }
   }, [])
 
   // Determine layout based on screen size and panel states

--- a/react-spectrogram/src/components/__tests__/AppCleanup.test.tsx
+++ b/react-spectrogram/src/components/__tests__/AppCleanup.test.tsx
@@ -1,0 +1,74 @@
+import { render } from '@testing-library/react'
+import { describe, it, expect, vi } from 'vitest'
+
+vi.mock('../../stores/audioStore', () => ({
+  useAudioStore: () => ({
+    currentTrack: null,
+    playlist: [],
+    currentTrackIndex: -1,
+    playTrack: vi.fn(),
+    removeFromPlaylist: vi.fn(),
+    reorderPlaylist: vi.fn(),
+    isPlaying: false,
+    isStopped: true,
+    currentTime: 0,
+    duration: 0,
+    volume: 1,
+    isMuted: false,
+    isLive: false,
+    isMicrophoneActive: false,
+  })
+}))
+
+vi.mock('../../stores/uiStore', () => ({
+  useUIStore: () => ({
+    isMobile: false,
+    metadataPanelOpen: false,
+    playlistPanelOpen: false,
+    settingsPanelOpen: false,
+    setMetadataPanelOpen: vi.fn(),
+    setPlaylistPanelOpen: vi.fn(),
+    setSettingsPanelOpen: vi.fn(),
+  })
+}))
+
+vi.mock('../../stores/settingsStore', () => ({
+  useSettingsStore: () => ({
+    theme: 'dark',
+    updateSettings: vi.fn(),
+    loadFromStorage: vi.fn(),
+  })
+}))
+
+vi.mock('../../hooks/useKeyboardShortcuts', () => ({
+  useKeyboardShortcuts: vi.fn(),
+}))
+
+vi.mock('../../hooks/useScreenSize', () => ({
+  useScreenSize: () => ({ isMobile: false, isTablet: false }),
+}))
+
+vi.mock('../../utils/wasm', () => ({
+  initWASM: vi.fn(() => Promise.resolve()),
+  extractMetadata: vi.fn().mockResolvedValue({}),
+  generateAmplitudeEnvelope: vi.fn().mockResolvedValue(new Float32Array()),
+}))
+
+vi.mock('../../utils/audioPlayer', () => ({
+  audioPlayer: {
+    cleanup: vi.fn(),
+    subscribe: vi.fn(() => () => {}),
+  },
+}))
+
+import App from '../../App'
+import { audioPlayer } from '../../utils/audioPlayer'
+
+describe('App cleanup', () => {
+  it('cleans up audio resources on unmount', () => {
+    const { unmount } = render(<App />)
+    unmount()
+    expect(audioPlayer.cleanup).toHaveBeenCalled()
+  })
+})
+

--- a/react-spectrogram/src/components/layout/Footer.tsx
+++ b/react-spectrogram/src/components/layout/Footer.tsx
@@ -1,13 +1,13 @@
-import React, { useRef, useCallback, useEffect, useState, useMemo } from 'react'
+import React, { useRef, useCallback, useMemo } from 'react'
 import { useAudioStore } from '@/stores/audioStore'
 import { useAudioFile } from '@/hooks/useAudioFile'
 import { useScreenSize } from '@/hooks/useScreenSize'
 import { WaveformSeekbar } from '@/components/spectrogram/WaveformSeekbar'
-import { 
-  Play, 
-  Pause, 
-  SkipBack, 
-  SkipForward, 
+import {
+  Play,
+  Pause,
+  SkipBack,
+  SkipForward,
   Square,
   Volume2,
   VolumeX,
@@ -19,27 +19,22 @@ import { cn } from '@/utils/cn'
 import { conditionalToast } from '@/utils/toast'
 
 export const Footer: React.FC = () => {
-  const seekBarRef = useRef<HTMLDivElement>(null)
   const volumeSliderRef = useRef<HTMLInputElement>(null)
-  const [isSeeking, setIsSeeking] = useState(false)
-  const [seekPosition, setSeekPosition] = useState(0)
   
-  const { 
-    isPlaying, 
-    isStopped, 
-    currentTime, 
-    duration, 
-    volume, 
+  const {
+    isPlaying,
+    isStopped,
+    currentTime,
+    duration,
+    volume,
     isMuted,
     currentTrack,
     playlist,
     currentTrackIndex
   } = useAudioStore()
-  
+
   const { isMobile, isTablet } = useScreenSize()
   const audioFile = useAudioFile()
-
-
 
   // Format time for display
   const formatTime = (seconds: number): string => {
@@ -47,38 +42,6 @@ export const Footer: React.FC = () => {
     const secs = Math.floor(seconds % 60)
     return `${mins}:${secs.toString().padStart(2, '0')}`
   }
-
-  // Handle seek bar interaction
-  const handleSeekStart = useCallback((event: React.MouseEvent | React.TouchEvent) => {
-    setIsSeeking(true)
-    handleSeek(event)
-  }, [])
-
-  const handleSeek = useCallback((event: React.MouseEvent | React.TouchEvent) => {
-    if (!seekBarRef.current || !isSeeking) return
-
-    const rect = seekBarRef.current.getBoundingClientRect()
-    const clientX = 'touches' in event ? event.touches[0].clientX : event.clientX
-    const x = clientX - rect.left
-    const percentage = Math.max(0, Math.min(1, x / rect.width))
-    
-    setSeekPosition(percentage)
-  }, [isSeeking])
-
-  const handleSeekEnd = useCallback(() => {
-    if (!isSeeking) return
-    
-    setIsSeeking(false)
-    const newTime = seekPosition * duration
-    audioFile.seekTo(newTime)
-  }, [isSeeking, seekPosition, duration, audioFile])
-
-  // Update seek position based on current time
-  useEffect(() => {
-    if (!isSeeking && duration > 0) {
-      setSeekPosition(currentTime / duration)
-    }
-  }, [currentTime, duration, isSeeking])
 
   // Handle volume change
   const handleVolumeChange = useCallback((event: React.ChangeEvent<HTMLInputElement>) => {

--- a/react-spectrogram/src/utils/__tests__/stopCurrentPlayback.test.ts
+++ b/react-spectrogram/src/utils/__tests__/stopCurrentPlayback.test.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect, vi } from 'vitest'
+import { audioPlayer } from '../audioPlayer'
+
+describe('stopCurrentPlayback', () => {
+  it('clears source and cancels animation frame without triggering onended', () => {
+    const mockStop = vi.fn(() => {
+      if (mockSource.onended) {
+        mockSource.onended(new Event('ended'))
+      }
+    })
+    const mockDisconnect = vi.fn()
+    const mockSource: any = {
+      stop: mockStop,
+      disconnect: mockDisconnect,
+      onended: vi.fn()
+    }
+
+    ;(audioPlayer as any).source = mockSource
+    ;(audioPlayer as any).animationFrameId = 1
+
+    const cancelSpy = vi.spyOn(global, 'cancelAnimationFrame')
+    const endedSpy = vi.spyOn(audioPlayer as any, 'handleTrackEnded')
+
+    ;(audioPlayer as any).stopCurrentPlayback()
+
+    expect(mockStop).toHaveBeenCalled()
+    expect(mockDisconnect).toHaveBeenCalled()
+    expect(cancelSpy).toHaveBeenCalledWith(1)
+    expect(mockSource.onended).toBeNull()
+    expect(endedSpy).not.toHaveBeenCalled()
+
+    cancelSpy.mockRestore()
+    endedSpy.mockRestore()
+  })
+})
+

--- a/react-spectrogram/src/utils/audioPlayer.ts
+++ b/react-spectrogram/src/utils/audioPlayer.ts
@@ -166,6 +166,8 @@ class AudioPlayerEngine {
   private stopCurrentPlayback() {
     if (this.source) {
       try {
+        // Prevent old onended handlers from firing after stop
+        this.source.onended = null
         this.source.stop()
       } catch (e) {
         // Source might already be stopped

--- a/react-spectrogram/src/utils/wasm.ts
+++ b/react-spectrogram/src/utils/wasm.ts
@@ -118,10 +118,23 @@ export async function extractMetadata(file: File): Promise<AudioMetadata> {
     const audio = new Audio()
     
     await new Promise((resolve, reject) => {
-      audio.addEventListener('loadedmetadata', resolve)
-      audio.addEventListener('error', reject)
+      const cleanup = () => {
+        audio.removeEventListener('loadedmetadata', onLoaded)
+        audio.removeEventListener('error', onError)
+      }
+      const onLoaded = () => {
+        cleanup()
+        resolve(null)
+      }
+      const onError = (e: Event) => {
+        cleanup()
+        reject(e)
+      }
+      audio.addEventListener('loadedmetadata', onLoaded)
+      audio.addEventListener('error', onError)
       audio.src = url
     })
+    audio.src = ''
 
     metadata.duration = audio.duration
     metadata.sample_rate = 44100 // Most common sample rate
@@ -177,10 +190,23 @@ async function extractBasicMetadata(file: File): Promise<AudioMetadata> {
     const url = URL.createObjectURL(file)
     
     await new Promise((resolve, reject) => {
-      audio.addEventListener('loadedmetadata', resolve)
-      audio.addEventListener('error', reject)
+      const cleanup = () => {
+        audio.removeEventListener('loadedmetadata', onLoaded)
+        audio.removeEventListener('error', onError)
+      }
+      const onLoaded = () => {
+        cleanup()
+        resolve(null)
+      }
+      const onError = (e: Event) => {
+        cleanup()
+        reject(e)
+      }
+      audio.addEventListener('loadedmetadata', onLoaded)
+      audio.addEventListener('error', onError)
       audio.src = url
     })
+    audio.src = ''
 
     metadata.duration = audio.duration
     metadata.sample_rate = 44100 // Most common sample rate


### PR DESCRIPTION
## Summary
- remove obsolete seekbar logic and rely on WaveformSeekbar
- stop previous audio sources to avoid overlap on track switch
- clean up audio context and metadata listeners on unmount
- add tests for audio cleanup and stopCurrentPlayback

## Testing
- `npm test src/utils/__tests__/stopCurrentPlayback.test.ts src/components/__tests__/AppCleanup.test.tsx` *(fails: unhandled errors but tests pass)*
- `npm run lint` *(fails: ESLint couldn't find configuration file)*

------
https://chatgpt.com/codex/tasks/task_e_68a3b955da44832bb45c3ea49d6c77ce