### PR TITLE
docs: update web-spectrogram references

### DIFF
--- a/README.md
+++ b/README.md
@@ -541,5 +541,5 @@ cargo xtask sanity -- <path-to-flac>  # Run the sanity check example
 - [API Documentation](https://docs.rs/kofft)
 - [Repository](https://github.com/kianostad/kofft)
 - [Crates.io](https://crates.io/crates/kofft)
-- [Web Spectrogram Demo](web-spectrogram/README.md)
+- [React Spectrogram Demo](react-spectrogram/README.md)
 

--- a/react-spectrogram/ALBUM_ART_EXTRACTION_ANALYSIS.md
+++ b/react-spectrogram/ALBUM_ART_EXTRACTION_ANALYSIS.md
@@ -29,7 +29,7 @@ I analyzed all test files in the project:
 #### WASM Album Art Extraction Logic
 
 ```rust
-// In web-spectrogram/src/lib.rs
+// In react-spectrogram/wasm/src/lib.rs
 if let Some(pic) = pick_cover_picture(tag.pictures()) {
     meta.album_art = Some(pic.data().to_vec());
     meta.album_art_mime = Some(picture_mime(&pic).to_string());


### PR DESCRIPTION
## Summary
- replace outdated web-spectrogram demo link with react-spectrogram demo in README
- fix album art analysis doc to reference new wasm crate path

## Testing
- no tests run

------
https://chatgpt.com/codex/tasks/task_e_68a49e000904832ba6cb050c64c7cca8