### PR TITLE
Use entry API and safe Arc casts for twiddle cache

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,7 @@ num_cpus = { version = "1.16", optional = true }
 colorous = { version = "1", optional = true }
 blake3 = { version = "1.5", features = ["std"] }
 rusqlite = { version = "0.29", optional = true, features = ["bundled"] }
+log = "0.4"
 
 [features]
 default = ["std", "simd", "wasm"]

--- a/src/fft.rs
+++ b/src/fft.rs
@@ -329,6 +329,13 @@ pub fn split_to_complex32(split: &SplitComplex<'_, f32>, out: &mut [Complex32]) 
 
 type BluesteinPair<T> = (Arc<[Complex<T>]>, Arc<[Complex<T>]>);
 
+#[cfg(feature = "precomputed-twiddles")]
+fn arc_cast<A, B>(arc: Arc<[A]>) -> Arc<[B]> {
+    assert_eq!(core::mem::size_of::<A>(), core::mem::size_of::<B>());
+    assert_eq!(core::mem::align_of::<A>(), core::mem::align_of::<B>());
+    unsafe { Arc::from_raw(Arc::into_raw(arc) as *const [B]) }
+}
+
 pub struct FftPlanner<T: Float> {
     /// Cache of per-stage twiddle tables. Each entry contains the twiddle
     /// factors for a particular butterfly size (`len`), stored contiguously so
@@ -372,39 +379,40 @@ impl<T: Float> FftPlanner<T> {
         {
             if TypeId::of::<T>() == TypeId::of::<f32>() {
                 if let Some(tab) = lookup_f32(n) {
-                    // SAFETY: We just checked T == f32
-                    let arc = unsafe {
-                        core::mem::transmute::<Arc<[crate::num::Complex32]>, Arc<[Complex<T>]>>(tab)
-                    };
-                    return arc;
+                    log::debug!("Retrieved precomputed twiddle table for n={}", n);
+                    return arc_cast::<crate::num::Complex32, Complex<T>>(tab);
                 }
             } else if TypeId::of::<T>() == TypeId::of::<f64>() {
                 if let Some(tab) = lookup_f64(n) {
-                    let arc = unsafe {
-                        core::mem::transmute::<Arc<[crate::num::Complex64]>, Arc<[Complex<T>]>>(tab)
-                    };
-                    return arc;
+                    log::debug!("Retrieved precomputed twiddle table for n={}", n);
+                    return arc_cast::<crate::num::Complex64, Complex<T>>(tab);
                 }
             }
         }
 
-        if !self.cache.contains_key(&n) {
-            let half = n / 2;
-            let angle = -T::from_f32(2.0) * T::pi() / T::from_f32(n as f32);
-            let (sin_step, cos_step) = angle.sin_cos();
-
-            let mut table: Vec<Complex<T>> = Vec::with_capacity(half);
-            let mut w_re = T::one();
-            let mut w_im = T::zero();
-            for _ in 0..half {
-                table.push(Complex::new(w_re, w_im));
-                let tmp = w_re;
-                w_re = w_re.mul_add(cos_step, -(w_im * sin_step));
-                w_im = w_im.mul_add(cos_step, tmp * sin_step);
+        match self.cache.entry(n) {
+            hashbrown::hash_map::Entry::Occupied(entry) => {
+                log::debug!("Retrieved cached twiddle table for n={}", n);
+                Arc::clone(entry.get())
             }
-            self.cache.insert(n, Arc::from(table));
+            hashbrown::hash_map::Entry::Vacant(entry) => {
+                log::debug!("Generated twiddle table for n={}", n);
+                let half = n / 2;
+                let angle = -T::from_f32(2.0) * T::pi() / T::from_f32(n as f32);
+                let (sin_step, cos_step) = angle.sin_cos();
+
+                let mut table: Vec<Complex<T>> = Vec::with_capacity(half);
+                let mut w_re = T::one();
+                let mut w_im = T::zero();
+                for _ in 0..half {
+                    table.push(Complex::new(w_re, w_im));
+                    let tmp = w_re;
+                    w_re = w_re.mul_add(cos_step, -(w_im * sin_step));
+                    w_im = w_im.mul_add(cos_step, tmp * sin_step);
+                }
+                Arc::clone(entry.insert(Arc::from(table)))
+            }
         }
-        Arc::clone(self.cache.get(&n).unwrap())
     }
 
     #[cfg(feature = "std")]

--- a/tests/twiddle.rs
+++ b/tests/twiddle.rs
@@ -1,28 +1,28 @@
-use kofft::{
-    fft::FftPlanner,
-    num::{Complex32, Complex64},
-};
+use kofft::fft::FftPlanner;
+#[cfg(feature = "precomputed-twiddles")]
+use kofft::num::{Complex32, Complex64};
 
 #[test]
-#[ignore]
-fn planner_twiddles_f32_f64() {
+fn twiddle_generation_and_cache() {
+    let mut planner = FftPlanner::<f32>::new();
+    // Use a non-precomputed size to force generation.
+    let t1 = planner.get_twiddles(10);
+    let ptr1 = t1.as_ptr();
+    let t2 = planner.get_twiddles(10);
+    assert_eq!(ptr1, t2.as_ptr());
+}
+
+#[cfg(feature = "precomputed-twiddles")]
+#[test]
+fn twiddle_precomputed_f32_f64() {
     let mut p32 = FftPlanner::<f32>::new();
     let t32 = p32.get_twiddles(8);
     let expected32 = Complex32::expi(-2.0 * std::f32::consts::PI / 8.0);
     assert!((t32[1].re - expected32.re).abs() < 1e-6);
     assert!((t32[1].im - expected32.im).abs() < 1e-6);
-    // Ensure cached reference is reused.
     let ptr1 = t32.as_ptr();
     let ptr2 = p32.get_twiddles(8).as_ptr();
     assert_eq!(ptr1, ptr2);
-
-    // Ensure Bluestein cache lengths are correct for non-power-of-two
-    #[cfg(feature = "std")]
-    {
-        let (chirp, fft_b) = p32.get_bluestein(5);
-        assert_eq!(chirp.len(), 5);
-        assert_eq!(fft_b.len(), 16);
-    }
 
     let mut p64 = FftPlanner::<f64>::new();
     let t64 = p64.get_twiddles(8);


### PR DESCRIPTION
## Summary
- replace unsafe `mem::transmute` with layout-checked `Arc` casts
- use `HashMap::entry` for twiddle cache and add debug logging
- cover twiddle generation and precomputed retrieval with tests

## Testing
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test`
- `cargo test --features precomputed-twiddles`
- `cargo tarpaulin --all-features --tests --run-types Tests --skip-clean` *(failed: command interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_68a4e1573428832bbf1e8212a8b29f4f