### PR TITLE
Enable scalar FFT kernels for non-SIMD builds

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -83,6 +83,7 @@ path = "examples/benchmark.rs"
 [[example]]
 name = "stft_usage"
 path = "examples/stft_usage.rs"
+required-features = ["std", "wasm", "simd"]
 
 [[example]]
 name = "ndfft_usage"
@@ -91,6 +92,7 @@ path = "examples/ndfft_usage.rs"
 [[example]]
 name = "spectrogram"
 path = "examples/spectrogram.rs"
+required-features = ["std", "wasm", "simd"]
 
 [[example]]
 name = "parallel_benchmark"

--- a/examples/spectrogram.rs
+++ b/examples/spectrogram.rs
@@ -1,3 +1,5 @@
+#![cfg(all(feature = "std", feature = "wasm", feature = "simd"))]
+
 //! Generates a spectrogram from a WAV file using kofft.
 //!
 //! Usage:

--- a/src/fft_kernels.rs
+++ b/src/fft_kernels.rs
@@ -1,227 +1,244 @@
-#[cfg(not(all(feature = "wasm", feature = "simd")))]
-compile_error!("fft_kernels requires `wasm` and `simd` features to be enabled");
+macro_rules! define_kernels {
+    () => {
+        #[inline(always)]
+        pub fn fft2<T: Float>(input: &mut [Complex<T>]) {
+            debug_assert_eq!(input.len(), 2);
+            let a = input[0];
+            let b = input[1];
+            input[0] = a.add(b);
+            input[1] = a.sub(b);
+        }
 
-use crate::num::{Complex, Float};
+        #[inline(always)]
+        pub fn fft4<T: Float>(input: &mut [Complex<T>]) {
+            debug_assert_eq!(input.len(), 4);
+            let a0 = input[0];
+            let a1 = input[1];
+            let a2 = input[2];
+            let a3 = input[3];
+            let even0 = a0.add(a2);
+            let even1 = a0.sub(a2);
+            let odd0 = a1.add(a3);
+            let odd1 = a1.sub(a3);
+            let w1 = Complex::new(T::zero(), -T::one());
+            let t1 = odd1.mul(w1);
+            input[0] = even0.add(odd0);
+            input[2] = even0.sub(odd0);
+            input[1] = even1.add(t1);
+            input[3] = even1.sub(t1);
+        }
 
-#[inline(always)]
-pub fn fft2<T: Float>(input: &mut [Complex<T>]) {
-    debug_assert_eq!(input.len(), 2);
-    let a = input[0];
-    let b = input[1];
-    input[0] = a.add(b);
-    input[1] = a.sub(b);
+        #[inline(always)]
+        pub fn fft8<T: Float>(input: &mut [Complex<T>]) {
+            debug_assert_eq!(input.len(), 8);
+            let w1 = Complex::new(T::zero(), -T::one());
+            let s = T::from_f32(0.70710677); // sqrt(2)/2
+
+            // load inputs before overwriting
+            let x0 = input[0];
+            let x1 = input[1];
+            let x2 = input[2];
+            let x3 = input[3];
+            let x4 = input[4];
+            let x5 = input[5];
+            let x6 = input[6];
+            let x7 = input[7];
+
+            // FFT4 on even indices (0,2,4,6)
+            let a0 = x0.add(x4);
+            let a1 = x0.sub(x4);
+            let a2 = x2.add(x6);
+            let a3 = x2.sub(x6);
+            let t = a3.mul(w1);
+            input[0] = a0.add(a2);
+            input[2] = a0.sub(a2);
+            input[1] = a1.add(t);
+            input[3] = a1.sub(t);
+
+            // FFT4 on odd indices (1,3,5,7)
+            let b0 = x1.add(x5);
+            let b1 = x1.sub(x5);
+            let b2 = x3.add(x7);
+            let b3 = x3.sub(x7);
+            let t = b3.mul(w1);
+            input[4] = b0.add(b2);
+            input[6] = b0.sub(b2);
+            input[5] = b1.add(t);
+            input[7] = b1.sub(t);
+
+            // Twiddle multiplication on odd part and final butterflies
+            let t1 = input[5].mul(Complex::new(s, -s));
+            let t2 = input[6].mul(w1);
+            let t3 = input[7].mul(Complex::new(-s, -s));
+            let o0 = input[4];
+            let e0 = input[0];
+            let e1 = input[1];
+            let e2 = input[2];
+            let e3 = input[3];
+            input[0] = e0.add(o0);
+            input[4] = e0.sub(o0);
+            input[1] = e1.add(t1);
+            input[5] = e1.sub(t1);
+            input[2] = e2.add(t2);
+            input[6] = e2.sub(t2);
+            input[3] = e3.add(t3);
+            input[7] = e3.sub(t3);
+        }
+
+        #[inline(always)]
+        pub fn fft16<T: Float>(input: &mut [Complex<T>]) {
+            debug_assert_eq!(input.len(), 16);
+            // load all inputs before overwriting
+            let x0 = input[0];
+            let x1 = input[1];
+            let x2 = input[2];
+            let x3 = input[3];
+            let x4 = input[4];
+            let x5 = input[5];
+            let x6 = input[6];
+            let x7 = input[7];
+            let x8 = input[8];
+            let x9 = input[9];
+            let x10 = input[10];
+            let x11 = input[11];
+            let x12 = input[12];
+            let x13 = input[13];
+            let x14 = input[14];
+            let x15 = input[15];
+
+            let w1 = Complex::new(T::zero(), -T::one());
+            let s = T::from_f32(0.70710677); // sqrt(2)/2
+
+            // ---- even index FFT8 ----
+            let a0 = x0.add(x8);
+            let a1 = x0.sub(x8);
+            let a2 = x4.add(x12);
+            let a3 = x4.sub(x12);
+            let t = a3.mul(w1);
+            let ea0 = a0.add(a2);
+            let ea2 = a0.sub(a2);
+            let ea1 = a1.add(t);
+            let ea3 = a1.sub(t);
+
+            let b0 = x2.add(x10);
+            let b1 = x2.sub(x10);
+            let b2 = x6.add(x14);
+            let b3 = x6.sub(x14);
+            let t = b3.mul(w1);
+            let eb0 = b0.add(b2);
+            let eb2 = b0.sub(b2);
+            let eb1 = b1.add(t);
+            let eb3 = b1.sub(t);
+
+            let t0 = eb0;
+            let t1 = eb1.mul(Complex::new(s, -s));
+            let t2 = eb2.mul(w1);
+            let t3 = eb3.mul(Complex::new(-s, -s));
+            input[0] = ea0.add(t0);
+            input[1] = ea1.add(t1);
+            input[2] = ea2.add(t2);
+            input[3] = ea3.add(t3);
+            input[4] = ea0.sub(t0);
+            input[5] = ea1.sub(t1);
+            input[6] = ea2.sub(t2);
+            input[7] = ea3.sub(t3);
+
+            // ---- odd index FFT8 ----
+            let c0 = x1.add(x9);
+            let c1 = x1.sub(x9);
+            let c2 = x5.add(x13);
+            let c3 = x5.sub(x13);
+            let t = c3.mul(w1);
+            let oa0 = c0.add(c2);
+            let oa2 = c0.sub(c2);
+            let oa1 = c1.add(t);
+            let oa3 = c1.sub(t);
+
+            let d0 = x3.add(x11);
+            let d1 = x3.sub(x11);
+            let d2 = x7.add(x15);
+            let d3 = x7.sub(x15);
+            let t = d3.mul(w1);
+            let ob0 = d0.add(d2);
+            let ob2 = d0.sub(d2);
+            let ob1 = d1.add(t);
+            let ob3 = d1.sub(t);
+
+            let t0 = ob0;
+            let t1 = ob1.mul(Complex::new(s, -s));
+            let t2 = ob2.mul(w1);
+            let t3 = ob3.mul(Complex::new(-s, -s));
+            input[8] = oa0.add(t0);
+            input[9] = oa1.add(t1);
+            input[10] = oa2.add(t2);
+            input[11] = oa3.add(t3);
+            input[12] = oa0.sub(t0);
+            input[13] = oa1.sub(t1);
+            input[14] = oa2.sub(t2);
+            input[15] = oa3.sub(t3);
+
+            // ---- twiddle multiply odd half ----
+            let c1 = T::from_f32(0.9238795);
+            let s1 = T::from_f32(-0.38268343);
+            let c2 = T::from_f32(0.70710677);
+            let s2 = T::from_f32(-0.70710677);
+            let c3 = T::from_f32(0.38268343);
+            let s3 = T::from_f32(-0.9238795);
+            let c4 = T::zero();
+            let s4 = T::from_f32(-1.0);
+
+            let o0 = input[8];
+            let o1 = input[9].mul(Complex::new(c1, s1));
+            let o2 = input[10].mul(Complex::new(c2, s2));
+            let o3 = input[11].mul(Complex::new(c3, s3));
+            let o4 = input[12].mul(Complex::new(c4, s4));
+            let o5 = input[13].mul(Complex::new(-c3, s3));
+            let o6 = input[14].mul(Complex::new(-c2, s2));
+            let o7 = input[15].mul(Complex::new(-c1, s1));
+
+            let e0 = input[0];
+            let e1 = input[1];
+            let e2 = input[2];
+            let e3 = input[3];
+            let e4 = input[4];
+            let e5 = input[5];
+            let e6 = input[6];
+            let e7 = input[7];
+
+            input[0] = e0.add(o0);
+            input[8] = e0.sub(o0);
+            input[1] = e1.add(o1);
+            input[9] = e1.sub(o1);
+            input[2] = e2.add(o2);
+            input[10] = e2.sub(o2);
+            input[3] = e3.add(o3);
+            input[11] = e3.sub(o3);
+            input[4] = e4.add(o4);
+            input[12] = e4.sub(o4);
+            input[5] = e5.add(o5);
+            input[13] = e5.sub(o5);
+            input[6] = e6.add(o6);
+            input[14] = e6.sub(o6);
+            input[7] = e7.add(o7);
+            input[15] = e7.sub(o7);
+        }
+    };
 }
 
-#[inline(always)]
-pub fn fft4<T: Float>(input: &mut [Complex<T>]) {
-    debug_assert_eq!(input.len(), 4);
-    let a0 = input[0];
-    let a1 = input[1];
-    let a2 = input[2];
-    let a3 = input[3];
-    let even0 = a0.add(a2);
-    let even1 = a0.sub(a2);
-    let odd0 = a1.add(a3);
-    let odd1 = a1.sub(a3);
-    let w1 = Complex::new(T::zero(), -T::one());
-    let t1 = odd1.mul(w1);
-    input[0] = even0.add(odd0);
-    input[2] = even0.sub(odd0);
-    input[1] = even1.add(t1);
-    input[3] = even1.sub(t1);
+#[cfg(feature = "simd")]
+mod simd {
+    use crate::num::{Complex, Float};
+    define_kernels!();
 }
 
-#[inline(always)]
-pub fn fft8<T: Float>(input: &mut [Complex<T>]) {
-    debug_assert_eq!(input.len(), 8);
-    let w1 = Complex::new(T::zero(), -T::one());
-    let s = T::from_f32(0.70710677); // sqrt(2)/2
-
-    // load inputs before overwriting
-    let x0 = input[0];
-    let x1 = input[1];
-    let x2 = input[2];
-    let x3 = input[3];
-    let x4 = input[4];
-    let x5 = input[5];
-    let x6 = input[6];
-    let x7 = input[7];
-
-    // FFT4 on even indices (0,2,4,6)
-    let a0 = x0.add(x4);
-    let a1 = x0.sub(x4);
-    let a2 = x2.add(x6);
-    let a3 = x2.sub(x6);
-    let t = a3.mul(w1);
-    input[0] = a0.add(a2);
-    input[2] = a0.sub(a2);
-    input[1] = a1.add(t);
-    input[3] = a1.sub(t);
-
-    // FFT4 on odd indices (1,3,5,7)
-    let b0 = x1.add(x5);
-    let b1 = x1.sub(x5);
-    let b2 = x3.add(x7);
-    let b3 = x3.sub(x7);
-    let t = b3.mul(w1);
-    input[4] = b0.add(b2);
-    input[6] = b0.sub(b2);
-    input[5] = b1.add(t);
-    input[7] = b1.sub(t);
-
-    // Twiddle multiplication on odd part and final butterflies
-    let t1 = input[5].mul(Complex::new(s, -s));
-    let t2 = input[6].mul(w1);
-    let t3 = input[7].mul(Complex::new(-s, -s));
-    let o0 = input[4];
-    let e0 = input[0];
-    let e1 = input[1];
-    let e2 = input[2];
-    let e3 = input[3];
-    input[0] = e0.add(o0);
-    input[4] = e0.sub(o0);
-    input[1] = e1.add(t1);
-    input[5] = e1.sub(t1);
-    input[2] = e2.add(t2);
-    input[6] = e2.sub(t2);
-    input[3] = e3.add(t3);
-    input[7] = e3.sub(t3);
+#[cfg(not(feature = "simd"))]
+mod scalar {
+    use crate::num::{Complex, Float};
+    define_kernels!();
 }
 
-#[inline(always)]
-pub fn fft16<T: Float>(input: &mut [Complex<T>]) {
-    debug_assert_eq!(input.len(), 16);
-    // load all inputs before overwriting
-    let x0 = input[0];
-    let x1 = input[1];
-    let x2 = input[2];
-    let x3 = input[3];
-    let x4 = input[4];
-    let x5 = input[5];
-    let x6 = input[6];
-    let x7 = input[7];
-    let x8 = input[8];
-    let x9 = input[9];
-    let x10 = input[10];
-    let x11 = input[11];
-    let x12 = input[12];
-    let x13 = input[13];
-    let x14 = input[14];
-    let x15 = input[15];
+#[cfg(feature = "simd")]
+pub use simd::*;
 
-    let w1 = Complex::new(T::zero(), -T::one());
-    let s = T::from_f32(0.70710677); // sqrt(2)/2
-
-    // ---- even index FFT8 ----
-    let a0 = x0.add(x8);
-    let a1 = x0.sub(x8);
-    let a2 = x4.add(x12);
-    let a3 = x4.sub(x12);
-    let t = a3.mul(w1);
-    let ea0 = a0.add(a2);
-    let ea2 = a0.sub(a2);
-    let ea1 = a1.add(t);
-    let ea3 = a1.sub(t);
-
-    let b0 = x2.add(x10);
-    let b1 = x2.sub(x10);
-    let b2 = x6.add(x14);
-    let b3 = x6.sub(x14);
-    let t = b3.mul(w1);
-    let eb0 = b0.add(b2);
-    let eb2 = b0.sub(b2);
-    let eb1 = b1.add(t);
-    let eb3 = b1.sub(t);
-
-    let t0 = eb0;
-    let t1 = eb1.mul(Complex::new(s, -s));
-    let t2 = eb2.mul(w1);
-    let t3 = eb3.mul(Complex::new(-s, -s));
-    input[0] = ea0.add(t0);
-    input[1] = ea1.add(t1);
-    input[2] = ea2.add(t2);
-    input[3] = ea3.add(t3);
-    input[4] = ea0.sub(t0);
-    input[5] = ea1.sub(t1);
-    input[6] = ea2.sub(t2);
-    input[7] = ea3.sub(t3);
-
-    // ---- odd index FFT8 ----
-    let c0 = x1.add(x9);
-    let c1 = x1.sub(x9);
-    let c2 = x5.add(x13);
-    let c3 = x5.sub(x13);
-    let t = c3.mul(w1);
-    let oa0 = c0.add(c2);
-    let oa2 = c0.sub(c2);
-    let oa1 = c1.add(t);
-    let oa3 = c1.sub(t);
-
-    let d0 = x3.add(x11);
-    let d1 = x3.sub(x11);
-    let d2 = x7.add(x15);
-    let d3 = x7.sub(x15);
-    let t = d3.mul(w1);
-    let ob0 = d0.add(d2);
-    let ob2 = d0.sub(d2);
-    let ob1 = d1.add(t);
-    let ob3 = d1.sub(t);
-
-    let t0 = ob0;
-    let t1 = ob1.mul(Complex::new(s, -s));
-    let t2 = ob2.mul(w1);
-    let t3 = ob3.mul(Complex::new(-s, -s));
-    input[8] = oa0.add(t0);
-    input[9] = oa1.add(t1);
-    input[10] = oa2.add(t2);
-    input[11] = oa3.add(t3);
-    input[12] = oa0.sub(t0);
-    input[13] = oa1.sub(t1);
-    input[14] = oa2.sub(t2);
-    input[15] = oa3.sub(t3);
-
-    // ---- twiddle multiply odd half ----
-    let c1 = T::from_f32(0.9238795);
-    let s1 = T::from_f32(-0.38268343);
-    let c2 = T::from_f32(0.70710677);
-    let s2 = T::from_f32(-0.70710677);
-    let c3 = T::from_f32(0.38268343);
-    let s3 = T::from_f32(-0.9238795);
-    let c4 = T::zero();
-    let s4 = T::from_f32(-1.0);
-
-    let o0 = input[8];
-    let o1 = input[9].mul(Complex::new(c1, s1));
-    let o2 = input[10].mul(Complex::new(c2, s2));
-    let o3 = input[11].mul(Complex::new(c3, s3));
-    let o4 = input[12].mul(Complex::new(c4, s4));
-    let o5 = input[13].mul(Complex::new(-c3, s3));
-    let o6 = input[14].mul(Complex::new(-c2, s2));
-    let o7 = input[15].mul(Complex::new(-c1, s1));
-
-    let e0 = input[0];
-    let e1 = input[1];
-    let e2 = input[2];
-    let e3 = input[3];
-    let e4 = input[4];
-    let e5 = input[5];
-    let e6 = input[6];
-    let e7 = input[7];
-
-    input[0] = e0.add(o0);
-    input[8] = e0.sub(o0);
-    input[1] = e1.add(o1);
-    input[9] = e1.sub(o1);
-    input[2] = e2.add(o2);
-    input[10] = e2.sub(o2);
-    input[3] = e3.add(o3);
-    input[11] = e3.sub(o3);
-    input[4] = e4.add(o4);
-    input[12] = e4.sub(o4);
-    input[5] = e5.add(o5);
-    input[13] = e5.sub(o5);
-    input[6] = e6.add(o6);
-    input[14] = e6.sub(o6);
-    input[7] = e7.add(o7);
-    input[15] = e7.sub(o7);
-}
+#[cfg(not(feature = "simd"))]
+pub use scalar::*;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -127,6 +127,7 @@ pub mod hilbert;
 /// Short-Time Fourier Transform (STFT)
 ///
 /// Streaming and batch STFT/ISTFT utilities.
+#[cfg(all(feature = "wasm", feature = "simd"))]
 pub mod stft;
 
 /// Cepstrum analysis
@@ -150,8 +151,8 @@ pub mod fuzzy;
 pub use fft::FftPlanner;
 pub use num::{Complex, Complex32, Complex64, Float};
 
-#[cfg(feature = "std")]
-/// Visualisation helpers (requires `std`)
+#[cfg(all(feature = "std", feature = "wasm", feature = "simd"))]
+/// Visualisation helpers (requires `std`, `wasm` and `simd`)
 pub mod visual;
 
 #[cfg(feature = "std")]

--- a/tests/features_enabled.rs
+++ b/tests/features_enabled.rs
@@ -1,3 +1,5 @@
+#![cfg(all(feature = "simd", feature = "wasm"))]
+
 #[test]
 fn wasm_and_simd_features_enabled() {
     assert!(cfg!(feature = "wasm"), "wasm feature not enabled");

--- a/tests/fft_kernels_features.rs
+++ b/tests/fft_kernels_features.rs
@@ -1,0 +1,46 @@
+use kofft::fft::{fft16, fft8, Complex32};
+
+fn dft(input: &[Complex32]) -> Vec<Complex32> {
+    let n = input.len();
+    let mut output = vec![Complex32::zero(); n];
+    for (k, out) in output.iter_mut().enumerate() {
+        let mut sum = Complex32::zero();
+        for (n_idx, x) in input.iter().enumerate() {
+            let angle = -2.0 * core::f32::consts::PI * (k * n_idx) as f32 / n as f32;
+            let tw = Complex32::new(angle.cos(), angle.sin());
+            sum = sum.add(x.mul(tw));
+        }
+        *out = sum;
+    }
+    output
+}
+
+fn run_kernels() {
+    for &n in &[8usize, 16] {
+        let mut data: Vec<Complex32> = (0..n)
+            .map(|i| Complex32::new((i as f32).sin(), (i as f32).cos()))
+            .collect();
+        let expected = dft(&data);
+        match n {
+            8 => fft8(&mut data),
+            16 => fft16(&mut data),
+            _ => unreachable!(),
+        }
+        for (a, b) in data.iter().zip(expected.iter()) {
+            assert!((a.re - b.re).abs() < 1e-2);
+            assert!((a.im - b.im).abs() < 1e-2);
+        }
+    }
+}
+
+#[cfg(feature = "simd")]
+#[test]
+fn kernels_with_simd() {
+    run_kernels();
+}
+
+#[cfg(not(feature = "simd"))]
+#[test]
+fn kernels_without_simd() {
+    run_kernels();
+}

--- a/tests/istft_stream.rs
+++ b/tests/istft_stream.rs
@@ -1,3 +1,5 @@
+#![cfg(all(feature = "simd", feature = "wasm"))]
+
 use kofft::fft::{Complex32, ScalarFftImpl};
 use kofft::stft::{istft, IstftStream, StftStream};
 

--- a/tests/stft.rs
+++ b/tests/stft.rs
@@ -1,3 +1,5 @@
+#![cfg(all(feature = "simd", feature = "wasm"))]
+
 use kofft::fft::{FftError, ScalarFftImpl};
 use kofft::stft::stft;
 use kofft::window::hann;


### PR DESCRIPTION
## Summary
- replace compile-time error with cfg-gated FFT kernel implementations, providing scalar fallbacks when SIMD is disabled
- gate STFT and visual modules behind `wasm`+`simd` features
- add feature-aware tests covering FFT kernels with and without SIMD

## Testing
- `cargo clippy --all-targets --all-features`
- `cargo clippy --all-targets --no-default-features --features std`
- `cargo test`
- `cargo test --no-default-features --features std`


------
https://chatgpt.com/codex/tasks/task_e_68a4e12c6dac832ba1d120c7d2206382