### PR TITLE
feat: add marquee and size swap for track info

### DIFF
--- a/react-spectrogram/src/components/__tests__/AlternatingInfo.test.tsx
+++ b/react-spectrogram/src/components/__tests__/AlternatingInfo.test.tsx
@@ -3,7 +3,7 @@ import { render, screen, act } from "@testing-library/react";
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 vi.mock("framer-motion", () => ({
   AnimatePresence: ({ children }: { children: React.ReactNode }) => <>{children}</>,
-  motion: { span: (props: any) => <span {...props} /> },
+  motion: { div: (props: any) => <div {...props} /> },
 }));
 import { AlternatingInfo } from "../layout/AlternatingInfo";
 
@@ -39,35 +39,5 @@ describe("AlternatingInfo", () => {
 
     await vi.advanceTimersByTimeAsync(1000);
     expect(getLastText()).toHaveTextContent("Artist Name");
-  });
-
-  it("activates marquee when text overflows", () => {
-    render(
-      <div style={{ width: "50px" }}>
-        <AlternatingInfo
-          artist="This is a very long artist name that should overflow"
-          album="Album"
-          interval={1000}
-        />
-      </div>,
-    );
-
-    const container = screen.getByTestId("alternating-info-text").parentElement as HTMLElement;
-    const span = screen.getByTestId("alternating-info-text");
-
-    Object.defineProperty(container, "clientWidth", {
-      value: 50,
-      configurable: true,
-    });
-    Object.defineProperty(span, "scrollWidth", {
-      value: 200,
-      configurable: true,
-    });
-
-    act(() => {
-      window.dispatchEvent(new Event("resize"));
-    });
-
-    expect(span.classList.contains("marquee")).toBe(true);
   });
 });

--- a/react-spectrogram/src/components/common/MarqueeText.tsx
+++ b/react-spectrogram/src/components/common/MarqueeText.tsx
@@ -1,0 +1,31 @@
+import React from "react";
+import { MARQUEE_DELAY_MS } from "@/config";
+import { cn } from "@/utils/cn";
+import { useMarquee } from "@/hooks/useMarquee";
+
+interface MarqueeTextProps extends React.HTMLAttributes<HTMLSpanElement> {
+  text: string;
+  className?: string;
+}
+
+export const MarqueeText: React.FC<MarqueeTextProps> = ({
+  text,
+  className,
+  ...spanProps
+}) => {
+  const ref = useMarquee<HTMLSpanElement>({ delay: MARQUEE_DELAY_MS, text });
+  return (
+    <div className="marquee-container" aria-label={text}>
+      <span
+        ref={ref}
+        data-text={text}
+        className={cn("marquee-text", className)}
+        {...spanProps}
+      >
+        {text}
+      </span>
+    </div>
+  );
+};
+
+export default MarqueeText;

--- a/react-spectrogram/src/components/layout/AlternatingInfo.tsx
+++ b/react-spectrogram/src/components/layout/AlternatingInfo.tsx
@@ -1,6 +1,7 @@
-import React, { useEffect, useRef, useState } from "react";
+import React, { useEffect, useState } from "react";
 import { AnimatePresence, motion } from "framer-motion";
 import { cn } from "@/utils/cn";
+import { MarqueeText } from "@/components/common/MarqueeText";
 
 interface AlternatingInfoProps {
   artist: string;
@@ -17,9 +18,6 @@ export const AlternatingInfo: React.FC<AlternatingInfoProps> = ({
   className,
 }) => {
   const [showArtist, setShowArtist] = useState(true);
-  const containerRef = useRef<HTMLDivElement>(null);
-  const [isOverflow, setIsOverflow] = useState(false);
-
   useEffect(() => {
     let timeout: ReturnType<typeof setTimeout>;
     const switchInfo = () => {
@@ -30,43 +28,26 @@ export const AlternatingInfo: React.FC<AlternatingInfoProps> = ({
     return () => clearTimeout(timeout);
   }, [interval]);
 
-  const checkOverflow = () => {
-    const container = containerRef.current;
-    const span = container?.firstElementChild as HTMLElement | null;
-    if (container && span) {
-      setIsOverflow(span.scrollWidth > container.clientWidth);
-    }
-  };
-
-  useEffect(() => {
-    checkOverflow();
-    window.addEventListener("resize", checkOverflow);
-    return () => window.removeEventListener("resize", checkOverflow);
-    // Depend on values that can change text size
-  }, [artist, album, showArtist]);
-
   const content = showArtist ? artist : album;
   const fallback = showArtist ? "Unknown Artist" : "Unknown Album";
   const displayText = content || fallback;
 
   return (
-    <div ref={containerRef} className="relative min-w-0 overflow-hidden">
+    <div className="relative min-w-0 overflow-hidden">
       <AnimatePresence mode="wait">
-        <motion.span
+        <motion.div
           key={showArtist ? "artist" : "album"}
           initial={{ opacity: 0 }}
           animate={{ opacity: 1 }}
           exit={{ opacity: 0 }}
           transition={{ duration: 0.5 }}
-          className={cn(
-            className,
-            "block",
-            isOverflow ? "marquee" : "truncate",
-          )}
-          data-testid="alternating-info-text"
         >
-          {displayText}
-        </motion.span>
+          <MarqueeText
+            text={displayText}
+            className={cn(className, "block")}
+            data-testid="alternating-info-text"
+          />
+        </motion.div>
       </AnimatePresence>
     </div>
   );

--- a/react-spectrogram/src/components/layout/Footer.tsx
+++ b/react-spectrogram/src/components/layout/Footer.tsx
@@ -18,6 +18,13 @@ import {
 import { cn } from "@/utils/cn";
 import { conditionalToast } from "@/utils/toast";
 import { AlternatingInfo } from "./AlternatingInfo";
+import { MarqueeText } from "@/components/common/MarqueeText";
+import {
+  TITLE_FONT_STEP,
+  INFO_MAX_CH,
+  NEXT_WINDOW_SEC,
+  SIZE_SWAP_DURATION_MS,
+} from "@/config";
 
 export const Footer: React.FC = () => {
   const volumeSliderRef = useRef<HTMLInputElement>(null);
@@ -43,7 +50,14 @@ export const Footer: React.FC = () => {
     ? playlist[currentTrackIndex + 1]
     : null;
   const showNextInfo =
-    !!currentTrack && hasUpcomingTrack && duration - currentTime <= 10;
+    !!currentTrack && hasUpcomingTrack && duration - currentTime <= NEXT_WINDOW_SEC;
+
+  const trackInfoStyle = {
+    width: `min(100%, ${INFO_MAX_CH}ch)`,
+    "--base-title-size": isMobile ? "0.75rem" : "0.875rem",
+    "--title-font-step": `${TITLE_FONT_STEP}rem`,
+    "--size-swap-duration": `${SIZE_SWAP_DURATION_MS}ms`,
+  } as React.CSSProperties;
 
   // Format time for display
   const formatTime = (seconds: number): string => {
@@ -267,42 +281,40 @@ export const Footer: React.FC = () => {
       {/* Single row layout with all controls */}
       <div className="flex items-center justify-between w-full h-full px-4 gap-3">
         {/* Left side - Album art and track info */}
-        <div className="flex items-center gap-2 min-w-0 flex-shrink-0">
+        <div className="flex items-center gap-2 min-w-0">
           {layoutConfig.showAlbumArt && renderCurrentTrackAlbumArt()}
 
           {layoutConfig.showTrackInfo && currentTrack && (
-            <div className="min-w-0 flex-shrink-0">
-              <h4
+              <div
                 className={cn(
-                  "font-medium text-neutral-100 truncate",
-                  isMobile ? "text-xs" : "text-sm",
+                  "track-info-area",
+                  showNextInfo && "next-active",
                 )}
+                data-testid="track-info-area"
+                style={trackInfoStyle}
               >
-                {currentTrack.metadata.title || currentTrack.file.name}
-              </h4>
-              {showNextInfo && upcomingTrack ? (
-                <p
-                  className={cn(
-                    "text-neutral-400",
-                    isMobile ? "text-xs" : "text-xs",
-                  )}
-                  data-testid="upcoming-track-info"
-                >
-                  {`Coming up: ${
-                    upcomingTrack.metadata.title || upcomingTrack.file.name
-                  } by ${upcomingTrack.metadata.artist || "Unknown Artist"}`}
-                </p>
-              ) : (
-                <AlternatingInfo
-                  artist={currentTrack.metadata.artist || "Unknown Artist"}
-                  album={currentTrack.metadata.album || "Unknown Album"}
-                  className={cn(
-                    "text-neutral-400",
-                    isMobile ? "text-xs" : "text-xs",
-                  )}
+                <MarqueeText
+                  text={currentTrack.metadata.title || currentTrack.file.name}
+                  className="track-title font-medium text-neutral-100"
                 />
-              )}
-            </div>
+                {showNextInfo && upcomingTrack ? (
+                  <MarqueeText
+                    text={`Coming up: ${
+                      upcomingTrack.metadata.title || upcomingTrack.file.name
+                    } by ${
+                      upcomingTrack.metadata.artist || "Unknown Artist"
+                    }`}
+                    className="next-info text-neutral-400"
+                    data-testid="upcoming-track-info"
+                  />
+                ) : (
+                  <AlternatingInfo
+                    artist={currentTrack.metadata.artist || "Unknown Artist"}
+                    album={currentTrack.metadata.album || "Unknown Album"}
+                    className="text-neutral-400"
+                  />
+                )}
+              </div>
           )}
         </div>
 

--- a/react-spectrogram/src/config.ts
+++ b/react-spectrogram/src/config.ts
@@ -1,0 +1,5 @@
+export const TITLE_FONT_STEP = 0.125; // rem
+export const INFO_MAX_CH = 36; // characters for max width
+export const MARQUEE_DELAY_MS = 1500; // ms
+export const NEXT_WINDOW_SEC = 7; // seconds
+export const SIZE_SWAP_DURATION_MS = 300; // ms

--- a/react-spectrogram/src/hooks/__tests__/useMarquee.test.tsx
+++ b/react-spectrogram/src/hooks/__tests__/useMarquee.test.tsx
@@ -1,0 +1,37 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, act } from "@testing-library/react";
+import { MarqueeText } from "@/components/common/MarqueeText";
+import { MARQUEE_DELAY_MS } from "@/config";
+
+vi.useFakeTimers();
+
+describe("useMarquee", () => {
+  it("activates marquee when text overflows", async () => {
+    render(
+      <div style={{ width: "100px" }}>
+        <MarqueeText text={"Long text that will overflow the container"} />
+      </div>,
+    );
+    const span = screen.getByText(/Long text/);
+    const container = span.parentElement as HTMLElement;
+    Object.defineProperty(container, "clientWidth", { value: 100, configurable: true });
+    Object.defineProperty(span, "scrollWidth", { value: 300, configurable: true });
+    act(() => {
+      window.dispatchEvent(new Event("resize"));
+    });
+    expect(span.classList.contains("marquee-active")).toBe(false);
+    vi.advanceTimersByTime(MARQUEE_DELAY_MS + 100);
+    expect(span.classList.contains("marquee-active")).toBe(true);
+  });
+
+  it("does not activate marquee when text fits", () => {
+    render(
+      <div style={{ width: "500px" }}>
+        <MarqueeText text={"Short"} />
+      </div>,
+    );
+    const span = screen.getByText("Short");
+    vi.advanceTimersByTime(MARQUEE_DELAY_MS + 100);
+    expect(span.classList.contains("marquee-active")).toBe(false);
+  });
+});

--- a/react-spectrogram/src/hooks/useMarquee.ts
+++ b/react-spectrogram/src/hooks/useMarquee.ts
@@ -1,0 +1,55 @@
+import { useEffect, useRef } from "react";
+
+interface UseMarqueeOptions {
+  /** Delay before starting marquee */
+  delay: number;
+  /** Content string used to recalc width on change */
+  text: string;
+}
+
+/**
+ * Hook to add marquee animation to overflowing text.
+ * Adds `marquee-active` class to the element after the delay when overflow occurs.
+ * Removes animation on cleanup or when text fits.
+ */
+export function useMarquee<T extends HTMLElement>({ delay, text }: UseMarqueeOptions) {
+  const ref = useRef<T>(null);
+
+  useEffect(() => {
+    const el = ref.current;
+    const container = el?.parentElement;
+    if (!el || !container) return;
+
+    const prefersReduced = window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+    let timer: ReturnType<typeof setTimeout> | null = null;
+
+    const update = () => {
+      if (!el || !container) return;
+      const overflow = el.scrollWidth > container.clientWidth;
+      el.classList.remove("marquee-active");
+      if (timer) {
+        clearTimeout(timer);
+        timer = null;
+      }
+      if (overflow && !prefersReduced) {
+        const duration = Math.max((el.scrollWidth / container.clientWidth) * 5, 5);
+        el.style.setProperty("--marquee-duration", `${duration}s`);
+        timer = setTimeout(() => {
+          el.classList.add("marquee-active");
+        }, delay);
+      }
+    };
+
+    update();
+    window.addEventListener("resize", update);
+    return () => {
+      if (timer) clearTimeout(timer);
+      el.classList.remove("marquee-active");
+      window.removeEventListener("resize", update);
+    };
+  }, [delay, text]);
+
+  return ref;
+}
+
+export default useMarquee;

--- a/react-spectrogram/src/index.css
+++ b/react-spectrogram/src/index.css
@@ -124,6 +124,84 @@
     @apply min-h-[4rem];
   }
 
+  .track-info-area {
+    width: min(100%, var(--info-max-ch));
+    min-width: 0;
+    flex-shrink: 0;
+    overflow: hidden;
+    display: flex;
+    flex-direction: column;
+    --title-size: calc(var(--base-title-size) + var(--title-font-step));
+    --next-size: var(--base-title-size);
+  }
+
+  .track-info-area.next-active {
+    --title-size: var(--base-title-size);
+    --next-size: calc(var(--base-title-size) + var(--title-font-step));
+  }
+
+  .track-title {
+    font-size: var(--title-size);
+    transition: font-size var(--size-swap-duration) ease-in-out;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+
+  .next-info {
+    font-size: var(--next-size);
+    transition: font-size var(--size-swap-duration) ease-in-out;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+
+  .marquee-container {
+    position: relative;
+    overflow: hidden;
+    min-width: 0;
+  }
+
+  .marquee-text {
+    display: inline-block;
+    white-space: nowrap;
+  }
+
+  .marquee-active {
+    animation: marquee var(--marquee-duration) linear infinite;
+    padding-right: 2ch;
+  }
+
+  .marquee-active::after {
+    content: attr(data-text);
+    padding-left: 2ch;
+  }
+
+  .marquee-container:hover .marquee-active,
+  .marquee-container:focus-within .marquee-active {
+    animation-play-state: paused;
+  }
+
+  @keyframes marquee {
+    from {
+      transform: translateX(0);
+    }
+    to {
+      transform: translateX(-100%);
+    }
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .marquee-active {
+      animation: none;
+    }
+
+    .track-title,
+    .next-info {
+      transition: none;
+    }
+  }
+
   /* Responsive layout utilities */
   .mobile-layout {
     @apply flex-col;


### PR DESCRIPTION
## Summary
- add overflow marquee hook and component for track info
- enlarge title text and support upcoming track size swap
- introduce configurable UI constants for marquee, fonts, and timing

## Testing
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*
- `npm test` *(fails: multiple component tests and EventTarget errors)*

------
https://chatgpt.com/codex/tasks/task_e_68a4e10519fc832b9085f186cfbd0b13