### PR TITLE
Add microphone streaming to web spectrogram

### DIFF
--- a/web-spectrogram/app.mjs
+++ b/web-spectrogram/app.mjs
@@ -14,12 +14,16 @@ export function ensureBuffer() {
 ensureBuffer();
 
 let wasm;
+let audioCtx;
+let processor;
+let stream;
 /* c8 ignore start */
 async function loadWasm() {
   if (!wasm) {
     if (typeof window === "undefined") {
       wasm = await import("./tests/pkg/web_spectrogram.js");
     } else {
+      /* c8 ignore next 2 */
       wasm = await import("./pkg/web_spectrogram.js");
       await wasm.default();
     }
@@ -58,6 +62,52 @@ export function drawSpectrogram(
   ctx.putImageData(img, 0, 0);
 }
 
+export async function startMic(canvas = document.getElementById("spec")) {
+  const w = await loadWasm();
+  try {
+    stream = await navigator.mediaDevices.getUserMedia({ audio: true });
+  } catch (err) {
+    console.error("microphone access denied", err);
+    return false;
+  }
+  audioCtx = new AudioContext();
+  const source = audioCtx.createMediaStreamSource(stream);
+  processor = audioCtx.createScriptProcessor(1024, 1, 1);
+  source.connect(processor);
+  processor.connect(audioCtx.destination);
+  const ctx = canvas.getContext("2d");
+  if (!canvas.height) canvas.height = 512;
+  if (!canvas.width) canvas.width = 512;
+  processor.onaudioprocess = (e) => {
+    const samples = e.inputBuffer.getChannelData(0);
+    const row = w.compute_frame(samples);
+    if (row.length === 0) return;
+    const { width, height } = canvas;
+    const img = ctx.getImageData(1, 0, width - 1, height);
+    ctx.putImageData(img, 0, 0);
+    const newImg = new ImageData(new Uint8ClampedArray(row), 1, height);
+    ctx.putImageData(newImg, width - 1, 0);
+  };
+  w.reset_state();
+  return true;
+}
+
+export function stopMic() {
+  if (processor) {
+    processor.disconnect();
+    processor = null;
+  }
+  if (stream) {
+    stream.getTracks().forEach((t) => t.stop());
+    stream = null;
+  }
+  if (audioCtx) {
+    audioCtx.close();
+    audioCtx = null;
+  }
+  wasm?.reset_state();
+}
+
 /* c8 ignore start */
 export async function initApp() {
   console.log("loading wasm");
@@ -65,6 +115,8 @@ export async function initApp() {
   console.log("wasm loaded");
   const fileInput = document.getElementById("file");
   const canvas = document.getElementById("spec");
+  const startBtn = document.getElementById("start");
+  const stopBtn = document.getElementById("stop");
   fileInput.addEventListener("change", async (e) => {
     const file = e.target.files[0];
     if (!file) return;
@@ -77,11 +129,28 @@ export async function initApp() {
     const res = w.stft_magnitudes(samples, 1024, 512);
     drawSpectrogram(canvas, res, w.color_from_magnitude_u8);
   });
+  /* c8 ignore start */
+  if (startBtn && stopBtn) {
+    startBtn.addEventListener("click", async () => {
+      startBtn.disabled = true;
+      stopBtn.disabled = false;
+      const ok = await startMic(canvas);
+      if (!ok) {
+        startBtn.disabled = false;
+        stopBtn.disabled = true;
+      }
+    });
+    stopBtn.addEventListener("click", () => {
+      stopMic();
+      startBtn.disabled = false;
+      stopBtn.disabled = true;
+    });
+  }
+  /* c8 ignore stop */
 }
 /* c8 ignore stop */
 
-/* c8 ignore start */
+/* c8 ignore next 3 */
 if (typeof window !== "undefined") {
   initApp();
 }
-/* c8 ignore stop */

--- a/web-spectrogram/index.html
+++ b/web-spectrogram/index.html
@@ -1,13 +1,15 @@
-<!DOCTYPE html>
+<!doctype html>
 <html>
-<head>
-  <meta charset="utf-8" />
-  <title>Web Spectrogram</title>
-  <link rel="manifest" href="manifest.json">
-</head>
-<body>
-  <input type="file" id="file" accept="audio/*" />
-  <canvas id="spec"></canvas>
-  <script type="module" src="app.mjs"></script>
-</body>
+  <head>
+    <meta charset="utf-8" />
+    <title>Web Spectrogram</title>
+    <link rel="manifest" href="manifest.json" />
+  </head>
+  <body>
+    <input type="file" id="file" accept="audio/*" />
+    <button id="start">Start Mic</button>
+    <button id="stop" disabled>Stop Mic</button>
+    <canvas id="spec"></canvas>
+    <script type="module" src="app.mjs"></script>
+  </body>
 </html>

--- a/web-spectrogram/tests/pkg/web_spectrogram.js
+++ b/web-spectrogram/tests/pkg/web_spectrogram.js
@@ -1,4 +1,12 @@
 export const Colormap = { Rainbow: 0 };
-export function color_from_magnitude_u8() { return [1,2,3]; }
-export function stft_magnitudes() { return { mags: [1,1], width: 1, height: 2, max_mag: 1 }; }
+export function color_from_magnitude_u8() {
+  return [1, 2, 3];
+}
+export function stft_magnitudes() {
+  return { mags: [1, 1], width: 1, height: 2, max_mag: 1 };
+}
 export default async function init() {}
+export function compute_frame(samples) {
+  return samples.length >= 1024 ? new Uint8Array(512 * 4) : new Uint8Array();
+}
+export function reset_state() {}


### PR DESCRIPTION
## Summary
- capture microphone audio via ScriptProcessor and stream frames to the spectrogram renderer
- wire up start/stop controls and reset on stop
- add tests for microphone start/stop and permission errors

## Testing
- `npx eslint web-spectrogram/app.mjs web-spectrogram/tests/app.test.mjs` *(fails: ESLint couldn't find an eslint.config.(js|mjs|cjs) file)*
- `npx prettier -w web-spectrogram/app.mjs web-spectrogram/index.html web-spectrogram/tests/app.test.mjs`
- `cargo fmt`
- `cargo clippy -p web-spectrogram -- -D warnings`
- `node --test --experimental-test-coverage web-spectrogram/tests/app.test.mjs`
- `cargo test -p web-spectrogram`


------
https://chatgpt.com/codex/tasks/task_e_68a46fad3c34832bb2b2969fe559f31a

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* New Features
  * Live microphone input for real-time spectrogram rendering.
  * Added Start Mic and Stop Mic buttons for interactive control.
  * Smooth start/stop workflow with UI state updates and graceful shutdown.
  * Clear handling of microphone permission denials with immediate feedback.

* Tests
  * Added coverage for starting/stopping live mic mode, permission-denied scenarios, and canvas update behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->