### PR TITLE
feat: add fuzzy search suggestions

### DIFF
--- a/react-spectrogram/src/components/__tests__/PlaylistSearch.test.tsx
+++ b/react-spectrogram/src/components/__tests__/PlaylistSearch.test.tsx
@@ -39,6 +39,19 @@ describe('PlaylistPanel search', () => {
       },
       duration: 200,
       url: 'url2'
+    },
+    {
+      id: '3',
+      file: new File(['test'], 'gamma.mp3', { type: 'audio/mp3' }),
+      metadata: {
+        title: 'Gamma Song',
+        artist: 'Artist3',
+        album: 'Album3',
+        genre: 'Jazz',
+        year: 2002
+      },
+      duration: 210,
+      url: 'url3'
     }
   ]
 
@@ -56,12 +69,15 @@ describe('PlaylistPanel search', () => {
     )
 
     const datalist = screen.getByTestId('playlist-search-suggestions')
-    const options = Array.from(datalist.querySelectorAll('option')).map((o) => o.getAttribute('value'))
-    expect(options).toContain('Alpha Song')
-    expect(options).toContain('Artist2')
+    const options = Array.from(datalist.querySelectorAll('option'))
+    expect(options).toHaveLength(11)
+    const alphaOption = datalist.querySelector('option[value="Alpha Song"]')
+    expect(alphaOption?.getAttribute('label')).toBe('🎵 Alpha Song')
+    expect(options[options.length - 1].disabled).toBe(true)
+    expect(options[options.length - 1].textContent).toContain('more')
 
     const input = screen.getByTestId('playlist-search-input')
-    fireEvent.change(input, { target: { value: 'Artist2' } })
+    fireEvent.change(input, { target: { value: 'Art2' } })
     expect(screen.getByText('Beta Song')).toBeInTheDocument()
     expect(screen.queryByText('Alpha Song')).toBeNull()
 

--- a/react-spectrogram/src/utils/__tests__/fuzzy.test.ts
+++ b/react-spectrogram/src/utils/__tests__/fuzzy.test.ts
@@ -1,0 +1,13 @@
+import { fuzzyMatch, fuzzyScore } from '../fuzzy'
+
+describe('fuzzy utils', () => {
+  it('matches subsequences and scores gaps', () => {
+    expect(fuzzyMatch('abc', 'a-b-c')).toBe(true)
+    expect(fuzzyScore('abc', 'a-b-c')).toBe(2)
+  })
+
+  it('returns Infinity when no match', () => {
+    expect(fuzzyScore('abc', 'ac')).toBe(Infinity)
+    expect(fuzzyMatch('abc', 'ac')).toBe(false)
+  })
+})

--- a/react-spectrogram/src/utils/fuzzy.ts
+++ b/react-spectrogram/src/utils/fuzzy.ts
@@ -1,0 +1,17 @@
+export function fuzzyScore(pattern: string, text: string): number {
+  pattern = pattern.toLowerCase()
+  text = text.toLowerCase()
+  let score = 0
+  let ti = 0
+  for (let pi = 0; pi < pattern.length; pi++) {
+    const found = text.indexOf(pattern[pi], ti)
+    if (found === -1) return Infinity
+    score += found - ti
+    ti = found + 1
+  }
+  return score
+}
+
+export function fuzzyMatch(pattern: string, text: string): boolean {
+  return fuzzyScore(pattern, text) !== Infinity
+}


### PR DESCRIPTION
## Summary
- add fuzzyMatch and fuzzyScore utilities
- limit playlist search suggestions to 10 fuzzy-ranked items with type symbols and overflow indicator
- test playlist search suggestion limit and fuzzy utilities

## Testing
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*
- `npm run test:coverage` *(fails: Failed to resolve imports for Playwright tests and wasm modules)*

------
https://chatgpt.com/codex/tasks/task_e_68a46b3e979c832b960795c13fae549d