### PR TITLE
feat: add control section component with responsive transitions

### DIFF
--- a/react-spectrogram/src/components/__tests__/ControlSection.test.tsx
+++ b/react-spectrogram/src/components/__tests__/ControlSection.test.tsx
@@ -1,0 +1,87 @@
+import { render, screen, cleanup } from "@testing-library/react";
+import { describe, it, expect, afterEach } from "vitest";
+import ControlSection from "../common/ControlSection";
+
+describe("ControlSection", () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("applies 3:1 typography ratio in now playing mode", () => {
+    render(
+      <ControlSection
+        art="art.jpg"
+        title="Song"
+        artist="Artist"
+        album="Album"
+        mode="now"
+      />,
+    );
+    const container = screen.getByTestId("control-section");
+    const titleScale = Number(
+      container.style.getPropertyValue("--title-scale"),
+    );
+    const metaScale = Number(
+      container.style.getPropertyValue("--meta-scale"),
+    );
+    expect(titleScale / metaScale).toBe(3);
+  });
+
+  it("flips ratio and shows coming up text when mode changes", async () => {
+    const { rerender } = render(
+      <ControlSection
+        art="art.jpg"
+        title="Song"
+        artist="Artist"
+        album="Album"
+        mode="now"
+      />,
+    );
+    rerender(
+      <ControlSection
+        art="art.jpg"
+        title="Next Song"
+        artist="Next Artist"
+        album="Next Album"
+        mode="next"
+      />,
+    );
+    await new Promise((r) => setTimeout(r, 310));
+    await screen.findByTestId("song-title");
+    const container = screen.getByTestId("control-section");
+    const titleScale = Number(
+      container.style.getPropertyValue("--title-scale"),
+    );
+    const metaScale = Number(
+      container.style.getPropertyValue("--meta-scale"),
+    );
+    const meta = screen.getByTestId("song-meta");
+    expect(meta).toHaveTextContent("Coming Up Next");
+    expect(metaScale / titleScale).toBe(3);
+  });
+
+  it("uses quick fade when only text changes", async () => {
+    const { rerender } = render(
+      <ControlSection
+        art="art.jpg"
+        title="Song"
+        artist="Artist"
+        album="Album"
+        mode="now"
+      />,
+    );
+    rerender(
+      <ControlSection
+        art="art.jpg"
+        title="Song 2"
+        artist="Artist"
+        album="Album"
+        mode="now"
+      />,
+    );
+    const container = screen.getByTestId("control-section");
+    expect(container.style.getPropertyValue("--fade-duration")).toBe("200ms");
+    await new Promise((r) => setTimeout(r, 210));
+    await screen.findByText("Song 2");
+  });
+});

--- a/react-spectrogram/src/components/common/ControlSection.tsx
+++ b/react-spectrogram/src/components/common/ControlSection.tsx
@@ -1,0 +1,91 @@
+import React, { useEffect, useRef, useState } from "react";
+import clsx from "clsx";
+
+export interface ControlSectionProps {
+  /** URL for the square album art */
+  art: string;
+  /** Song title */
+  title: string;
+  /** Artist name */
+  artist: string;
+  /** Album name */
+  album: string;
+  /** Display mode */
+  mode: "now" | "next";
+}
+
+interface DisplayedText {
+  title: string;
+  artist: string;
+  album: string;
+  mode: "now" | "next";
+}
+
+/**
+ * ControlSection renders album art with song information and handles
+ * transitions between "Now Playing" and "Coming Up" states.
+ */
+export function ControlSection({
+  art,
+  title,
+  artist,
+  album,
+  mode,
+}: ControlSectionProps) {
+  const [displayed, setDisplayed] = useState<DisplayedText>({
+    title,
+    artist,
+    album,
+    mode,
+  });
+  const [fading, setFading] = useState(false);
+  const [fadeDuration, setFadeDuration] = useState(200);
+  const prevRef = useRef<DisplayedText>(displayed);
+
+  useEffect(() => {
+    const isStateChange = prevRef.current.mode !== mode;
+    const duration = isStateChange ? 300 : 200;
+    setFadeDuration(duration);
+    setFading(true);
+    const timeout = setTimeout(() => {
+      setDisplayed({ title, artist, album, mode });
+      setFading(false);
+      prevRef.current = { title, artist, album, mode };
+    }, duration);
+    return () => clearTimeout(timeout);
+  }, [title, artist, album, mode]);
+
+  const metaText =
+    displayed.mode === "now"
+      ? `${displayed.artist} • ${displayed.album}`
+      : "Coming Up Next";
+
+  return (
+    <div
+      className={clsx(
+        "control-section",
+        displayed.mode === "next" && "coming-up",
+        fading && "fading",
+      )}
+      style={{
+        ["--fade-duration" as any]: `${fadeDuration}ms`,
+        ["--title-scale" as any]: displayed.mode === "now" ? 3 : 1,
+        ["--meta-scale" as any]: displayed.mode === "now" ? 1 : 3,
+        ["--gap" as any]: displayed.mode === "now" ? "0.125rem" : "0.0625rem",
+      }}
+      data-testid="control-section"
+    >
+      <img src={art} alt="Album art" className="album-art" />
+      <div className="text-stack">
+        <div className="song-title" data-testid="song-title">
+          {displayed.title}
+        </div>
+        <div className="song-meta" data-testid="song-meta">
+          {metaText}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default ControlSection;

--- a/react-spectrogram/src/index.css
+++ b/react-spectrogram/src/index.css
@@ -550,3 +550,66 @@
     }
   }
 }
+/* Control section styles */
+.control-section {
+  display: flex;
+  gap: 0.25rem;
+  align-items: stretch;
+  --art-size: clamp(3rem, 20vw, 6rem);
+  --base-size: clamp(0.5rem, 2vw, 0.875rem);
+  --title-scale: 3;
+  --meta-scale: 1;
+  --gap: 0.125rem;
+  --transition: cubic-bezier(0.2, 0, 0, 1);
+}
+
+.control-section.coming-up {
+  --title-scale: 1;
+  --meta-scale: 3;
+  --gap: 0.0625rem;
+}
+
+.control-section .album-art {
+  width: var(--art-size);
+  height: var(--art-size);
+  object-fit: cover;
+  transition: transform 300ms var(--transition);
+}
+
+.control-section.coming-up .album-art {
+  transform: scale(1.05);
+}
+
+.control-section .text-stack {
+  display: flex;
+  flex-direction: column;
+  height: var(--art-size);
+}
+
+.control-section .song-title {
+  font-size: calc(var(--base-size) * var(--title-scale));
+  line-height: 1;
+  margin-bottom: var(--gap);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  transition: font-size 300ms var(--transition), line-height 300ms var(--transition),
+    letter-spacing 300ms var(--transition), transform 300ms var(--transition);
+}
+
+.control-section .song-meta {
+  font-size: calc(var(--base-size) * var(--meta-scale));
+  line-height: 1;
+  margin-top: auto;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  transition: font-size 300ms var(--transition), line-height 300ms var(--transition),
+    letter-spacing 300ms var(--transition), transform 300ms var(--transition);
+}
+
+.control-section.fading .song-title,
+.control-section.fading .song-meta {
+  opacity: 0;
+  transition: opacity var(--fade-duration) var(--transition);
+}


### PR DESCRIPTION
## Summary
- add ControlSection component for album art and track details
- style control section with responsive typography and transitions
- cover component with tests

## Testing
- `npm test src/components/__tests__/ControlSection.test.tsx`
- `npm run test:coverage src/components/__tests__/ControlSection.test.tsx`
- `npm run lint:fix` *(fails: ESLint couldn't find a configuration file)*
- `npm test` *(fails: TypeError: loadFromStorage is not a function)*

------
https://chatgpt.com/codex/tasks/task_e_68a4ef5dfa38832b96ee99293387c93f