### PR TITLE
feat: add wasm audio resampler with ts fallback

### DIFF
--- a/react-spectrogram/src/utils/audio.ts
+++ b/react-spectrogram/src/utils/audio.ts
@@ -1,105 +1,142 @@
-import { AudioTrack, AudioMetadata } from '@/types'
-import { extractMetadata } from './wasm'
+import { AudioTrack, AudioMetadata } from "@/types";
+import { extractMetadata, resampleAudio } from "./wasm";
 
 export const SUPPORTED_AUDIO_FORMATS = [
-  'audio/mpeg',
-  'audio/mp3',
-  'audio/wav',
-  'audio/wave',
-  'audio/x-wav',
-  'audio/flac',
-  'audio/ogg',
-  'audio/oga',
-  'audio/webm',
-  'audio/aac',
-  'audio/m4a',
-  'audio/x-m4a',
-]
+  "audio/mpeg",
+  "audio/mp3",
+  "audio/wav",
+  "audio/wave",
+  "audio/x-wav",
+  "audio/flac",
+  "audio/ogg",
+  "audio/oga",
+  "audio/webm",
+  "audio/aac",
+  "audio/m4a",
+  "audio/x-m4a",
+];
 
 export function isAudioFile(file: File): boolean {
-  return SUPPORTED_AUDIO_FORMATS.includes(file.type) || 
-         file.name.match(/\.(mp3|wav|flac|ogg|webm|aac|m4a)$/i) !== null
+  return (
+    SUPPORTED_AUDIO_FORMATS.includes(file.type) ||
+    file.name.match(/\.(mp3|wav|flac|ogg|webm|aac|m4a)$/i) !== null
+  );
 }
 
 export function formatDuration(seconds: number): string {
-  const hours = Math.floor(seconds / 3600)
-  const minutes = Math.floor((seconds % 3600) / 60)
-  const secs = Math.floor(seconds % 60)
-  
+  const hours = Math.floor(seconds / 3600);
+  const minutes = Math.floor((seconds % 3600) / 60);
+  const secs = Math.floor(seconds % 60);
+
   if (hours > 0) {
-    return `${hours}:${minutes.toString().padStart(2, '0')}:${secs.toString().padStart(2, '0')}`
+    return `${hours}:${minutes.toString().padStart(2, "0")}:${secs.toString().padStart(2, "0")}`;
   }
-  return `${minutes}:${secs.toString().padStart(2, '0')}`
+  return `${minutes}:${secs.toString().padStart(2, "0")}`;
 }
 
 export function formatFileSize(bytes: number): string {
-  const units = ['B', 'KB', 'MB', 'GB']
-  let size = bytes
-  let unitIndex = 0
-  
+  const units = ["B", "KB", "MB", "GB"];
+  let size = bytes;
+  let unitIndex = 0;
+
   while (size >= 1024 && unitIndex < units.length - 1) {
-    size /= 1024
-    unitIndex++
+    size /= 1024;
+    unitIndex++;
   }
-  
-  return `${size.toFixed(1)} ${units[unitIndex]}`
+
+  return `${size.toFixed(1)} ${units[unitIndex]}`;
 }
 
 export function generateTrackId(): string {
-  return `track_${Date.now()}_${Math.random().toString(36).substr(2, 9)}`
+  return `track_${Date.now()}_${Math.random().toString(36).substr(2, 9)}`;
 }
 
-export function createAudioTrack(file: File, metadata: AudioMetadata): AudioTrack {
+export function createAudioTrack(
+  file: File,
+  metadata: AudioMetadata,
+): AudioTrack {
   return {
     id: generateTrackId(),
     file,
     metadata,
     duration: metadata.duration || 0,
     url: URL.createObjectURL(file),
-  }
+  };
 }
 
 export function revokeTrackUrl(track: AudioTrack): void {
-  if (track.url && track.url.startsWith('blob:')) {
-    URL.revokeObjectURL(track.url)
+  if (track.url && track.url.startsWith("blob:")) {
+    URL.revokeObjectURL(track.url);
   }
 }
 
 export async function extractAudioMetadata(file: File): Promise<AudioMetadata> {
-  return await extractMetadata(file)
+  return await extractMetadata(file);
 }
 
 export function getAudioInputDevices(): Promise<MediaDeviceInfo[]> {
-  return navigator.mediaDevices.enumerateDevices()
-    .then(devices => devices.filter(device => device.kind === 'audioinput'))
+  return navigator.mediaDevices
+    .enumerateDevices()
+    .then((devices) =>
+      devices.filter((device) => device.kind === "audioinput"),
+    );
 }
 
 export async function requestMicrophonePermission(): Promise<MediaStream | null> {
   try {
-    return await navigator.mediaDevices.getUserMedia({ audio: true })
+    return await navigator.mediaDevices.getUserMedia({ audio: true });
   } catch (error) {
-    return null
+    return null;
   }
 }
 
-export function decodeAudioData(audioContext: AudioContext, arrayBuffer: ArrayBuffer): Promise<AudioBuffer> {
-  return audioContext.decodeAudioData(arrayBuffer)
+export function decodeAudioData(
+  audioContext: AudioContext,
+  arrayBuffer: ArrayBuffer,
+): Promise<AudioBuffer> {
+  return audioContext.decodeAudioData(arrayBuffer);
 }
 
 export function getAudioBufferData(audioBuffer: AudioBuffer): Float32Array {
-  const channelData = audioBuffer.getChannelData(0)
-  return new Float32Array(channelData)
+  const channelData = audioBuffer.getChannelData(0);
+  return new Float32Array(channelData);
 }
 
-export function resampleAudioData(audioData: Float32Array, targetSampleRate: number, originalSampleRate: number): Float32Array {
-  const ratio = originalSampleRate / targetSampleRate
-  const newLength = Math.round(audioData.length / ratio)
-  const resampled = new Float32Array(newLength)
-  
+export async function resampleAudioData(
+  audioData: Float32Array,
+  targetSampleRate: number,
+  originalSampleRate: number,
+): Promise<Float32Array> {
+  const wasmResult = await resampleAudio(
+    audioData,
+    originalSampleRate,
+    targetSampleRate,
+  );
+  if (wasmResult) return wasmResult;
+  return resampleAudioDataFallback(
+    audioData,
+    targetSampleRate,
+    originalSampleRate,
+  );
+}
+
+export function resampleAudioDataFallback(
+  audioData: Float32Array,
+  targetSampleRate: number,
+  originalSampleRate: number,
+): Float32Array {
+  const ratio = originalSampleRate / targetSampleRate;
+  const newLength = Math.round(audioData.length / ratio);
+  const resampled = new Float32Array(newLength);
+
   for (let i = 0; i < newLength; i++) {
-    const index = Math.round(i * ratio)
-    resampled[i] = audioData[index] || 0
+    const index = i * ratio;
+    const i0 = Math.floor(index);
+    const frac = index - i0;
+    const s0 = audioData[i0] || 0;
+    const s1 = audioData[i0 + 1] || s0;
+    resampled[i] = s0 + (s1 - s0) * frac;
   }
-  
-  return resampled
+
+  return resampled;
 }

--- a/react-spectrogram/src/utils/wasm.ts
+++ b/react-spectrogram/src/utils/wasm.ts
@@ -13,6 +13,11 @@ interface WASMModule {
     windowMs: number,
     smoothingSamples: number,
   ) => Float32Array;
+  resample_audio?: (
+    audioData: Float32Array,
+    srcRate: number,
+    dstRate: number,
+  ) => Float32Array;
 }
 
 let wasmModule: WASMModule | null = null;
@@ -242,6 +247,27 @@ async function extractBasicMetadata(file: File): Promise<AudioMetadata> {
   }
 
   return metadata;
+}
+
+// Resample audio data using WASM if available
+export async function resampleAudio(
+  audioData: Float32Array,
+  srcRate: number,
+  dstRate: number,
+): Promise<Float32Array | null> {
+  try {
+    const module = await initWASM();
+    if (module && module.resample_audio) {
+      try {
+        return module.resample_audio(audioData, srcRate, dstRate);
+      } catch (error) {
+        // WASM resampling failed
+      }
+    }
+  } catch (error) {
+    // WASM module not available for resampling
+  }
+  return null;
 }
 
 // Generate waveform data using WASM

--- a/react-spectrogram/wasm/src/lib.rs
+++ b/react-spectrogram/wasm/src/lib.rs
@@ -4,7 +4,7 @@ use console_error_panic_hook;
 use kofft::fft::{self, new_fft_impl, Complex32, FftImpl};
 use kofft::visual::spectrogram::{self, Colormap as KColormap};
 use kofft::window::hann;
-use kofft::{dct, wavelet};
+use kofft::{dct, resample, wavelet};
 use wasm_bindgen::prelude::*;
 
 #[wasm_bindgen(start)]
@@ -149,6 +149,11 @@ pub fn haar_forward(input: &[f32]) -> HaarResult {
 #[wasm_bindgen]
 pub fn haar_inverse(avg: &[f32], diff: &[f32]) -> Vec<f32> {
     wavelet::haar_inverse(avg, diff)
+}
+
+#[wasm_bindgen]
+pub fn resample_audio(input: &[f32], src_rate: f32, dst_rate: f32) -> Vec<f32> {
+    resample::linear_resample(input, src_rate, dst_rate)
 }
 
 const WIN_LEN: usize = 1024;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -139,6 +139,11 @@ pub mod cepstrum;
 /// Extended collection of window functions for specialized applications.
 pub mod window_more;
 
+/// Audio resampling utilities
+///
+/// Linear interpolation-based resampler with WASM bindings.
+pub mod resample;
+
 pub use fft::FftPlanner;
 pub use num::{Complex, Complex32, Complex64, Float};
 

--- a/src/resample.rs
+++ b/src/resample.rs
@@ -1,0 +1,31 @@
+use alloc::vec::Vec;
+use core::cmp;
+use core::f32;
+
+/// Linearly resample `input` from `src_rate` to `dst_rate`.
+///
+/// Returns a newly allocated `Vec<f32>` with the resampled signal.
+/// If either rate is non-positive or input is empty, an empty vector is returned.
+pub fn linear_resample(input: &[f32], src_rate: f32, dst_rate: f32) -> Vec<f32> {
+    if input.is_empty() || src_rate <= 0.0 || dst_rate <= 0.0 {
+        return Vec::new();
+    }
+
+    if (src_rate - dst_rate).abs() < f32::EPSILON {
+        return input.to_vec();
+    }
+
+    let ratio = dst_rate / src_rate;
+    let out_len = (input.len() as f32 * ratio).ceil() as usize;
+    let mut output = Vec::with_capacity(out_len);
+
+    for i in 0..out_len {
+        let pos = i as f32 / ratio;
+        let idx = pos.floor() as usize;
+        let frac = pos - idx as f32;
+        let s0 = *input.get(idx).unwrap_or(&input[input.len() - 1]);
+        let s1 = *input.get(cmp::min(idx + 1, input.len() - 1)).unwrap_or(&s0);
+        output.push(s0 + (s1 - s0) * frac);
+    }
+    output
+}

--- a/tests/resample.rs
+++ b/tests/resample.rs
@@ -1,0 +1,66 @@
+use kofft::resample::linear_resample;
+use std::time::Instant;
+
+fn naive_nearest(input: &[f32], src_rate: f32, dst_rate: f32) -> Vec<f32> {
+    let ratio = src_rate / dst_rate;
+    let out_len = (input.len() as f32 / ratio).ceil() as usize;
+    let mut out = Vec::with_capacity(out_len);
+    for i in 0..out_len {
+        let idx = (i as f32 * ratio).round() as usize;
+        out.push(*input.get(idx).unwrap_or(&0.0));
+    }
+    out
+}
+
+fn mse(a: &[f32], b: &[f32]) -> f32 {
+    let len = a.len().min(b.len());
+    let mut err = 0.0;
+    for i in 0..len {
+        let d = a[i] - b[i];
+        err += d * d;
+    }
+    err / len as f32
+}
+
+#[test]
+fn linear_has_lower_error_than_nearest() {
+    let src_rate = 44_100.0;
+    let dst_rate = 48_000.0;
+    let freq = 1_000.0;
+    let duration = 0.1; // seconds
+    let len = (src_rate * duration) as usize;
+    let input: Vec<f32> = (0..len)
+        .map(|i| (2.0 * std::f32::consts::PI * freq * i as f32 / src_rate).sin())
+        .collect();
+    let expected: Vec<f32> = (0..(dst_rate * duration) as usize)
+        .map(|i| (2.0 * std::f32::consts::PI * freq * i as f32 / dst_rate).sin())
+        .collect();
+
+    let linear = linear_resample(&input, src_rate, dst_rate);
+    let nearest = naive_nearest(&input, src_rate, dst_rate);
+
+    let err_linear = mse(&linear, &expected);
+    let err_nearest = mse(&nearest, &expected);
+
+    assert!(err_linear < err_nearest);
+}
+
+#[test]
+fn benchmark_linear_resampler() {
+    let src_rate = 44_100.0;
+    let dst_rate = 48_000.0;
+    let input = vec![0.0f32; (src_rate * 2.0) as usize];
+
+    let start = Instant::now();
+    let _ = linear_resample(&input, src_rate, dst_rate);
+    let linear_time = start.elapsed();
+
+    let start = Instant::now();
+    let _ = naive_nearest(&input, src_rate, dst_rate);
+    let nearest_time = start.elapsed();
+
+    println!("linear: {:?}, nearest: {:?}", linear_time, nearest_time);
+
+    // Ensure the linear resampler is within 2x of the naive nearest neighbour
+    assert!(linear_time <= nearest_time * 2);
+}


### PR DESCRIPTION
## Summary
- add linear resampling routine in Rust
- expose resampler to JS via wasm and hook into audio utilities with TS fallback
- cover resampling quality and benchmark via unit tests

## Testing
- `cargo clippy -p kofft --all-targets --all-features -- -D warnings`
- `cargo clippy --all-targets` *(failed: warnings in web-spectrogram crate)*
- `cargo test`
- `npm run lint` *(failed: ESLint couldn't find configuration file)*
- `npm test` *(failed: loadFromStorage is not a function)*

------
https://chatgpt.com/codex/tasks/task_e_68a4b542e3b0832b83b601e11db17b29