### PR TITLE
chore: remove web spectrogram xtask command

### DIFF
--- a/xtask/src/lib.rs
+++ b/xtask/src/lib.rs
@@ -1,9 +1,6 @@
+use std::env;
 use std::process::Command;
 use std::string::String;
-use std::fs;
-use std::env;
-use anyhow::Result;
-use std::path::PathBuf;
 
 /// Options derived from the host machine used to configure cargo commands.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -22,14 +19,6 @@ impl BuildConfig {
             Some(self.features.join(" "))
         }
     }
-}
-
-/// Get the workspace root directory
-fn workspace_root() -> PathBuf {
-    let manifest_dir = std::env::var("CARGO_MANIFEST_DIR").unwrap();
-    let mut path = PathBuf::from(manifest_dir);
-    path.pop(); // Go up from xtask to workspace root
-    path
 }
 
 /// Detect build configuration from the current machine.
@@ -200,62 +189,6 @@ pub fn sanity_command(input: &str, output: &str) -> Command {
     cmd
 }
 
-pub fn web_spectrogram_command() -> Result<()> {
-    let web_spectrogram_dir = workspace_root().join("web-spectrogram");
-    
-    // Build WebAssembly module directly with cargo
-    let status = Command::new("cargo")
-        .args(&["build", "--lib", "--release", "--target", "wasm32-unknown-unknown", "--no-default-features"])
-        .current_dir(&web_spectrogram_dir)
-        .status()?;
-    
-    if !status.success() {
-        anyhow::bail!("Failed to build WebAssembly module");
-    }
-    
-    // Copy the built WASM files to pkg directory
-    let pkg_dir = web_spectrogram_dir.join("pkg");
-    if !pkg_dir.exists() {
-        fs::create_dir(&pkg_dir)?;
-    }
-    
-    // Copy the built .wasm file
-    let wasm_source = workspace_root()
-        .join("target")
-        .join("wasm32-unknown-unknown")
-        .join("release")
-        .join("web_spectrogram.wasm");
-    let wasm_dest = pkg_dir.join("web_spectrogram.wasm");
-    fs::copy(wasm_source, wasm_dest)?;
-    
-    // Generate the JavaScript bindings using wasm-bindgen CLI
-    let status = Command::new("wasm-bindgen")
-        .args(&[
-            "--target", "web",
-            "--out-dir", "pkg",
-            "--out-name", "web_spectrogram",
-            "../target/wasm32-unknown-unknown/release/web_spectrogram.wasm"
-        ])
-        .current_dir(&web_spectrogram_dir)
-        .status()?;
-    
-    if !status.success() {
-        anyhow::bail!("Failed to generate JavaScript bindings");
-    }
-    
-    // Build and run the server
-    let status = Command::new("cargo")
-        .args(&["run", "--bin", "web-spectrogram-server", "--features", "server"])
-        .current_dir(&web_spectrogram_dir)
-        .status()?;
-    
-    if !status.success() {
-        anyhow::bail!("Failed to run web-spectrogram server");
-    }
-    
-    Ok(())
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -353,18 +286,6 @@ mod tests {
         assert!(args.contains(&"sanity-check".to_string()));
         assert!(args.contains(&"in.flac".to_string()));
         assert!(args.contains(&"out.png".to_string()));
-        let wcmd = web_spectrogram_command();
-        assert_eq!(wcmd.get_program(), "sh");
-        let wargs: Vec<_> = wcmd
-            .get_args()
-            .map(|a| a.to_str().unwrap().to_string())
-            .collect();
-        assert!(wargs.contains(&"-c".to_string()));
-        assert!(wargs
-            .iter()
-            .any(|a| a.contains("wasm-pack build --target web")));
-        assert!(wargs.iter().all(|a| !a.contains("npm")));
-        assert!(wargs.iter().any(|a| a.contains("cp index.html")));
     }
 
     #[test]

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -1,5 +1,4 @@
 use clap::{Parser, Subcommand};
-use std::process::Command;
 #[cfg(not(test))]
 use xtask::*;
 
@@ -22,8 +21,6 @@ enum Commands {
     BenchLibs,
     #[command(name = "update-bench-readme")]
     UpdateBenchReadme,
-    #[command(name = "web-spectrogram")]
-    WebSpectrogram,
     Sanity {
         /// Path to input audio file
         input: String,
@@ -53,20 +50,6 @@ fn main() -> std::io::Result<()> {
         Commands::Benchmark => benchmark_command(&cfg).status(),
         Commands::BenchLibs => bench_libs_command(&cfg).status(),
         Commands::UpdateBenchReadme => update_bench_readme_command(&cfg).status(),
-        Commands::WebSpectrogram => {
-            match web_spectrogram_command() {
-                Ok(_) => {
-                    let mut cmd = Command::new("echo");
-                    cmd.arg("web-spectrogram completed successfully");
-                    cmd.status()
-                },
-                Err(e) => {
-                    eprintln!("web-spectrogram failed: {}", e);
-                    let mut cmd = Command::new("false");
-                    cmd.status()
-                }
-            }
-        },
         Commands::Sanity { input, output } => sanity_command(&input, &output).status(),
     }?;
 
@@ -78,10 +61,10 @@ mod tests {
     use super::*;
 
     #[test]
-    fn parse_web_spectrogram_command() {
-        let cli = Cli::parse_from(["xtask", "web-spectrogram"]);
+    fn parse_build_command() {
+        let cli = Cli::parse_from(["xtask", "build"]);
         match cli.command {
-            Commands::WebSpectrogram => {}
+            Commands::Build => {}
             _ => panic!("parsed wrong command"),
         }
     }


### PR DESCRIPTION
## Summary
- remove obsolete web spectrogram command and helpers
- drop WebSpectrogram subcommand from task runner
- update tests after removing web spectrogram support

## Testing
- `cargo fmt -p xtask`
- `cargo clippy -p xtask -- -D warnings`
- `cargo test -p xtask`
- `cargo tarpaulin -p xtask --ignore-tests` *(fails: no such command: `tarpaulin`)*

------
https://chatgpt.com/codex/tasks/task_e_68a48979cb5c832bbfa0b5d66f2ad3dc