### PR TITLE
feat: add WebGL spectrogram renderer

### DIFF
--- a/web-spectrogram/app.mjs
+++ b/web-spectrogram/app.mjs
@@ -68,7 +68,40 @@ function drawSpectrogramWebGL(gl, canvas, res) {
   const fs = gl.createShader(gl.FRAGMENT_SHADER);
   gl.shaderSource(
     fs,
-    "precision highp float; varying vec2 v; uniform sampler2D m; uniform float maxMag; const float FLOOR_DB=-80.0; vec3 rainbow(float t){ if(t<0.25){ float local=t/0.25; return mix(vec3(0.0,0.0,0.0), vec3(0.0,0.0,1.0), local);} else if(t<0.5){ float local=(t-0.25)/0.25; return mix(vec3(0.0,0.0,1.0), vec3(0.0,1.0,1.0), local);} else if(t<0.75){ float local=(t-0.5)/0.25; return mix(vec3(0.0,1.0,1.0), vec3(1.0,1.0,0.0), local);} else if(t<0.9){ float local=(t-0.75)/0.15; return mix(vec3(1.0,1.0,0.0), vec3(1.0,0.0,0.0), local);} float local=(t-0.9)/0.1; return mix(vec3(1.0,0.0,0.0), vec3(1.0,1.0,1.0), local);} void main(){ float mag=texture2D(m,v).r; float ratio=mag/maxMag; float db=20.0*log(max(ratio,1e-12)); float t=(db-FLOOR_DB)/(-FLOOR_DB); gl_FragColor=vec4(rainbow(clamp(t,0.0,1.0)),1.0); }",
+  const fragmentShaderSource = `
+    precision highp float;
+    varying vec2 v;
+    uniform sampler2D m;
+    uniform float maxMag;
+    const float FLOOR_DB = -80.0;
+    vec3 rainbow(float t) {
+      if (t < 0.25) {
+        float local = t / 0.25;
+        return mix(vec3(0.0, 0.0, 0.0), vec3(0.0, 0.0, 1.0), local);
+      } else if (t < 0.5) {
+        float local = (t - 0.25) / 0.25;
+        return mix(vec3(0.0, 0.0, 1.0), vec3(0.0, 1.0, 1.0), local);
+      } else if (t < 0.75) {
+        float local = (t - 0.5) / 0.25;
+        return mix(vec3(0.0, 1.0, 1.0), vec3(1.0, 1.0, 0.0), local);
+      } else if (t < 0.9) {
+        float local = (t - 0.75) / 0.15;
+        return mix(vec3(1.0, 1.0, 0.0), vec3(1.0, 0.0, 0.0), local);
+      }
+      float local = (t - 0.9) / 0.1;
+      return mix(vec3(1.0, 0.0, 0.0), vec3(1.0, 1.0, 1.0), local);
+    }
+    void main() {
+      float mag = texture2D(m, v).r;
+      float ratio = mag / maxMag;
+      float db = 20.0 * log(max(ratio, 1e-12));
+      float t = (db - FLOOR_DB) / (-FLOOR_DB);
+      gl_FragColor = vec4(rainbow(clamp(t, 0.0, 1.0)), 1.0);
+    }
+  `;
+  gl.shaderSource(
+    fs,
+    fragmentShaderSource,
   );
   gl.compileShader(fs);
 

--- a/web-spectrogram/app.mjs
+++ b/web-spectrogram/app.mjs
@@ -123,7 +123,7 @@ export function drawSpectrogram(
 ) {
   const gl = canvas.getContext("webgl2") || canvas.getContext("webgl") || null;
   if (gl) {
-    drawSpectrogramWebGL(gl, canvas, res, colormap);
+    drawSpectrogramWebGL(gl, canvas, res);
     return;
   }
   if (typeof navigator !== "undefined" && navigator.gpu) {

--- a/web-spectrogram/app.mjs
+++ b/web-spectrogram/app.mjs
@@ -166,7 +166,6 @@ export function drawSpectrogram(
       drawSpectrogramCanvas(canvas, res, colorFn, colormap);
       return;
     }
-  }
   drawSpectrogramCanvas(canvas, res, colorFn, colormap);
 }
 


### PR DESCRIPTION
## Summary
- add WebGL fragment shader renderer for spectrograms
- fall back to Canvas 2D when GPU contexts are missing
- expand tests for GPU path and fallback

## Testing
- `npx prettier -w web-spectrogram/app.mjs web-spectrogram/tests/app.test.mjs`
- `npx eslint web-spectrogram/app.mjs web-spectrogram/tests/app.test.mjs` *(fails: ESLint couldn't find an eslint.config.* file)*
- `node --test --experimental-test-coverage web-spectrogram/tests/app.test.mjs`


------
https://chatgpt.com/codex/tasks/task_e_68a46fabe804832baf95b27927b27edc

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* New Features
  * Added hardware-accelerated spectrogram rendering with automatic WebGL usage when available, falling back to 2D Canvas. Prepares for future WebGPU support.
  * Delivers smoother, faster rendering for larger spectrograms without changing how colors or normalization appear.
* Tests
  * Added tests covering the WebGL rendering path and updated tests for the 2D Canvas fallback to ensure correct context selection and drawing behavior.
* Chores
  * No public API changes; existing methods and signatures remain intact.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->