### PR TITLE
Optimize ISTFT buffering and add memory benchmarks

### DIFF
--- a/kofft-bench/Cargo.toml
+++ b/kofft-bench/Cargo.toml
@@ -13,6 +13,7 @@ serde_json = "1"
 once_cell = "1"
 chrono = { version = "0.4", default-features = false, features = ["clock"] }
 rusqlite = { version = "0.29", features = ["bundled"] }
+procfs = "0.14"
 
 [features]
 default = []
@@ -33,6 +34,10 @@ harness = false
 
 [[bench]]
 name = "waveform_cache"
+harness = false
+
+[[bench]]
+name = "memory_usage"
 harness = false
 
 [[example]]

--- a/kofft-bench/benches/memory_usage.rs
+++ b/kofft-bench/benches/memory_usage.rs
@@ -1,0 +1,28 @@
+use criterion::{criterion_group, criterion_main, Criterion};
+use kofft::fft::{Complex32, ScalarFftImpl};
+use kofft::stft::IstftStream;
+use procfs::process::Process;
+use std::hint::black_box;
+
+fn memory_usage_benchmark(c: &mut Criterion) {
+    c.bench_function("istft_stream_memory_usage", |b| {
+        b.iter(|| {
+            let win_len = 1024;
+            let hop = 512;
+            let window = vec![1.0f32; win_len];
+            let fft = ScalarFftImpl::<f32>::default();
+            let mut istft = IstftStream::new(win_len, hop, &window, &fft).unwrap();
+            let mut frame = vec![Complex32::new(0.0, 0.0); win_len];
+            let process = Process::myself().unwrap();
+            let before = process.statm().unwrap().resident;
+            for _ in 0..1000 {
+                istft.push_frame(&mut frame).unwrap();
+            }
+            let after = process.statm().unwrap().resident;
+            black_box(after - before);
+        });
+    });
+}
+
+criterion_group!(benches, memory_usage_benchmark);
+criterion_main!(benches);

--- a/src/stft.rs
+++ b/src/stft.rs
@@ -55,7 +55,7 @@
 //! let mut frame = vec![Complex32::new(0.0, 0.0); window.len()];
 //! let mut out = Vec::new();
 //! while stft_stream.next_frame(&mut frame).unwrap() {
-//!     out.extend_from_slice(istft_stream.push_frame(&frame).unwrap());
+//!     out.extend_from_slice(istft_stream.push_frame(&mut frame).unwrap());
 //! }
 //! out.extend_from_slice(istft_stream.flush());
 //! ```
@@ -415,7 +415,6 @@ pub struct IstftStream<'a, Fft: crate::fft::FftImpl<f32>> {
     buffer: alloc::vec::Vec<f32>,
     /// Buffer storing the sum of squared window values for normalization.
     norm_buf: alloc::vec::Vec<f32>,
-    time_buf: alloc::vec::Vec<crate::fft::Complex32>,
     buf_pos: usize,
     out_pos: usize,
     frame_count: usize,
@@ -436,7 +435,6 @@ impl<'a, Fft: crate::fft::FftImpl<f32>> IstftStream<'a, Fft> {
         }
         let buffer = vec![0.0f32; win_len + hop * 2];
         let norm_buf = vec![0.0f32; win_len + hop * 2];
-        let time_buf = vec![crate::fft::Complex32::new(0.0, 0.0); win_len];
         Ok(Self {
             win_len,
             hop,
@@ -444,7 +442,6 @@ impl<'a, Fft: crate::fft::FftImpl<f32>> IstftStream<'a, Fft> {
             fft,
             buffer,
             norm_buf,
-            time_buf,
             buf_pos: 0,
             out_pos: 0,
             frame_count: 0,
@@ -456,16 +453,26 @@ impl<'a, Fft: crate::fft::FftImpl<f32>> IstftStream<'a, Fft> {
     /// Returns a slice of length `hop` containing the next chunk of time-domain
     /// signal. Remaining samples after all frames have been pushed can be
     /// retrieved via [`flush`].
-    pub fn push_frame(&mut self, frame: &[crate::fft::Complex32]) -> Result<&[f32], FftError> {
+    pub fn push_frame(&mut self, frame: &mut [crate::fft::Complex32]) -> Result<&[f32], FftError> {
         if frame.len() != self.win_len {
             return Err(FftError::MismatchedLengths);
         }
-        self.time_buf.copy_from_slice(frame);
-        self.fft.ifft(&mut self.time_buf)?;
+        if self.buf_pos + self.win_len > self.buffer.len() {
+            let shift = self.out_pos;
+            self.buffer.copy_within(shift.., 0);
+            self.norm_buf.copy_within(shift.., 0);
+            self.buf_pos -= shift;
+            self.out_pos = 0;
+            for i in self.buf_pos + self.win_len - self.hop..self.buffer.len() {
+                self.buffer[i] = 0.0;
+                self.norm_buf[i] = 0.0;
+            }
+        }
+        self.fft.ifft(frame)?;
         // Window and overlap-add
-        for i in 0..self.win_len {
+        for (i, sample) in frame.iter().enumerate().take(self.win_len) {
             let win = self.window[i];
-            let val = self.time_buf[i].re * win;
+            let val = sample.re * win;
             let idx = self.buf_pos + i;
             self.buffer[idx] += val;
             self.norm_buf[idx] += win * win;
@@ -483,17 +490,12 @@ impl<'a, Fft: crate::fft::FftImpl<f32>> IstftStream<'a, Fft> {
         }
         self.out_pos += self.hop;
         self.buf_pos += self.hop;
-        // Zero the region that will be written next time
-        if self.buf_pos + self.win_len > self.buffer.len() {
-            // Extend buffer if needed
-            let new_len = self.buf_pos + self.win_len;
-            self.buffer.resize(new_len, 0.0);
-            self.norm_buf.resize(new_len, 0.0);
-        }
         for i in 0..self.hop {
             let idx = self.buf_pos + self.win_len - self.hop + i;
-            self.buffer[idx] = 0.0;
-            self.norm_buf[idx] = 0.0;
+            if idx < self.buffer.len() {
+                self.buffer[idx] = 0.0;
+                self.norm_buf[idx] = 0.0;
+            }
         }
         Ok(&self.buffer[out_start..out_end])
     }
@@ -522,6 +524,11 @@ impl<'a, Fft: crate::fft::FftImpl<f32>> IstftStream<'a, Fft> {
         }
         self.out_pos = out_end;
         &self.buffer[out_start..out_end]
+    }
+
+    /// Current length of the internal buffer (for diagnostics and testing).
+    pub fn buffer_len(&self) -> usize {
+        self.buffer.len()
     }
 }
 
@@ -687,8 +694,8 @@ mod edge_case_tests {
         let window = vec![1.0f32; win_len];
         let fft = ScalarFftImpl::<f32>::default();
         let mut istft_stream = IstftStream::new(win_len, hop, &window, &fft).unwrap();
-        let frame = vec![Complex32::new(0.0, 0.0); win_len - 1];
-        let res = istft_stream.push_frame(&frame);
+        let mut frame = vec![Complex32::new(0.0, 0.0); win_len - 1];
+        let res = istft_stream.push_frame(&mut frame);
         assert!(matches!(res, Err(FftError::MismatchedLengths)));
     }
 
@@ -762,7 +769,7 @@ mod edge_case_tests {
         let mut output = Vec::new();
         let mut frame = vec![Complex32::new(0.0, 0.0); win_len];
         while stft_stream.next_frame(&mut frame).unwrap() {
-            let out = istft_stream.push_frame(&frame).unwrap();
+            let out = istft_stream.push_frame(&mut frame).unwrap();
             output.extend_from_slice(out);
         }
         let tail = istft_stream.flush();

--- a/tests/istft_stream.rs
+++ b/tests/istft_stream.rs
@@ -17,7 +17,8 @@ fn istft_stream_reconstructs_and_flushes() {
 
     while stft_stream.next_frame(&mut frame).unwrap() {
         frames.push(frame.clone());
-        let out = istft_stream.push_frame(&frame).unwrap();
+        let mut frame_copy = frame.clone();
+        let out = istft_stream.push_frame(&mut frame_copy).unwrap();
         output_stream.extend_from_slice(out);
     }
     let tail = istft_stream.flush();

--- a/tests/memory_usage.rs
+++ b/tests/memory_usage.rs
@@ -1,0 +1,17 @@
+use kofft::fft::{Complex32, ScalarFftImpl};
+use kofft::stft::IstftStream;
+
+#[test]
+fn istft_stream_memory_capped() {
+    let win_len = 4;
+    let hop = 2;
+    let window = vec![1.0f32; win_len];
+    let fft = ScalarFftImpl::<f32>::default();
+    let mut istft_stream = IstftStream::new(win_len, hop, &window, &fft).unwrap();
+    let initial = istft_stream.buffer_len();
+    let mut frame = vec![Complex32::new(0.0, 0.0); win_len];
+    for _ in 0..1000 {
+        istft_stream.push_frame(&mut frame).unwrap();
+    }
+    assert_eq!(istft_stream.buffer_len(), initial);
+}


### PR DESCRIPTION
## Summary
- perform ISTFT in place and shift internal buffers to cap memory growth
- expose buffer length and add tests/benchmarks for long stream memory usage

## Testing
- `cargo clippy --all-targets --all-features`
- `cargo test`
- `cargo test --features internal-tests`
- `cargo bench -p kofft-bench --bench memory_usage -- --sample-size 10`


------
https://chatgpt.com/codex/tasks/task_e_68a4e16bc3f8832b93da9228ac69cfba