### PR TITLE
Refactor seekbar

### DIFF
--- a/react-spectrogram/src/utils/__tests__/waveform.test.ts
+++ b/react-spectrogram/src/utils/__tests__/waveform.test.ts
@@ -1,0 +1,18 @@
+import { describe, it, expect } from "vitest";
+import { computeWaveformPeaks, clearWaveformPeaksCache } from "../waveform";
+
+describe("computeWaveformPeaks", () => {
+  it("zeroes trailing bars without samples", () => {
+    const data = new Float32Array([1, -1, 1, -1]);
+    const peaks = computeWaveformPeaks(data, 10);
+    expect(peaks[peaks.length - 1]).toBe(0);
+  });
+
+  it("caches results per buffer and bar count", () => {
+    const data = new Float32Array([1, -1, 1, -1]);
+    const first = computeWaveformPeaks(data, 2);
+    const second = computeWaveformPeaks(data, 2);
+    expect(first).toBe(second);
+    clearWaveformPeaksCache();
+  });
+});

--- a/react-spectrogram/src/utils/waveform.ts
+++ b/react-spectrogram/src/utils/waveform.ts
@@ -37,6 +37,10 @@ export function computeWaveformPeaks(
 
   for (let i = 0; i < numBars; i++) {
     const start = i * samplesPerBar;
+    if (start >= audioData.length) {
+      peaks[i] = 0;
+      continue;
+    }
     const end = Math.min(start + samplesPerBar, audioData.length);
     let min = 1.0;
     let max = -1.0;
@@ -47,7 +51,7 @@ export function computeWaveformPeaks(
       if (sample > max) max = sample;
     }
 
-    peaks[i] = Math.max(Math.abs(min), Math.abs(max));
+    peaks[i] = start < end ? Math.max(Math.abs(min), Math.abs(max)) : 0;
   }
 
   cacheForBuffer.set(numBars, peaks);


### PR DESCRIPTION
## Summary
- center waveform bars and support theme colors for seekbar
- debounce seek updates and use pointer events
- ensure waveform peaks zero trailing bars

## Testing
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*
- `npm test` *(fails: TypeError: Cannot destructure property 'isMobile' of 'useScreenSize(...)' as it is undefined)*

------
https://chatgpt.com/codex/tasks/task_e_68a4425f82c8832ba7cc32d9faa350ac