### PR TITLE
Add microphone-driven web spectrogram

### DIFF
--- a/web-spectrogram/app.mjs
+++ b/web-spectrogram/app.mjs
@@ -41,7 +41,35 @@ export class SpectrogramApp {
           0,
           this.canvas.width,
           this.canvas.height - 1,
-        );
+        // Preserve current canvas content before resizing
+        const prevWidth = this.canvas.width;
+        const prevHeight = this.canvas.height;
+        let prevImage = null;
+        if (prevWidth > 0 && prevHeight > 0) {
+          // Create an offscreen canvas to store the previous image
+          const offscreen = document.createElement('canvas');
+          offscreen.width = prevWidth;
+          offscreen.height = prevHeight;
+          offscreen.getContext('2d').drawImage(this.canvas, 0, 0);
+          prevImage = offscreen;
+        }
+        this.canvas.width = width;
+        // Optionally, set canvas.height if it can change (not shown here)
+        const imageData = new ImageData(new Uint8ClampedArray(frame), width, 1);
+        if (prevImage) {
+          // Draw the previous image shifted up by one row
+          this.ctx.drawImage(
+            prevImage,
+            0,
+            1,
+            width,
+            this.canvas.height - 1,
+            0,
+            0,
+            width,
+            this.canvas.height - 1,
+          );
+        }
         this.ctx.putImageData(imageData, 0, this.canvas.height - 1);
       };
       this.source.connect(this.processor);

--- a/web-spectrogram/app.mjs
+++ b/web-spectrogram/app.mjs
@@ -23,7 +23,10 @@ export class SpectrogramApp {
       this.source = this.audioContext.createMediaStreamSource(this.stream);
       this.processor = this.audioContext.createScriptProcessor(4096, 1, 1);
       this.processor.onaudioprocess = (e) => {
-        const input = e.inputBuffer.getChannelData(0);
+      await this._ensureWorkletModule();
+      this.processor = new AudioWorkletNode(this.audioContext, 'spectrogram-processor', { numberOfInputs: 1, numberOfOutputs: 0, channelCount: 1 });
+      this.processor.port.onmessage = (event) => {
+        const input = event.data;
         const frame = this.computeFrame(input);
         if (!frame || frame.length === 0) return;
         const width = frame.length / BYTES_PER_PIXEL;

--- a/web-spectrogram/app.mjs
+++ b/web-spectrogram/app.mjs
@@ -27,7 +27,9 @@ export class SpectrogramApp {
         const frame = this.computeFrame(input);
         if (!frame || frame.length === 0) return;
         const width = frame.length / 4;
-        this.canvas.width = width;
+        if (this.canvas.width !== width) {
+          this.canvas.width = width;
+        }
         const imageData = new ImageData(new Uint8ClampedArray(frame), width, 1);
         this.ctx.drawImage(
           this.canvas,

--- a/web-spectrogram/app.mjs
+++ b/web-spectrogram/app.mjs
@@ -26,7 +26,7 @@ export class SpectrogramApp {
         const input = e.inputBuffer.getChannelData(0);
         const frame = this.computeFrame(input);
         if (!frame || frame.length === 0) return;
-        const width = frame.length / 4;
+        const width = frame.length / BYTES_PER_PIXEL;
         if (this.canvas.width !== width) {
           this.canvas.width = width;
         }

--- a/web-spectrogram/app.mjs
+++ b/web-spectrogram/app.mjs
@@ -1,0 +1,67 @@
+export class SpectrogramApp {
+  constructor({ canvas, computeFrame, audioContext, navigator }) {
+    this.canvas = canvas;
+    this.ctx = canvas.getContext("2d");
+    this.computeFrame = computeFrame;
+    const Ctor = audioContext
+      ? null
+      : globalThis.AudioContext || globalThis.webkitAudioContext;
+    this.audioContext = audioContext || (Ctor ? new Ctor() : null);
+    this.navigator = navigator || globalThis.navigator;
+    this.source = null;
+    this.processor = null;
+    this.stream = null;
+    this.onError = (e) => console.error(e);
+  }
+
+  async start() {
+    if (this.stream) return;
+    try {
+      this.stream = await this.navigator.mediaDevices.getUserMedia({
+        audio: true,
+      });
+      this.source = this.audioContext.createMediaStreamSource(this.stream);
+      this.processor = this.audioContext.createScriptProcessor(4096, 1, 1);
+      this.processor.onaudioprocess = (e) => {
+        const input = e.inputBuffer.getChannelData(0);
+        const frame = this.computeFrame(input);
+        if (!frame || frame.length === 0) return;
+        const width = frame.length / 4;
+        this.canvas.width = width;
+        const imageData = new ImageData(new Uint8ClampedArray(frame), width, 1);
+        this.ctx.drawImage(
+          this.canvas,
+          0,
+          0,
+          this.canvas.width,
+          this.canvas.height - 1,
+          0,
+          0,
+          this.canvas.width,
+          this.canvas.height - 1,
+        );
+        this.ctx.putImageData(imageData, 0, this.canvas.height - 1);
+      };
+      this.source.connect(this.processor);
+      this.processor.connect(this.audioContext.destination);
+    } catch (err) {
+      this.onError(err);
+    }
+  }
+
+  stop() {
+    if (this.processor) {
+      this.processor.disconnect();
+      this.processor.onaudioprocess = null;
+      this.processor = null;
+    }
+    if (this.source) {
+      this.source.disconnect();
+      this.source = null;
+    }
+    if (this.stream) {
+      this.stream.getTracks().forEach((t) => t.stop());
+      this.stream = null;
+    }
+  }
+}

--- a/web-spectrogram/app.test.mjs
+++ b/web-spectrogram/app.test.mjs
@@ -1,0 +1,107 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { SpectrogramApp } from "./app.mjs";
+
+globalThis.ImageData = class {
+  constructor(data, width, height) {
+    this.data = data;
+    this.width = width;
+    this.height = height;
+  }
+};
+
+test("start, process audio, and stop", async () => {
+  let getUserMediaCalled = false;
+  const fakeTrack = { stop: () => (fakeTrack.stopped = true) };
+  const stream = { getTracks: () => [fakeTrack] };
+  const navigator = {
+    mediaDevices: {
+      getUserMedia: async () => {
+        getUserMediaCalled = true;
+        return stream;
+      },
+    },
+  };
+
+  const source = {
+    connect: (node) => {
+      source.connected = node;
+    },
+    disconnect: () => {
+      source.disconnected = true;
+    },
+  };
+
+  const processor = {
+    connect: () => {
+      processor.connected = true;
+    },
+    disconnect: () => {
+      processor.disconnected = true;
+    },
+    onaudioprocess: null,
+  };
+
+  const audioContext = {
+    createMediaStreamSource: () => source,
+    createScriptProcessor: () => processor,
+    destination: {},
+  };
+
+  const calls = [];
+  const canvas = {
+    width: 2,
+    height: 1,
+    getContext: () => ({
+      drawImage: () => calls.push("draw"),
+      putImageData: () => calls.push("put"),
+    }),
+  };
+
+  let callCount = 0;
+  const computeFrame = (input) => {
+    assert.equal(input.length, 4);
+    callCount++;
+    return callCount === 1 ? [] : [0, 0, 0, 255, 0, 0, 0, 255];
+  };
+
+  const app = new SpectrogramApp({
+    canvas,
+    computeFrame,
+    audioContext,
+    navigator,
+  });
+  await app.start();
+  assert.ok(getUserMediaCalled);
+  const floatData = new Float32Array([0, 0, 0, 0]);
+  processor.onaudioprocess({
+    inputBuffer: { getChannelData: () => floatData },
+  });
+  assert.deepEqual(calls, []);
+  processor.onaudioprocess({
+    inputBuffer: { getChannelData: () => floatData },
+  });
+  assert.deepEqual(calls, ["draw", "put"]);
+  app.stop();
+  assert.ok(processor.disconnected);
+  assert.ok(source.disconnected);
+  assert.ok(fakeTrack.stopped);
+});
+
+test("permission error triggers handler", async () => {
+  const navigator = {
+    mediaDevices: {
+      getUserMedia: async () => {
+        throw new Error("denied");
+      },
+    },
+  };
+  const canvas = { width: 1, height: 1, getContext: () => ({}) };
+  let error;
+  const app = new SpectrogramApp({ canvas, computeFrame: () => [], navigator });
+  app.onError = (e) => {
+    error = e;
+  };
+  await app.start();
+  assert.ok(error instanceof Error);
+});


### PR DESCRIPTION
## Summary
- Add browser spectrogram app that streams microphone audio into the WASM `compute_frame` function and renders frames to a canvas
- Provide start/stop controls with graceful error handling
- Include unit tests for audio processing and error flow

## Testing
- `npx prettier web-spectrogram/app.mjs web-spectrogram/app.test.mjs --write`
- `npx eslint web-spectrogram/app.mjs web-spectrogram/app.test.mjs` *(fails: ESLint couldn't find an eslint.config file)*
- `node --test --experimental-test-coverage web-spectrogram/app.test.mjs`
- `cargo fmt --all`
- `cargo clippy -p web-spectrogram --all-targets -- -D warnings` *(fails: could not compile `web-spectrogram` due to unresolved imports)*
- `cargo test -p web-spectrogram` *(fails: could not compile `web-spectrogram` due to unresolved imports)*

------
https://chatgpt.com/codex/tasks/task_e_68a47f50a8a0832b9800fe37296eddc6