### PR TITLE
Enable WASM SIMD and multithreading support

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,5 @@
+[target.wasm32-unknown-unknown]
+rustflags = [
+    "-C", "target-feature=+simd128",
+    "-C", "target-feature=+atomics",
+]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,7 +41,7 @@ parallel = ["rayon"]
 x86_64 = []      # AVX/SSE on x86_64
 sse = []         # Force SSE2-only backend
 aarch64 = []     # NEON on 64-bit ARM
-wasm = []        # WebAssembly SIMD128
+wasm = ["simd"] # WebAssembly SIMD128, always include portable SIMD for heavy modules
 avx2 = []        # Enable AVX2-specific code paths
 avx512 = []      # Enable AVX-512 code paths
 

--- a/web-spectrogram/tests/app.test.mjs
+++ b/web-spectrogram/tests/app.test.mjs
@@ -5,7 +5,10 @@ import {
   drawSpectrogram,
   initApp,
   ensureBuffer,
+  loadWasm,
+  ensureSharedArrayBuffer,
 } from "../app.mjs";
+import { getThreadPoolInit } from "./pkg/web_spectrogram.js";
 
 test("magnitudeToDb converts correctly", () => {
   const db = magnitudeToDb(1, 1);
@@ -32,6 +35,27 @@ test("drawSpectrogram writes pixels", () => {
   assert.equal(ctx.last.data[0], 1);
   assert.equal(ctx.last.data[1], 2);
   assert.equal(ctx.last.data[2], 3);
+});
+
+test("loadWasm initializes thread pool", async () => {
+  await loadWasm();
+  const cores = global.navigator?.hardwareConcurrency || 1;
+  assert.equal(getThreadPoolInit(), cores);
+});
+
+test("ensureSharedArrayBuffer works", () => {
+  assert.doesNotThrow(() => ensureSharedArrayBuffer());
+});
+
+test("ensureSharedArrayBuffer throws when missing", () => {
+  const original = global.SharedArrayBuffer;
+  try {
+    // eslint-disable-next-line no-global-assign
+    global.SharedArrayBuffer = undefined;
+    assert.throws(() => ensureSharedArrayBuffer());
+  } finally {
+    global.SharedArrayBuffer = original;
+  }
 });
 
 test("initApp loads and processes file", async () => {

--- a/web-spectrogram/tests/pkg/web_spectrogram.js
+++ b/web-spectrogram/tests/pkg/web_spectrogram.js
@@ -1,4 +1,7 @@
 export const Colormap = { Rainbow: 0 };
 export function color_from_magnitude_u8() { return [1,2,3]; }
 export function stft_magnitudes() { return { mags: [1,1], width: 1, height: 2, max_mag: 1 }; }
+export let threadPoolInit = 0;
+export async function initThreadPool(n) { threadPoolInit = n; }
+export function getThreadPoolInit() { return threadPoolInit; }
 export default async function init() {}


### PR DESCRIPTION
## Summary
- ensure wasm feature pulls in portable SIMD
- add wasm simd128/atomics compile flags
- initialize WASM thread pool with SharedArrayBuffer check

## Testing
- `cargo fmt --all`
- `cargo clippy --all-targets --all-features`
- `cargo test`
- `node --test --experimental-test-coverage web-spectrogram/tests/app.test.mjs`


------
https://chatgpt.com/codex/tasks/task_e_68a46fb5e87c832b818165aa384bb7a7

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * WebAssembly now auto-initializes a thread pool based on available CPU cores when supported.
  * Clearer error shown in browsers without SharedArrayBuffer support.
  * Public API updated to allow direct loading of the WebAssembly module.

* **Performance**
  * Enabled WebAssembly SIMD and atomics for faster processing where supported.

* **Tests**
  * Added tests for thread-pool initialization and SharedArrayBuffer handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->