### PR TITLE
Display upcoming track message near end of playback

### DIFF
--- a/react-spectrogram/src/components/__tests__/UpcomingTrackInfo.test.tsx
+++ b/react-spectrogram/src/components/__tests__/UpcomingTrackInfo.test.tsx
@@ -1,0 +1,83 @@
+import { render, screen } from "@testing-library/react";
+import { describe, it, beforeEach } from "vitest";
+import { Footer } from "../layout/Footer";
+import { vi } from "vitest";
+
+const mockState: any = {
+  isPlaying: true,
+  isStopped: false,
+  currentTime: 0,
+  duration: 60,
+  volume: 1,
+  isMuted: false,
+  currentTrack: null,
+  playlist: [],
+  currentTrackIndex: 0,
+};
+
+vi.mock("../../stores/audioStore", () => ({
+  useAudioStore: () => mockState,
+}));
+
+vi.mock("../../hooks/useAudioFile", () => ({
+  useAudioFile: () => ({
+    playTrack: vi.fn(),
+    pausePlayback: vi.fn(),
+    resumePlayback: vi.fn(),
+    stopPlayback: vi.fn(),
+    seekTo: vi.fn(),
+    setAudioVolume: vi.fn(),
+    toggleMute: vi.fn(),
+  }),
+}));
+
+vi.mock("../../hooks/useScreenSize", () => ({
+  useScreenSize: () => ({ isMobile: false, isTablet: false }),
+}));
+
+vi.mock("../../components/spectrogram/CanvasWaveformSeekbar", () => ({
+  CanvasWaveformSeekbar: () => <div data-testid="seekbar" />,
+}));
+
+describe("Upcoming track info", () => {
+  beforeEach(() => {
+    const file1 = new File([""], "track1.mp3", { type: "audio/mpeg" });
+    const file2 = new File([""], "track2.mp3", { type: "audio/mpeg" });
+    const track1 = {
+      id: "1",
+      file: file1,
+      metadata: { title: "Track 1", artist: "Artist 1", album: "Album 1" },
+      duration: 60,
+      url: "track1",
+    };
+    const track2 = {
+      id: "2",
+      file: file2,
+      metadata: { title: "Track 2", artist: "Artist 2", album: "Album 2" },
+      duration: 60,
+      url: "track2",
+    };
+    mockState.currentTrack = track1;
+    mockState.playlist = [track1, track2];
+    mockState.currentTrackIndex = 0;
+    mockState.currentTime = 0;
+    mockState.duration = 60;
+  });
+
+  it("shows next track when within last 10 seconds", () => {
+    mockState.currentTime = 55;
+    render(<Footer />);
+    expect(
+      screen.getByText("Coming up: Track 2 by Artist 2"),
+    ).toBeInTheDocument();
+  });
+
+  it("shows alternating info when not near end", () => {
+    mockState.currentTime = 30;
+    render(<Footer />);
+    expect(screen.queryByText("Coming up: Track 2 by Artist 2")).toBeNull();
+    expect(screen.getByTestId("alternating-info-text")).toHaveTextContent(
+      "Artist 1",
+    );
+  });
+});

--- a/react-spectrogram/src/components/layout/Footer.tsx
+++ b/react-spectrogram/src/components/layout/Footer.tsx
@@ -37,6 +37,14 @@ export const Footer: React.FC = () => {
   const { isMobile, isTablet } = useScreenSize();
   const audioFile = useAudioFile();
 
+  const hasUpcomingTrack =
+    currentTrackIndex >= 0 && currentTrackIndex < playlist.length - 1;
+  const upcomingTrack = hasUpcomingTrack
+    ? playlist[currentTrackIndex + 1]
+    : null;
+  const showNextInfo =
+    !!currentTrack && hasUpcomingTrack && duration - currentTime <= 10;
+
   // Format time for display
   const formatTime = (seconds: number): string => {
     const mins = Math.floor(seconds / 60);
@@ -272,14 +280,28 @@ export const Footer: React.FC = () => {
               >
                 {currentTrack.metadata.title || currentTrack.file.name}
               </h4>
-              <AlternatingInfo
-                artist={currentTrack.metadata.artist || "Unknown Artist"}
-                album={currentTrack.metadata.album || "Unknown Album"}
-                className={cn(
-                  "text-neutral-400",
-                  isMobile ? "text-xs" : "text-xs",
-                )}
-              />
+              {showNextInfo && upcomingTrack ? (
+                <p
+                  className={cn(
+                    "text-neutral-400",
+                    isMobile ? "text-xs" : "text-xs",
+                  )}
+                  data-testid="upcoming-track-info"
+                >
+                  {`Coming up: ${
+                    upcomingTrack.metadata.title || upcomingTrack.file.name
+                  } by ${upcomingTrack.metadata.artist || "Unknown Artist"}`}
+                </p>
+              ) : (
+                <AlternatingInfo
+                  artist={currentTrack.metadata.artist || "Unknown Artist"}
+                  album={currentTrack.metadata.album || "Unknown Album"}
+                  className={cn(
+                    "text-neutral-400",
+                    isMobile ? "text-xs" : "text-xs",
+                  )}
+                />
+              )}
             </div>
           )}
         </div>


### PR DESCRIPTION
## Summary
- show next track info when current song has under 10s remaining
- test footer to ensure upcoming track info appears when appropriate

## Testing
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*
- `npx vitest run src/components/__tests__/UpcomingTrackInfo.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68a4a5b86550832ba31d56f41d1ee6a4