### PR TITLE
feat: animate album art transition

### DIFF
--- a/react-spectrogram/src/components/__tests__/ControlSection.test.tsx
+++ b/react-spectrogram/src/components/__tests__/ControlSection.test.tsx
@@ -21,9 +21,7 @@ describe("ControlSection", () => {
     const titleScale = Number(
       container.style.getPropertyValue("--title-scale"),
     );
-    const metaScale = Number(
-      container.style.getPropertyValue("--meta-scale"),
-    );
+    const metaScale = Number(container.style.getPropertyValue("--meta-scale"));
     expect(titleScale / metaScale).toBe(3);
   });
 
@@ -52,9 +50,7 @@ describe("ControlSection", () => {
     const titleScale = Number(
       container.style.getPropertyValue("--title-scale"),
     );
-    const metaScale = Number(
-      container.style.getPropertyValue("--meta-scale"),
-    );
+    const metaScale = Number(container.style.getPropertyValue("--meta-scale"));
     const meta = screen.getByTestId("song-meta");
     expect(meta).toHaveTextContent("Coming Up Next");
     expect(metaScale / titleScale).toBe(3);
@@ -83,5 +79,36 @@ describe("ControlSection", () => {
     expect(container.style.getPropertyValue("--fade-duration")).toBe("200ms");
     await new Promise((r) => setTimeout(r, 210));
     await screen.findByText("Song 2");
+  });
+
+  it("animates album art when switching to next with a new album", async () => {
+    const { rerender } = render(
+      <ControlSection
+        art="art1.jpg"
+        title="Song"
+        artist="Artist"
+        album="Album1"
+        mode="now"
+      />,
+    );
+    rerender(
+      <ControlSection
+        art="art2.jpg"
+        title="Song2"
+        artist="Artist2"
+        album="Album2"
+        mode="next"
+      />,
+    );
+    const stack = screen
+      .getByTestId("control-section")
+      .querySelector(".art-stack");
+    expect(stack?.children.length).toBe(2);
+    const next = screen.getByTestId("next-art");
+    expect(next.className).toContain("animating");
+    await new Promise((r) => setTimeout(r, 310));
+    expect(screen.queryByTestId("next-art")).toBeNull();
+    const current = screen.getByTestId("current-art");
+    expect(current).toHaveAttribute("src", "art2.jpg");
   });
 });

--- a/react-spectrogram/src/components/common/ControlSection.tsx
+++ b/react-spectrogram/src/components/common/ControlSection.tsx
@@ -41,6 +41,10 @@ export function ControlSection({
   const [fading, setFading] = useState(false);
   const [fadeDuration, setFadeDuration] = useState(200);
   const prevRef = useRef<DisplayedText>(displayed);
+  const [currentArt, setCurrentArt] = useState(art);
+  const [nextArt, setNextArt] = useState<string | null>(null);
+  const [artAnimating, setArtAnimating] = useState(false);
+  const prevArtRef = useRef({ album, mode });
 
   useEffect(() => {
     const isStateChange = prevRef.current.mode !== mode;
@@ -54,6 +58,25 @@ export function ControlSection({
     }, duration);
     return () => clearTimeout(timeout);
   }, [title, artist, album, mode]);
+
+  useEffect(() => {
+    const prev = prevArtRef.current;
+    const modeSwitchedToNext = prev.mode !== "next" && mode === "next";
+    const albumChanged = prev.album !== album;
+    if (modeSwitchedToNext && albumChanged) {
+      setNextArt(art);
+      setArtAnimating(true);
+      const timeout = setTimeout(() => {
+        setCurrentArt(art);
+        setNextArt(null);
+        setArtAnimating(false);
+      }, 300);
+      prevArtRef.current = { album, mode };
+      return () => clearTimeout(timeout);
+    }
+    setCurrentArt(art);
+    prevArtRef.current = { album, mode };
+  }, [art, album, mode]);
 
   const metaText =
     displayed.mode === "now"
@@ -75,7 +98,22 @@ export function ControlSection({
       }}
       data-testid="control-section"
     >
-      <img src={art} alt="Album art" className="album-art" />
+      <div className="art-stack">
+        <img
+          src={currentArt}
+          alt="Album art"
+          className="album-art current"
+          data-testid="current-art"
+        />
+        {nextArt && (
+          <img
+            src={nextArt}
+            alt="Next album art"
+            className={clsx("album-art next", artAnimating && "animating")}
+            data-testid="next-art"
+          />
+        )}
+      </div>
       <div className="text-stack">
         <div className="song-title" data-testid="song-title">
           {displayed.title}

--- a/react-spectrogram/src/index.css
+++ b/react-spectrogram/src/index.css
@@ -4,38 +4,46 @@
 
 :root {
   /* Seekbar theme variables */
-  --seek-played: rgb(59, 130, 246);      /* blue-500 */
-  --seek-unplayed: rgb(107, 114, 128);  /* gray-500 - brighter for better visibility */
+  --seek-played: rgb(59, 130, 246); /* blue-500 */
+  --seek-unplayed: rgb(
+    107,
+    114,
+    128
+  ); /* gray-500 - brighter for better visibility */
   --seek-buffered: rgba(59, 130, 246, 0.6); /* blue-500 with more opacity */
-  --seek-focus: rgb(59, 130, 246);      /* blue-500 */
+  --seek-focus: rgb(59, 130, 246); /* blue-500 */
   --seek-disabled: rgba(156, 163, 175, 0.4); /* gray-400 with more opacity */
-  --seek-hover-played: rgb(96, 165, 250);    /* blue-400 */
+  --seek-hover-played: rgb(96, 165, 250); /* blue-400 */
   --seek-hover-unplayed: rgb(156, 163, 175); /* gray-400 - brighter on hover */
-  --seek-time-label: rgb(156, 163, 175);     /* gray-400 */
+  --seek-time-label: rgb(156, 163, 175); /* gray-400 */
 }
 
 /* Dark theme overrides */
 .dark {
-  --seek-played: rgb(59, 130, 246);      /* blue-500 */
-  --seek-unplayed: rgb(107, 114, 128);  /* gray-500 - brighter for better visibility */
+  --seek-played: rgb(59, 130, 246); /* blue-500 */
+  --seek-unplayed: rgb(
+    107,
+    114,
+    128
+  ); /* gray-500 - brighter for better visibility */
   --seek-buffered: rgba(59, 130, 246, 0.6); /* blue-500 with more opacity */
-  --seek-focus: rgb(59, 130, 246);      /* blue-500 */
+  --seek-focus: rgb(59, 130, 246); /* blue-500 */
   --seek-disabled: rgba(156, 163, 175, 0.4); /* gray-400 with more opacity */
-  --seek-hover-played: rgb(96, 165, 250);    /* blue-400 */
+  --seek-hover-played: rgb(96, 165, 250); /* blue-400 */
   --seek-hover-unplayed: rgb(156, 163, 175); /* gray-400 - brighter on hover */
-  --seek-time-label: rgb(156, 163, 175);     /* gray-400 */
+  --seek-time-label: rgb(156, 163, 175); /* gray-400 */
 }
 
 /* Light theme overrides */
 .light {
-  --seek-played: rgb(37, 99, 235);      /* blue-600 */
-  --seek-unplayed: rgb(156, 163, 175);  /* gray-400 */
+  --seek-played: rgb(37, 99, 235); /* blue-600 */
+  --seek-unplayed: rgb(156, 163, 175); /* gray-400 */
   --seek-buffered: rgba(37, 99, 235, 0.5); /* blue-600 with opacity */
-  --seek-focus: rgb(37, 99, 235);      /* blue-600 */
+  --seek-focus: rgb(37, 99, 235); /* blue-600 */
   --seek-disabled: rgba(156, 163, 175, 0.3); /* gray-400 with opacity */
-  --seek-hover-played: rgb(59, 130, 246);    /* blue-500 */
+  --seek-hover-played: rgb(59, 130, 246); /* blue-500 */
   --seek-hover-unplayed: rgb(107, 114, 128); /* gray-500 */
-  --seek-time-label: rgb(107, 114, 128);     /* gray-500 */
+  --seek-time-label: rgb(107, 114, 128); /* gray-500 */
 }
 
 /* Custom scrollbar styles */
@@ -80,12 +88,14 @@
   * {
     @apply border-neutral-800;
   }
-  
+
   body {
     @apply bg-neutral-950 text-neutral-100 font-sans;
-    font-feature-settings: "rlig" 1, "calt" 1;
+    font-feature-settings:
+      "rlig" 1,
+      "calt" 1;
   }
-  
+
   html {
     @apply antialiased;
   }
@@ -96,26 +106,26 @@
   .app-layout {
     @apply min-h-screen flex flex-col overflow-hidden;
   }
-  
+
   .main-content {
     @apply flex-1 flex relative overflow-hidden;
   }
-  
+
   .sidebar-left {
     @apply bg-neutral-900 border-r border-neutral-800 flex-shrink-0;
     @apply transition-all duration-300 ease-in-out;
   }
-  
+
   .sidebar-right {
     @apply bg-neutral-900 border-l border-neutral-800 flex-shrink-0;
     @apply transition-all duration-300 ease-in-out;
   }
-  
+
   .content-area {
     @apply flex-1 flex flex-col relative overflow-hidden;
     @apply transition-all duration-300 ease-in-out;
   }
-  
+
   .footer-controls {
     @apply bg-neutral-900 border-t border-neutral-800 flex-shrink-0;
     @apply flex flex-col relative z-50;
@@ -206,11 +216,11 @@
   .mobile-layout {
     @apply flex-col;
   }
-  
+
   .tablet-layout {
     @apply flex-row;
   }
-  
+
   .desktop-layout {
     @apply flex-row;
   }
@@ -220,20 +230,20 @@
     .app-layout {
       @apply h-screen;
     }
-    
+
     .main-content {
       @apply flex-col;
     }
-    
+
     .sidebar-left,
     .sidebar-right {
       @apply hidden;
     }
-    
+
     .content-area {
       @apply flex-1;
     }
-    
+
     .footer-controls {
       @apply min-h-[4rem];
     }
@@ -245,11 +255,11 @@
     .sidebar-right {
       @apply absolute top-0 h-full z-20 shadow-2xl;
     }
-    
+
     .sidebar-left {
       @apply left-0;
     }
-    
+
     .sidebar-right {
       @apply right-0;
     }
@@ -266,80 +276,80 @@
   /* Custom scrollbar styles */
   .scrollbar-thin {
     scrollbar-width: thin;
-    scrollbar-color: theme('colors.neutral.600') theme('colors.neutral.800');
+    scrollbar-color: theme("colors.neutral.600") theme("colors.neutral.800");
   }
-  
+
   .scrollbar-thin::-webkit-scrollbar {
     width: 6px;
   }
-  
+
   .scrollbar-thin::-webkit-scrollbar-track {
     @apply bg-neutral-800;
   }
-  
+
   .scrollbar-thin::-webkit-scrollbar-thumb {
     @apply bg-neutral-600 rounded-full;
   }
-  
+
   .scrollbar-thin::-webkit-scrollbar-thumb:hover {
     @apply bg-neutral-500;
   }
-  
+
   /* Focus styles */
   .focus-ring {
     @apply focus:outline-none focus:ring-2 focus:ring-accent-blue focus:ring-offset-2 focus:ring-offset-neutral-950;
   }
-  
+
   /* Button base styles */
   .btn-base {
     @apply inline-flex items-center justify-center rounded-md text-sm font-medium transition-colors focus-ring disabled:pointer-events-none disabled:opacity-50;
   }
-  
+
   .btn-primary {
     @apply btn-base bg-accent-blue text-white hover:bg-accent-blue/90;
   }
-  
+
   .btn-secondary {
     @apply btn-base bg-neutral-800 text-neutral-100 hover:bg-neutral-700;
   }
-  
+
   .btn-ghost {
     @apply btn-base hover:bg-neutral-800 hover:text-neutral-100;
   }
-  
+
   /* Icon button styles */
   .icon-btn {
     @apply inline-flex items-center justify-center rounded-md p-2 text-neutral-400 transition-colors hover:text-neutral-100 hover:bg-neutral-800 focus-ring;
   }
-  
+
   .icon-btn.active {
     @apply text-accent-blue bg-neutral-800;
   }
-  
+
   /* Panel styles */
   .panel {
     @apply bg-neutral-900 border border-neutral-800 rounded-lg shadow-medium;
   }
-  
+
   /* Sidebar styles */
   .sidebar {
     @apply bg-neutral-900 border-r border-neutral-800 transition-all duration-300 ease-in-out;
   }
-  
+
   /* Spectrogram canvas styles */
   .spectrogram-canvas {
     @apply rounded-lg bg-neutral-950 border border-neutral-800;
   }
-  
+
   /* Waveform styles */
   .waveform-bar {
     @apply bg-neutral-600 rounded-sm transition-all duration-150;
   }
-  
+
   .waveform-bar.played {
     @apply bg-accent-blue;
   }
-  
+
   .waveform-bar.current {
     @apply bg-accent-teal;
   }
@@ -349,11 +359,11 @@
     @apply relative bg-neutral-800/30 rounded-lg border border-neutral-700/50;
     @apply transition-all duration-200;
   }
-  
+
   .waveform-seekbar:hover {
     @apply bg-neutral-800/50 border-neutral-600/50;
   }
-  
+
   .waveform-seekbar:focus-within {
     @apply border-blue-400/50 ring-2 ring-blue-400/20;
   }
@@ -362,11 +372,11 @@
   .slider-thumb {
     @apply appearance-none w-4 h-4 bg-neutral-300 rounded-full cursor-pointer border-0;
   }
-  
+
   .slider-thumb:hover {
     @apply bg-neutral-200;
   }
-  
+
   .slider-thumb:focus {
     @apply outline-none ring-2 ring-accent-blue ring-offset-2 ring-offset-neutral-950;
   }
@@ -375,15 +385,15 @@
   .animate-slide-in {
     animation: slideIn 0.3s ease-in-out;
   }
-  
+
   .animate-fade-in {
     animation: fadeIn 0.3s ease-in-out;
   }
-  
+
   .animate-scale-in {
     animation: scaleIn 0.15s ease-in-out;
   }
-  
+
   .animate-pulse-subtle {
     animation: pulseSubtle 2s ease-in-out infinite;
   }
@@ -411,26 +421,26 @@
     padding-top: 0;
     padding-bottom: 0;
   }
-  
+
   /* Text truncation */
   .text-truncate {
     @apply overflow-hidden text-ellipsis whitespace-nowrap;
   }
-  
+
   /* Aspect ratio utilities */
   .aspect-square {
     aspect-ratio: 1 / 1;
   }
-  
+
   .aspect-video {
     aspect-ratio: 16 / 9;
   }
-  
+
   /* Glass effect */
   .glass {
     @apply bg-white/10 backdrop-blur-md border border-white/20;
   }
-  
+
   /* Gradient text */
   .gradient-text {
     @apply bg-gradient-to-r from-accent-blue to-accent-teal bg-clip-text text-transparent;
@@ -447,7 +457,7 @@
       opacity: 1;
     }
   }
-  
+
   @keyframes slideInFromBottom {
     from {
       transform: translateY(100%);
@@ -458,7 +468,7 @@
       opacity: 1;
     }
   }
-  
+
   @keyframes fadeIn {
     from {
       opacity: 0;
@@ -467,7 +477,7 @@
       opacity: 1;
     }
   }
-  
+
   @keyframes scaleIn {
     from {
       transform: scale(0.95);
@@ -478,9 +488,10 @@
       opacity: 1;
     }
   }
-  
+
   @keyframes pulseSubtle {
-    0%, 100% {
+    0%,
+    100% {
       opacity: 1;
     }
     50% {
@@ -489,10 +500,15 @@
   }
 
   @keyframes bounce {
-    0%, 20%, 53%, 80%, 100% {
+    0%,
+    20%,
+    53%,
+    80%,
+    100% {
       transform: translate3d(0, 0, 0);
     }
-    40%, 43% {
+    40%,
+    43% {
       transform: translate3d(0, -8px, 0);
     }
     70% {
@@ -518,12 +534,12 @@
     .icon-btn {
       @apply min-w-[44px] min-h-[44px];
     }
-    
+
     /* Improve slider touch targets */
     input[type="range"] {
       @apply h-3;
     }
-    
+
     /* Better focus indicators for touch */
     .focus-ring {
       @apply focus:ring-4 focus:ring-accent-blue/50;
@@ -535,7 +551,7 @@
     .btn-primary {
       @apply border-2 border-current;
     }
-    
+
     .icon-btn {
       @apply border border-transparent hover:border-current;
     }
@@ -569,15 +585,38 @@
   --gap: 0.0625rem;
 }
 
-.control-section .album-art {
+.control-section .art-stack {
+  position: relative;
   width: var(--art-size);
   height: var(--art-size);
+}
+
+.control-section .art-stack .album-art {
+  width: 100%;
+  height: 100%;
   object-fit: cover;
+  position: absolute;
+  top: 0;
+  left: 0;
   transition: transform 300ms var(--transition);
 }
 
-.control-section.coming-up .album-art {
+.control-section.coming-up .art-stack .album-art.current {
   transform: scale(1.05);
+}
+
+.control-section .art-stack .album-art.next {
+  transform: rotate(-45deg) scale(0.8) translate(-20%, 20%);
+}
+
+.control-section .art-stack .album-art.next.animating {
+  animation: albumArtSlideForward 300ms var(--transition) forwards;
+}
+
+@keyframes albumArtSlideForward {
+  to {
+    transform: rotate(0deg) scale(1) translate(0, 0);
+  }
 }
 
 .control-section .text-stack {
@@ -593,8 +632,11 @@
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
-  transition: font-size 300ms var(--transition), line-height 300ms var(--transition),
-    letter-spacing 300ms var(--transition), transform 300ms var(--transition);
+  transition:
+    font-size 300ms var(--transition),
+    line-height 300ms var(--transition),
+    letter-spacing 300ms var(--transition),
+    transform 300ms var(--transition);
 }
 
 .control-section .song-meta {
@@ -604,8 +646,11 @@
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
-  transition: font-size 300ms var(--transition), line-height 300ms var(--transition),
-    letter-spacing 300ms var(--transition), transform 300ms var(--transition);
+  transition:
+    font-size 300ms var(--transition),
+    line-height 300ms var(--transition),
+    letter-spacing 300ms var(--transition),
+    transform 300ms var(--transition);
 }
 
 .control-section.fading .song-title,


### PR DESCRIPTION
## Summary
- animate album art transition when switching to next track
- add CSS keyframes for sliding/rotating album art
- test transition stack and class changes

## Testing
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*
- `npm test src/components/__tests__/ControlSection.test.tsx`
- `npx vitest run --coverage src/components/__tests__/ControlSection.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68a4fac0bf58832b8db66584b476d258