### PR TITLE
feat: lazy load playlist album art

### DIFF
--- a/react-spectrogram/src/components/__tests__/PlaylistPanelLoading.test.tsx
+++ b/react-spectrogram/src/components/__tests__/PlaylistPanelLoading.test.tsx
@@ -32,3 +32,69 @@ describe('PlaylistPanel loading placeholder', () => {
     expect(screen.getByTestId('track-loading-spinner')).toBeInTheDocument()
   })
 })
+
+describe('PlaylistPanel artwork visibility', () => {
+  it('removes artwork when out of view and restores it when visible again', () => {
+    const art = new Uint8Array(200).fill(1)
+    const track: any = {
+      id: '1',
+      file: new File([], 't.mp3'),
+      metadata: {
+        title: 't',
+        artist: '',
+        album: '',
+        duration: 0,
+        album_art: art,
+        album_art_mime: 'image/png',
+      },
+      duration: 0,
+      url: '',
+    }
+
+    const observers: any[] = []
+    const OriginalIO = globalThis.IntersectionObserver
+    class MockIO {
+      cb: any
+      el?: Element
+      constructor(cb: any) {
+        this.cb = cb
+        observers.push(this)
+      }
+      observe = (el: Element) => {
+        this.el = el
+      }
+      unobserve = () => {}
+      disconnect = () => {}
+      trigger(isIntersecting: boolean) {
+        this.cb([{ isIntersecting, target: this.el! }])
+      }
+    }
+    ;(globalThis as any).IntersectionObserver = MockIO
+
+    render(
+      <PlaylistPanel
+        tracks={[track]}
+        currentTrackIndex={-1}
+        isOpen={true}
+        onClose={() => {}}
+        onTrackSelect={() => {}}
+        onTrackRemove={() => {}}
+        onTrackReorder={() => {}}
+      />
+    )
+
+    const img = screen.getByAltText('Album Art') as HTMLImageElement
+    const observer = observers[0]
+
+    observer.trigger(true)
+    expect(img.getAttribute('src')).toContain('blob:')
+
+    observer.trigger(false)
+    expect(img.getAttribute('src')).toBeNull()
+
+    observer.trigger(true)
+    expect(img.getAttribute('src')).toContain('blob:')
+
+    ;(globalThis as any).IntersectionObserver = OriginalIO
+  })
+})


### PR DESCRIPTION
## Summary
- add LazyAlbumArt component using IntersectionObserver to revoke object URLs when images leave view
- integrate lazy loading for playlist and current track artwork
- test that artwork src is cleared off-screen and restored when re-entering

## Testing
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*
- `npm run test:coverage` *(fails: expected "spy" to be called 1 times, but got 0 times)*
- `npx vitest run src/components/__tests__/PlaylistPanelLoading.test.tsx --coverage` *(fails: Failed to resolve import "../wasm/web_spectrogram" from "src/utils/wasm.ts". Does the file exist?)*

------
https://chatgpt.com/codex/tasks/task_e_68a46f741840832b938c0b9dffc2d896