### PR TITLE
fix wasm path for album art

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,4 +34,5 @@ web-spectrogram/pkg/
 web-spectrogram/app/dist/
 
 react-spectrogram/wasm/target/
-react-spectrogram/src/wasm/
+react-spectrogram/src/wasm/*
+!react-spectrogram/src/wasm/.gitkeep

--- a/react-spectrogram/src/utils/__tests__/wasm.test.ts
+++ b/react-spectrogram/src/utils/__tests__/wasm.test.ts
@@ -3,7 +3,7 @@ import { extractMetadata } from "../wasm";
 // import { AudioMetadata } from '@/types'
 
 // Mock the WASM module completely
-vi.mock("../../wasm/react_spectrogram_wasm", () => ({
+vi.mock("@wasm/react_spectrogram_wasm", () => ({
   default: {
     start: vi.fn(),
     MetadataExtractor: vi.fn(() => ({
@@ -82,5 +82,16 @@ describe("WASM Metadata Extraction", () => {
       album: "Unknown Album",
       format: "audio/mp3",
     });
+  });
+
+  it("returns null when WASM import fails", async () => {
+    vi.doMock("@wasm/react_spectrogram_wasm", () => {
+      throw new Error("Failed to load");
+    });
+    // Need to re-import module after overriding mock
+    vi.resetModules();
+    const { initWASM: init } = await import("../wasm");
+    const wasm = await init();
+    expect(wasm).toBeNull();
   });
 });

--- a/react-spectrogram/src/utils/wasm.ts
+++ b/react-spectrogram/src/utils/wasm.ts
@@ -30,7 +30,7 @@ export async function initWASM(): Promise<WASMModule | null> {
       // Dynamic import of the WASM glue
       // eslint-disable-next-line @typescript-eslint/ban-ts-comment
       // @ts-ignore - resolved by Vite at runtime
-      const module: any = await import("../../wasm/react_spectrogram_wasm");
+      const module: any = await import("@wasm/react_spectrogram_wasm");
 
       // Initialize the wasm instance by calling the default init
       if (typeof module.default === "function") {


### PR DESCRIPTION
## Summary
- fix WASM import path to use alias and avoid 404s
- add regression test ensuring missing WASM import returns null
- track wasm build directory with gitkeep

## Testing
- `npx prettier -w react-spectrogram/src/utils/wasm.ts react-spectrogram/src/utils/__tests__/wasm.test.ts`
- `npm --prefix react-spectrogram run lint` *(fails: ESLint couldn't find a configuration file)*
- `npm --prefix react-spectrogram run test` *(fails: jsdom lacks Web Audio API support)*
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a4a7590670832b86ccfff0c6951f9a