### PR TITLE
feat: add alternating info with marquee

### DIFF
--- a/react-spectrogram/src/components/__tests__/AlternatingInfo.test.tsx
+++ b/react-spectrogram/src/components/__tests__/AlternatingInfo.test.tsx
@@ -1,0 +1,73 @@
+import React from "react";
+import { render, screen, act } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+vi.mock("framer-motion", () => ({
+  AnimatePresence: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  motion: { span: (props: any) => <span {...props} /> },
+}));
+import { AlternatingInfo } from "../layout/AlternatingInfo";
+
+describe("AlternatingInfo", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("alternates between artist and album", async () => {
+    render(
+      <AlternatingInfo
+        artist="Artist Name"
+        album="Album Title"
+        interval={1000}
+      />,
+    );
+
+    await act(async () => {});
+
+    const getLastText = () => {
+      const nodes = screen.getAllByTestId("alternating-info-text");
+      return nodes[nodes.length - 1];
+    };
+
+    expect(getLastText()).toHaveTextContent("Artist Name");
+
+    await vi.advanceTimersByTimeAsync(1000);
+    expect(getLastText()).toHaveTextContent("Album Title");
+
+    await vi.advanceTimersByTimeAsync(1000);
+    expect(getLastText()).toHaveTextContent("Artist Name");
+  });
+
+  it("activates marquee when text overflows", () => {
+    render(
+      <div style={{ width: "50px" }}>
+        <AlternatingInfo
+          artist="This is a very long artist name that should overflow"
+          album="Album"
+          interval={1000}
+        />
+      </div>,
+    );
+
+    const container = screen.getByTestId("alternating-info-text").parentElement as HTMLElement;
+    const span = screen.getByTestId("alternating-info-text");
+
+    Object.defineProperty(container, "clientWidth", {
+      value: 50,
+      configurable: true,
+    });
+    Object.defineProperty(span, "scrollWidth", {
+      value: 200,
+      configurable: true,
+    });
+
+    act(() => {
+      window.dispatchEvent(new Event("resize"));
+    });
+
+    expect(span.classList.contains("marquee")).toBe(true);
+  });
+});

--- a/react-spectrogram/src/components/layout/AlternatingInfo.tsx
+++ b/react-spectrogram/src/components/layout/AlternatingInfo.tsx
@@ -1,0 +1,75 @@
+import React, { useEffect, useRef, useState } from "react";
+import { AnimatePresence, motion } from "framer-motion";
+import { cn } from "@/utils/cn";
+
+interface AlternatingInfoProps {
+  artist: string;
+  album: string;
+  /** Interval in milliseconds to switch between artist and album */
+  interval?: number;
+  className?: string;
+}
+
+export const AlternatingInfo: React.FC<AlternatingInfoProps> = ({
+  artist,
+  album,
+  interval = 4000,
+  className,
+}) => {
+  const [showArtist, setShowArtist] = useState(true);
+  const containerRef = useRef<HTMLDivElement>(null);
+  const [isOverflow, setIsOverflow] = useState(false);
+
+  useEffect(() => {
+    let timeout: ReturnType<typeof setTimeout>;
+    const switchInfo = () => {
+      setShowArtist((prev) => !prev);
+      timeout = setTimeout(switchInfo, interval);
+    };
+    timeout = setTimeout(switchInfo, interval);
+    return () => clearTimeout(timeout);
+  }, [interval]);
+
+  const checkOverflow = () => {
+    const container = containerRef.current;
+    const span = container?.firstElementChild as HTMLElement | null;
+    if (container && span) {
+      setIsOverflow(span.scrollWidth > container.clientWidth);
+    }
+  };
+
+  useEffect(() => {
+    checkOverflow();
+    window.addEventListener("resize", checkOverflow);
+    return () => window.removeEventListener("resize", checkOverflow);
+    // Depend on values that can change text size
+  }, [artist, album, showArtist]);
+
+  const content = showArtist ? artist : album;
+  const fallback = showArtist ? "Unknown Artist" : "Unknown Album";
+  const displayText = content || fallback;
+
+  return (
+    <div ref={containerRef} className="relative min-w-0 overflow-hidden">
+      <AnimatePresence mode="wait">
+        <motion.span
+          key={showArtist ? "artist" : "album"}
+          initial={{ opacity: 0 }}
+          animate={{ opacity: 1 }}
+          exit={{ opacity: 0 }}
+          transition={{ duration: 0.5 }}
+          className={cn(
+            className,
+            "block",
+            isOverflow ? "marquee" : "truncate",
+          )}
+          data-testid="alternating-info-text"
+        >
+          {displayText}
+        </motion.span>
+      </AnimatePresence>
+    </div>
+  );
+};
+
+export default AlternatingInfo;

--- a/react-spectrogram/src/components/layout/Footer.tsx
+++ b/react-spectrogram/src/components/layout/Footer.tsx
@@ -17,6 +17,7 @@ import {
 } from "lucide-react";
 import { cn } from "@/utils/cn";
 import { conditionalToast } from "@/utils/toast";
+import { AlternatingInfo } from "./AlternatingInfo";
 
 export const Footer: React.FC = () => {
   const volumeSliderRef = useRef<HTMLInputElement>(null);
@@ -271,14 +272,14 @@ export const Footer: React.FC = () => {
               >
                 {currentTrack.metadata.title || currentTrack.file.name}
               </h4>
-              <p
+              <AlternatingInfo
+                artist={currentTrack.metadata.artist || "Unknown Artist"}
+                album={currentTrack.metadata.album || "Unknown Album"}
                 className={cn(
-                  "text-neutral-400 truncate",
+                  "text-neutral-400",
                   isMobile ? "text-xs" : "text-xs",
                 )}
-              >
-                {currentTrack.metadata.artist || "Unknown Artist"}
-              </p>
+              />
             </div>
           )}
         </div>

--- a/react-spectrogram/src/index.css
+++ b/react-spectrogram/src/index.css
@@ -311,6 +311,22 @@
   }
 }
 
+/* Marquee animation for overflowing text */
+@keyframes marquee {
+  0% {
+    transform: translateX(0);
+  }
+  100% {
+    transform: translateX(-100%);
+  }
+}
+
+.marquee {
+  display: inline-block;
+  white-space: nowrap;
+  animation: marquee 8s linear infinite;
+}
+
 @layer utilities {
   /* Override py-1 to remove padding */
   .py-1 {


### PR DESCRIPTION
## Summary
- toggle between artist and album in footer with cross-fade
- marquee overflowed text in footer info
- add tests for AlternatingInfo behavior

## Testing
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*
- `npm test` *(fails: useScreenSize undefined and other test failures)*
- `npx vitest run src/components/__tests__/AlternatingInfo.test.tsx` *(passes with unhandled error about removeEventListener)*
- `npx vitest run src/components/__tests__/AlternatingInfo.test.tsx --coverage` *(passes with unhandled error about removeEventListener)*

------
https://chatgpt.com/codex/tasks/task_e_68a45a579088832bbdd361104e59509f