### PR TITLE
feat: cache audio metadata

### DIFF
--- a/react-spectrogram/src/hooks/__tests__/useAudioFile.test.ts
+++ b/react-spectrogram/src/hooks/__tests__/useAudioFile.test.ts
@@ -1,20 +1,40 @@
-import { describe, it, expect, vi, act } from 'vitest'
-import { renderHook } from '@testing-library/react'
-import { useAudioFile } from '../useAudioFile'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { renderHook, act, waitFor } from '@testing-library/react'
 
-const state: any = { playlist: [], currentTrack: null }
-const addToPlaylist = vi.fn(track => state.playlist.push(track))
-const setCurrentTrack = vi.fn(track => { state.currentTrack = track })
-const updateTrack = vi.fn()
-
-const useAudioStore = () => ({ addToPlaylist, setCurrentTrack }) as any
-useAudioStore.getState = () => ({ ...state, updateTrack })
+const {
+  state,
+  addToPlaylist,
+  setCurrentTrack,
+  updateTrack,
+  useAudioStore
+} = vi.hoisted(() => {
+  const state: any = { playlist: [], currentTrack: null }
+  const addToPlaylist = vi.fn((track) => state.playlist.push(track))
+  const setCurrentTrack = vi.fn((track) => { state.currentTrack = track })
+  const updateTrack = vi.fn()
+  const useAudioStore: any = () => ({ addToPlaylist, setCurrentTrack })
+  useAudioStore.getState = () => ({ ...state, updateTrack })
+  return { state, addToPlaylist, setCurrentTrack, updateTrack, useAudioStore }
+})
 
 vi.mock('@/stores/audioStore', () => ({ useAudioStore }))
 
+const { extractMetadata, generateAmplitudeEnvelope } = vi.hoisted(() => {
+  return {
+    extractMetadata: vi.fn().mockResolvedValue({
+      title: 'meta',
+      artist: 'artist',
+      album: 'album',
+      duration: 1,
+      sample_rate: 44100,
+    }),
+    generateAmplitudeEnvelope: vi.fn().mockResolvedValue(new Float32Array([1, 2, 3]))
+  }
+})
+
 vi.mock('@/utils/wasm', () => ({
-  extractMetadata: vi.fn().mockResolvedValue({ title: 'meta', artist: 'artist', album: 'album', duration: 1, sample_rate: 44100 }),
-  generateAmplitudeEnvelope: vi.fn().mockResolvedValue(new Float32Array([1, 2, 3]))
+  extractMetadata,
+  generateAmplitudeEnvelope,
 }))
 
 vi.mock('@/utils/artwork', () => ({
@@ -23,7 +43,20 @@ vi.mock('@/utils/artwork', () => ({
 
 vi.mock('@/utils/audioPlayer', () => ({
   audioPlayer: {
-    initAudioContext: vi.fn().mockResolvedValue({ decodeAudioData: vi.fn().mockResolvedValue({ getChannelData: () => new Float32Array(0) }) })
+    subscribe: vi.fn().mockReturnValue(() => {}),
+    initAudioContext: vi.fn().mockResolvedValue({
+      decodeAudioData: vi.fn().mockResolvedValue({ getChannelData: () => new Float32Array(0) })
+    }),
+    playTrack: vi.fn(),
+    stopPlayback: vi.fn(),
+    pausePlayback: vi.fn(),
+    resumePlayback: vi.fn(),
+    seekTo: vi.fn(),
+    setVolume: vi.fn(),
+    toggleMute: vi.fn(),
+    getFrequencyData: vi.fn(),
+    getTimeData: vi.fn(),
+    cleanup: vi.fn()
   }
 }))
 
@@ -31,7 +64,19 @@ vi.mock('@/utils/toast', () => ({
   conditionalToast: { success: vi.fn(), error: vi.fn() }
 }))
 
+import { useAudioFile } from '../useAudioFile'
 describe('useAudioFile', () => {
+  beforeEach(() => {
+    state.playlist = []
+    state.currentTrack = null
+    addToPlaylist.mockClear()
+    setCurrentTrack.mockClear()
+    updateTrack.mockClear()
+    extractMetadata.mockClear()
+    ;(localStorage.getItem as any).mockReset()
+    ;(localStorage.setItem as any).mockReset()
+  })
+
   it('adds placeholder and updates track asynchronously', async () => {
     const file = new File(['data'], 'track.mp3', { type: 'audio/mpeg' })
     ;(file as any).arrayBuffer = vi.fn().mockResolvedValue(new ArrayBuffer(8))
@@ -39,8 +84,45 @@ describe('useAudioFile', () => {
     let placeholder: any
     await act(async () => { placeholder = await result.current.loadAudioFile(file) })
     expect(addToPlaylist).toHaveBeenCalledWith(expect.objectContaining({ isLoading: true }))
-    await Promise.resolve()
-    await Promise.resolve()
-    expect(updateTrack).toHaveBeenCalledWith(placeholder.id, expect.objectContaining({ isLoading: false }))
+    await waitFor(() =>
+      expect(updateTrack).toHaveBeenCalledWith(placeholder.id, expect.objectContaining({ isLoading: false }))
+    )
+  })
+
+  it('uses cached metadata and skips extractMetadata', async () => {
+    const encoder = new TextEncoder()
+    const buffer = encoder.encode('data').buffer
+    const hashBuffer = await crypto.subtle.digest('SHA-256', buffer)
+    const hash = Array.from(new Uint8Array(hashBuffer))
+      .map(b => b.toString(16).padStart(2, '0'))
+      .join('')
+    const cacheKey = `audio-metadata-${hash}`
+    const store: Record<string, string> = {
+      [cacheKey]: JSON.stringify({
+        metadata: { title: 'cached', artist: 'artist', album: 'album', duration: 1, sample_rate: 44100 },
+        artwork: null,
+      }),
+    }
+    ;(localStorage.getItem as any).mockImplementation(key => store[key] || null)
+    ;(localStorage.setItem as any).mockImplementation((key, val) => {
+      store[key] = val
+    })
+
+    const file = new File(['data'], 'track.mp3', { type: 'audio/mpeg' })
+    ;(file as any).arrayBuffer = vi.fn().mockResolvedValue(buffer)
+
+    const { result } = renderHook(() => useAudioFile())
+    await act(async () => {
+      await result.current.loadAudioFile(file)
+    })
+
+    await waitFor(() => expect(updateTrack).toHaveBeenCalled())
+
+    expect(localStorage.getItem).toHaveBeenCalledWith(cacheKey)
+    expect(extractMetadata).not.toHaveBeenCalled()
+    expect(updateTrack).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({ metadata: expect.objectContaining({ title: 'cached' }) })
+    )
   })
 })

--- a/react-spectrogram/src/hooks/useAudioFile.ts
+++ b/react-spectrogram/src/hooks/useAudioFile.ts
@@ -195,7 +195,8 @@ export const useAudioFile = () => {
                     data: parsed.artwork.data ? base64ToUint8(parsed.artwork.data) : undefined,
                   }
                 : undefined
-            } catch {
+            } catch (parseError) {
+              console.error(`Failed to parse cached metadata for key "${cacheKey}":`, parseError);
               metadata = await parseMetadata(file)
               const artworkResult = await extractArtwork(metadata, file.name, arrayBuffer)
               artwork = artworkResult.artwork

--- a/react-spectrogram/src/hooks/useAudioFile.ts
+++ b/react-spectrogram/src/hooks/useAudioFile.ts
@@ -215,7 +215,9 @@ export const useAudioFile = () => {
               : undefined
             try {
               localStorage.setItem(cacheKey, JSON.stringify({ metadata: metadataToStore, artwork: artworkToStore }))
-            } catch {}
+            } catch (e) {
+              console.error('Failed to cache audio metadata in localStorage:', e);
+            }
           }
 
           const audioData = await generateAmplitudeEnvelopeData(file, metadata, arrayBuffer)


### PR DESCRIPTION
## Summary
- cache audio metadata and artwork using a file hash to skip redundant parsing
- test audio file hook uses cached metadata when available

## Testing
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*
- `npx vitest run src/hooks/__tests__/useAudioFile.test.ts` *(passes with unhandled jsdom error)*
- `npx vitest run src/hooks/__tests__/useAudioFile.test.ts --coverage` *(passes with unhandled jsdom error)*

------
https://chatgpt.com/codex/tasks/task_e_68a46f729920832bb8ef8c94457566d4