### PR TITLE
Guard ND FFT against dimension overflow

### DIFF
--- a/src/fft.rs
+++ b/src/fft.rs
@@ -448,6 +448,7 @@ pub enum FftError {
     EmptyInput,
     NonPowerOfTwoNoStd,
     MismatchedLengths,
+    Overflow,
     InvalidStride,
     InvalidHopSize,
     InvalidValue,

--- a/tests/ndfft_overflow.rs
+++ b/tests/ndfft_overflow.rs
@@ -1,0 +1,27 @@
+use kofft::fft::{Complex, FftError, ScalarFftImpl};
+use kofft::ndfft::{fft2d_inplace, fft3d_inplace, Fft3dScratch};
+
+#[test]
+fn fft2d_inplace_overflow() {
+    let mut data: Vec<Complex<f32>> = Vec::new();
+    let mut scratch: Vec<Complex<f32>> = Vec::new();
+    let fft = ScalarFftImpl::<f32>::default();
+    let res = fft2d_inplace(&mut data, usize::MAX, 2, &fft, &mut scratch);
+    assert_eq!(res, Err(FftError::Overflow));
+}
+
+#[test]
+fn fft3d_inplace_overflow() {
+    let mut data: Vec<Complex<f32>> = Vec::new();
+    let mut tube: Vec<Complex<f32>> = Vec::new();
+    let mut row: Vec<Complex<f32>> = Vec::new();
+    let mut col: Vec<Complex<f32>> = Vec::new();
+    let mut scratch = Fft3dScratch {
+        tube: &mut tube,
+        row: &mut row,
+        col: &mut col,
+    };
+    let fft = ScalarFftImpl::<f32>::default();
+    let res = fft3d_inplace(&mut data, usize::MAX, 2, 2, &fft, &mut scratch);
+    assert_eq!(res, Err(FftError::Overflow));
+}


### PR DESCRIPTION
## Summary
- add `Overflow` error variant
- use `checked_mul` in `fft2d_inplace` and `fft3d_inplace`
- test overflow handling for huge dimensions

## Testing
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test`
- `cargo tarpaulin --timeout 600`


------
https://chatgpt.com/codex/tasks/task_e_68a4e1669dfc832b9a5020114bd18df0