### PR TITLE
chore: lengthen marquee duration

### DIFF
--- a/react-spectrogram/src/config.ts
+++ b/react-spectrogram/src/config.ts
@@ -1,7 +1,7 @@
 export const TITLE_FONT_STEP = 0.125; // rem
 export const INFO_MAX_CH = 36; // characters for max width
 export const MARQUEE_DELAY_MS = 1500; // ms
-export const MARQUEE_DURATION_MULTIPLIER = 5; // seconds
+export const MARQUEE_DURATION_MULTIPLIER = 8; // seconds
 export const MARQUEE_MIN_DURATION = 5; // seconds
 export const NEXT_WINDOW_SEC = 7; // seconds
 export const SIZE_SWAP_DURATION_MS = 300; // ms

--- a/react-spectrogram/src/hooks/__tests__/useMarquee.test.tsx
+++ b/react-spectrogram/src/hooks/__tests__/useMarquee.test.tsx
@@ -1,7 +1,11 @@
 import { describe, it, expect, vi } from "vitest";
 import { render, screen, act } from "@testing-library/react";
 import { MarqueeText } from "@/components/common/MarqueeText";
-import { MARQUEE_DELAY_MS } from "@/config";
+import {
+  MARQUEE_DELAY_MS,
+  MARQUEE_DURATION_MULTIPLIER,
+  MARQUEE_MIN_DURATION,
+} from "@/config";
 
 vi.useFakeTimers();
 
@@ -14,11 +18,24 @@ describe("useMarquee", () => {
     );
     const span = screen.getByText(/Long text/);
     const container = span.parentElement as HTMLElement;
-    Object.defineProperty(container, "clientWidth", { value: 100, configurable: true });
-    Object.defineProperty(span, "scrollWidth", { value: 300, configurable: true });
+    Object.defineProperty(container, "clientWidth", {
+      value: 100,
+      configurable: true,
+    });
+    Object.defineProperty(span, "scrollWidth", {
+      value: 300,
+      configurable: true,
+    });
     act(() => {
       window.dispatchEvent(new Event("resize"));
     });
+    const expectedDuration = Math.max(
+      (300 / 100) * MARQUEE_DURATION_MULTIPLIER,
+      MARQUEE_MIN_DURATION,
+    );
+    expect(span.style.getPropertyValue("--marquee-duration")).toBe(
+      `${expectedDuration}s`,
+    );
     expect(span.classList.contains("marquee-active")).toBe(false);
     vi.advanceTimersByTime(MARQUEE_DELAY_MS + 100);
     expect(span.classList.contains("marquee-active")).toBe(true);


### PR DESCRIPTION
## Summary
- increase marquee animation length
- test marquee duration calculation

## Testing
- `npx prettier react-spectrogram/src/config.ts react-spectrogram/src/hooks/__tests__/useMarquee.test.tsx --write`
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*
- `npm run test:coverage` *(fails: 20 failed, 4 passed, 19 skipped)*

------
https://chatgpt.com/codex/tasks/task_e_68a4fabb7a20832bac2d528ce5a08b17