### PR TITLE
feat: speed up track loading with async placeholders

### DIFF
--- a/react-spectrogram/src/components/__tests__/PlaylistPanelLoading.test.tsx
+++ b/react-spectrogram/src/components/__tests__/PlaylistPanelLoading.test.tsx
@@ -1,0 +1,34 @@
+import { render, screen } from '@testing-library/react'
+import { PlaylistPanel } from '../layout/PlaylistPanel'
+import { describe, it, vi } from 'vitest'
+
+vi.mock('@/hooks/useAudioFile', () => ({
+  useAudioFile: () => ({ loadAudioFiles: vi.fn() })
+}))
+
+describe('PlaylistPanel loading placeholder', () => {
+  it('shows spinner for loading tracks', () => {
+    const track: any = {
+      id: '1',
+      file: new File([], 't.mp3'),
+      metadata: { title: 't', artist: '', album: '', duration: 0 },
+      duration: 0,
+      url: '',
+      isLoading: true,
+    }
+
+    render(
+      <PlaylistPanel
+        tracks={[track]}
+        currentTrackIndex={-1}
+        isOpen={true}
+        onClose={() => {}}
+        onTrackSelect={() => {}}
+        onTrackRemove={() => {}}
+        onTrackReorder={() => {}}
+      />
+    )
+
+    expect(screen.getByTestId('track-loading-spinner')).toBeInTheDocument()
+  })
+})

--- a/react-spectrogram/src/components/layout/PlaylistPanel.tsx
+++ b/react-spectrogram/src/components/layout/PlaylistPanel.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useRef, useCallback } from 'react'
-import { X, Play, Trash2, FileAudio, Pause } from 'lucide-react'
+import { X, Play, Trash2, FileAudio, Pause, Loader2 } from 'lucide-react'
 import { AudioTrack } from '@/types'
 import { cn } from '@/utils/cn'
 import { formatDuration } from '@/utils/audio'
@@ -372,7 +372,18 @@ export function PlaylistPanel({
 
   const renderAlbumArt = (track: AudioTrack, index: number) => {
     const isCurrentTrack = currentTrackIndex === index
-    
+
+    if (track.isLoading) {
+      return (
+        <div
+          className="w-16 h-16 bg-neutral-800 rounded-md flex-shrink-0 flex items-center justify-center"
+          data-testid="track-loading-spinner"
+        >
+          <Loader2 size={20} className="text-neutral-500 animate-spin" />
+        </div>
+      )
+    }
+
     if (isCurrentTrack) {
       // Use the circular progress control for current track
       return (

--- a/react-spectrogram/src/hooks/__tests__/useAudioFile.test.ts
+++ b/react-spectrogram/src/hooks/__tests__/useAudioFile.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect, vi, act } from 'vitest'
+import { renderHook } from '@testing-library/react'
+import { useAudioFile } from '../useAudioFile'
+
+const state: any = { playlist: [], currentTrack: null }
+const addToPlaylist = vi.fn(track => state.playlist.push(track))
+const setCurrentTrack = vi.fn(track => { state.currentTrack = track })
+const updateTrack = vi.fn()
+
+const useAudioStore = () => ({ addToPlaylist, setCurrentTrack }) as any
+useAudioStore.getState = () => ({ ...state, updateTrack })
+
+vi.mock('@/stores/audioStore', () => ({ useAudioStore }))
+
+vi.mock('@/utils/wasm', () => ({
+  extractMetadata: vi.fn().mockResolvedValue({ title: 'meta', artist: 'artist', album: 'album', duration: 1, sample_rate: 44100 }),
+  generateAmplitudeEnvelope: vi.fn().mockResolvedValue(new Float32Array([1, 2, 3]))
+}))
+
+vi.mock('@/utils/artwork', () => ({
+  extractArtwork: vi.fn().mockResolvedValue({ artwork: null })
+}))
+
+vi.mock('@/utils/audioPlayer', () => ({
+  audioPlayer: {
+    initAudioContext: vi.fn().mockResolvedValue({ decodeAudioData: vi.fn().mockResolvedValue({ getChannelData: () => new Float32Array(0) }) })
+  }
+}))
+
+vi.mock('@/utils/toast', () => ({
+  conditionalToast: { success: vi.fn(), error: vi.fn() }
+}))
+
+describe('useAudioFile', () => {
+  it('adds placeholder and updates track asynchronously', async () => {
+    const file = new File(['data'], 'track.mp3', { type: 'audio/mpeg' })
+    ;(file as any).arrayBuffer = vi.fn().mockResolvedValue(new ArrayBuffer(8))
+    const { result } = renderHook(() => useAudioFile())
+    let placeholder: any
+    await act(async () => { placeholder = await result.current.loadAudioFile(file) })
+    expect(addToPlaylist).toHaveBeenCalledWith(expect.objectContaining({ isLoading: true }))
+    await Promise.resolve()
+    await Promise.resolve()
+    expect(updateTrack).toHaveBeenCalledWith(placeholder.id, expect.objectContaining({ isLoading: false }))
+  })
+})

--- a/react-spectrogram/src/stores/__tests__/audioStore.test.ts
+++ b/react-spectrogram/src/stores/__tests__/audioStore.test.ts
@@ -34,4 +34,26 @@ describe('audioStore', () => {
 
     expect(revokeTrackUrl).toHaveBeenCalledWith(track)
   })
+
+  it('updates track in playlist and currentTrack', () => {
+    const track: AudioTrack = {
+      id: '1',
+      file: new File([], 'test.mp3'),
+      metadata: { title: 't', artist: 'a', album: 'b', duration: 0 },
+      duration: 0,
+      url: 'blob:test',
+      isLoading: true,
+    }
+
+    const store = useAudioStore.getState()
+    store.setPlaylist([track])
+    store.setCurrentTrack(track)
+
+    store.updateTrack('1', { metadata: { ...track.metadata, title: 'updated' }, isLoading: false })
+
+    const updated = useAudioStore.getState().playlist[0]
+    expect(updated.metadata.title).toBe('updated')
+    expect(updated.isLoading).toBe(false)
+    expect(useAudioStore.getState().currentTrack?.metadata.title).toBe('updated')
+  })
 })

--- a/react-spectrogram/src/stores/audioStore.ts
+++ b/react-spectrogram/src/stores/audioStore.ts
@@ -17,6 +17,7 @@ interface AudioStore extends AudioState {
   setCurrentTrack: (track: AudioTrack | null) => void
   setPlaylist: (tracks: AudioTrack[]) => void
   addToPlaylist: (track: AudioTrack) => void
+  updateTrack: (id: string, updates: Partial<AudioTrack>) => void
   removeFromPlaylist: (index: number) => void
   reorderPlaylist: (fromIndex: number, toIndex: number) => void
   setCurrentTrackIndex: (index: number) => void
@@ -67,7 +68,23 @@ export const useAudioStore = create<AudioStore>()(
       const { playlist } = get()
       set({ playlist: [...playlist, track] })
     },
-    
+
+    updateTrack: (id, updates) => {
+      const { playlist, currentTrack } = get()
+      const index = playlist.findIndex(t => t.id === id)
+      if (index === -1) return
+      const updatedTrack = { ...playlist[index], ...updates }
+      const newPlaylist = [...playlist]
+      newPlaylist[index] = updatedTrack
+      const newState: Partial<AudioState> & { playlist: AudioTrack[] } = {
+        playlist: newPlaylist,
+      }
+      if (currentTrack && currentTrack.id === id) {
+        newState.currentTrack = updatedTrack
+      }
+      set(newState)
+    },
+
     removeFromPlaylist: (index) => {
       const { playlist, currentTrackIndex } = get()
       const trackToRemove = playlist[index]

--- a/react-spectrogram/src/types/index.ts
+++ b/react-spectrogram/src/types/index.ts
@@ -112,6 +112,7 @@ export interface AudioTrack {
   url: string;
   artwork?: ArtworkSource;
   audioData?: Float32Array; // Audio buffer data for waveform generation
+  isLoading?: boolean;
 }
 
 export interface SpectrogramSettings {


### PR DESCRIPTION
## Summary
- load audio files in parallel with background processing
- update audio store with track updates via new `updateTrack`
- show loading spinner for tracks still processing

## Testing
- `npm run lint:fix` *(fails: ESLint couldn't find a configuration file)*
- `npm run test:coverage` *(fails: module import and mocking issues)*


------
https://chatgpt.com/codex/tasks/task_e_68a457434e8c832bb74feb31f177788b