### PR TITLE
Add optional waveform caching with SQLite

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,7 @@ hashbrown = "0.14"
 num_cpus = { version = "1.16", optional = true }
 colorous = { version = "1", optional = true }
 blake3 = { version = "1.5", features = ["std"] }
+rusqlite = { version = "0.29", optional = true, features = ["bundled"] }
 
 [features]
 default = ["std", "simd", "wasm"]
@@ -53,6 +54,7 @@ compile-time-rfft = []
 simd = []
 soa = []
 precomputed-twiddles = ["std"]
+waveform-cache = ["rusqlite", "std"]
 
 [dependencies.rayon]
 version = "1.7"

--- a/README.md
+++ b/README.md
@@ -19,10 +19,30 @@ High-performance, `no_std`, MCU-friendly DSP library featuring FFT, DCT, DST, Ha
 - **🌐 WebAssembly support**
 - **📱 Parallel processing** (optional)
 - **🎵 Hybrid song identification**: fast metadata lookup with BLAKE3 fallback
+- **💾 Waveform caching (opt-in)**: SQLite-backed waveform snapshots for faster startup
 
 ## Benchmarks
 
 See [benchmarks](benchmarks/README.md) for detailed benchmark results and data.
+
+## Waveform Caching
+
+The optional `waveform-cache` feature stores per-track waveform snapshots in a
+SQLite database. Loading a cached waveform avoids recomputation and can reduce
+startup latency, at the cost of additional disk usage proportional to the
+number of tracks. Each entry stores the waveform samples for a track in the
+`waveform_samples` table:
+
+```
+CREATE TABLE waveform_samples (
+    track_id TEXT PRIMARY KEY,
+    samples  BLOB NOT NULL
+);
+```
+
+Because caching increases storage requirements, the feature is **not enabled by
+default**. Opt in by enabling the `waveform-cache` Cargo feature when compiling
+`kofft` if faster startups are worth the space trade-off.
 
 ## Quick Start
 

--- a/kofft-bench/Cargo.toml
+++ b/kofft-bench/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-kofft = { path = "..", default-features = false, features = ["std", "slow"] }
+kofft = { path = "..", default-features = false, features = ["std", "slow", "waveform-cache", "simd", "wasm"] }
 criterion = { version = "0.7", features = ["html_reports"] }
 rustfft = "6"
 realfft = "3"
@@ -12,6 +12,7 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 once_cell = "1"
 chrono = { version = "0.4", default-features = false, features = ["clock"] }
+rusqlite = { version = "0.29", features = ["bundled"] }
 
 [features]
 default = []
@@ -28,6 +29,10 @@ precomputed-twiddles = ["kofft/precomputed-twiddles"]
 
 [[bench]]
 name = "bench_fft"
+harness = false
+
+[[bench]]
+name = "waveform_cache"
 harness = false
 
 [[example]]

--- a/kofft-bench/benches/waveform_cache.rs
+++ b/kofft-bench/benches/waveform_cache.rs
@@ -1,0 +1,28 @@
+use criterion::{criterion_group, criterion_main, Criterion};
+use kofft::media::playback::{get_or_generate_waveform, init_db};
+use rusqlite::Connection;
+
+fn benchmark_waveform_cache(c: &mut Criterion) {
+    let conn = Connection::open_in_memory().unwrap();
+    init_db(&conn).unwrap();
+    let audio = vec![0.1f32; 10_000];
+    let track_id = "track1";
+
+    c.bench_function("generate_waveform", |b| {
+        b.iter(|| {
+            conn.execute("DELETE FROM waveform_samples", []).unwrap();
+            let _ = get_or_generate_waveform(&conn, track_id, &audio).unwrap();
+        });
+    });
+
+    conn.execute("DELETE FROM waveform_samples", []).unwrap();
+    let _ = get_or_generate_waveform(&conn, track_id, &audio).unwrap();
+    c.bench_function("load_cached_waveform", |b| {
+        b.iter(|| {
+            let _ = get_or_generate_waveform(&conn, track_id, &audio).unwrap();
+        });
+    });
+}
+
+criterion_group!(benches, benchmark_waveform_cache);
+criterion_main!(benches);

--- a/src/media/mod.rs
+++ b/src/media/mod.rs
@@ -2,3 +2,6 @@
 
 #[cfg(feature = "std")]
 pub mod index;
+
+#[cfg(all(feature = "std", feature = "waveform-cache"))]
+pub mod playback;

--- a/src/media/playback.rs
+++ b/src/media/playback.rs
@@ -1,0 +1,107 @@
+//! Waveform caching and retrieval for media playback.
+//!
+//! This module provides a simple API to cache per-track waveform snapshots
+//! in a SQLite database. Cached waveforms are loaded on demand during
+//! playback, falling back to on-the-fly generation when no cached data is
+//! available.
+
+use rusqlite::{params, Connection};
+use std::vec::Vec;
+
+/// Initialize the waveform cache database schema.
+pub fn init_db(conn: &Connection) -> rusqlite::Result<()> {
+    conn.execute_batch(include_str!("waveform_schema.sql"))?;
+    Ok(())
+}
+
+/// Store a waveform snapshot for the given track identifier.
+fn store_waveform(conn: &Connection, track_id: &str, waveform: &[f32]) -> rusqlite::Result<()> {
+    let bytes = waveform_as_bytes(waveform);
+    conn.execute(
+        "INSERT OR REPLACE INTO waveform_samples (track_id, samples) VALUES (?1, ?2)",
+        params![track_id, bytes],
+    )?;
+    Ok(())
+}
+
+/// Attempt to load a cached waveform snapshot.
+fn load_waveform(conn: &Connection, track_id: &str) -> rusqlite::Result<Option<Vec<f32>>> {
+    let mut stmt = conn.prepare("SELECT samples FROM waveform_samples WHERE track_id = ?1")?;
+    let mut rows = stmt.query(params![track_id])?;
+    if let Some(row) = rows.next()? {
+        let blob: Vec<u8> = row.get(0)?;
+        Ok(Some(bytes_to_waveform(&blob)))
+    } else {
+        Ok(None)
+    }
+}
+
+/// Get the waveform snapshot for a track, generating and caching it if necessary.
+pub fn get_or_generate_waveform(
+    conn: &Connection,
+    track_id: &str,
+    audio: &[f32],
+) -> rusqlite::Result<Vec<f32>> {
+    if let Some(cached) = load_waveform(conn, track_id)? {
+        return Ok(cached);
+    }
+    let waveform = generate_waveform(audio);
+    store_waveform(conn, track_id, &waveform)?;
+    Ok(waveform)
+}
+
+/// Simple waveform generation by averaging absolute amplitudes over windows of 100 samples.
+fn generate_waveform(audio: &[f32]) -> Vec<f32> {
+    let window = 100;
+    audio
+        .chunks(window)
+        .map(|chunk| chunk.iter().map(|v| v.abs()).sum::<f32>() / chunk.len() as f32)
+        .collect()
+}
+
+fn waveform_as_bytes(waveform: &[f32]) -> Vec<u8> {
+    waveform.iter().flat_map(|f| f.to_le_bytes()).collect()
+}
+
+fn bytes_to_waveform(bytes: &[u8]) -> Vec<f32> {
+    bytes
+        .chunks_exact(4)
+        .map(|b| f32::from_le_bytes([b[0], b[1], b[2], b[3]]))
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alloc::vec;
+
+    fn setup() -> Connection {
+        let conn = Connection::open_in_memory().unwrap();
+        init_db(&conn).unwrap();
+        conn
+    }
+
+    #[test]
+    fn generates_and_caches_waveform() {
+        let conn = setup();
+        let audio = vec![0.5f32; 200];
+        let wf1 = get_or_generate_waveform(&conn, "track", &audio).unwrap();
+        // second call should retrieve from cache
+        let wf2 = get_or_generate_waveform(&conn, "track", &audio).unwrap();
+        assert_eq!(wf1, wf2);
+        let count: i64 = conn
+            .query_row("SELECT COUNT(*) FROM waveform_samples", [], |r| r.get(0))
+            .unwrap();
+        assert_eq!(count, 1);
+    }
+
+    #[test]
+    fn returns_cached_waveform_without_audio() {
+        let conn = setup();
+        let audio = vec![0.1f32; 300];
+        let wf1 = get_or_generate_waveform(&conn, "song", &audio).unwrap();
+        // Provide empty audio to ensure cached result is used
+        let wf2 = get_or_generate_waveform(&conn, "song", &[]).unwrap();
+        assert_eq!(wf1, wf2);
+    }
+}

--- a/src/media/waveform_schema.sql
+++ b/src/media/waveform_schema.sql
@@ -1,0 +1,4 @@
+CREATE TABLE IF NOT EXISTS waveform_samples (
+    track_id TEXT PRIMARY KEY,
+    samples BLOB NOT NULL
+);


### PR DESCRIPTION
## Summary
- add `waveform-cache` feature backed by SQLite
- load precomputed waveform snapshots during playback
- document and benchmark waveform caching

## Testing
- `cargo clippy --all-targets --features waveform-cache`
- `cargo test --features waveform-cache`
- `cargo tarpaulin --features waveform-cache --out Stdout`
- `cargo bench -p kofft-bench --bench waveform_cache`


------
https://chatgpt.com/codex/tasks/task_e_68a4992dec3c832b91ca0b8b511f110d