### PR TITLE
Remove web-spectrogram from workspace

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ build = "build.rs"
 
 
 [workspace]
-members = ["kofft-bench", "sanity-check", "xtask", "web-spectrogram"]
+members = ["kofft-bench", "sanity-check", "xtask"]
 
 [dependencies]
 libm = "0.2"


### PR DESCRIPTION
## Summary
- remove web-spectrogram from workspace members

## Testing
- `cargo fmt` *(fails: this file contains an unclosed delimiter in src/stft.rs)*
- `cargo clippy --all-targets --all-features` *(fails: this file contains an unclosed delimiter in src/stft.rs)*
- `cargo test` *(fails: this file contains an unclosed delimiter in src/stft.rs)*
- `cargo check` *(fails: this file contains an unclosed delimiter in src/stft.rs)*

------
https://chatgpt.com/codex/tasks/task_e_68a489650a78832bbe0eeae9d515e881