### PR TITLE
Enable metadata-driven playlist search

### DIFF
--- a/react-spectrogram/src/components/__tests__/MetadataPanelSearch.test.tsx
+++ b/react-spectrogram/src/components/__tests__/MetadataPanelSearch.test.tsx
@@ -1,0 +1,74 @@
+import { render, screen, fireEvent } from '@testing-library/react'
+import { vi } from 'vitest'
+import { MetadataPanel } from '../layout/MetadataPanel'
+import { PlaylistPanel } from '../layout/PlaylistPanel'
+import { AudioTrack } from '@/types'
+import { usePlaylistSearchStore } from '@/stores/playlistSearchStore'
+
+vi.mock('@/utils/wasm', () => ({}), { virtual: true })
+vi.mock('@/hooks/useAudioFile', () => ({
+  useAudioFile: () => ({
+    loadAudioFiles: vi.fn(),
+  }),
+}))
+
+const tracks: AudioTrack[] = [
+  {
+    id: '1',
+    file: new File(['test'], 'alpha.mp3', { type: 'audio/mp3' }),
+    metadata: {
+      title: 'Alpha Song',
+      artist: 'Artist1',
+      album: 'Album1',
+      genre: 'Rock',
+      year: 2000,
+    },
+    duration: 180,
+    url: 'url1',
+  },
+  {
+    id: '2',
+    file: new File(['test'], 'beta.mp3', { type: 'audio/mp3' }),
+    metadata: {
+      title: 'Beta Song',
+      artist: 'Artist2',
+      album: 'Album2',
+      genre: 'Pop',
+      year: 2001,
+    },
+    duration: 200,
+    url: 'url2',
+  },
+]
+
+describe('MetadataPanel search links', () => {
+  beforeEach(() => {
+    usePlaylistSearchStore.setState({ searchQuery: '' })
+  })
+
+  it('sets search query when metadata value clicked', () => {
+    render(
+      <>
+        <MetadataPanel track={tracks[0]} isOpen={true} onClose={() => {}} />
+        <PlaylistPanel
+          tracks={tracks}
+          currentTrackIndex={-1}
+          isOpen={true}
+          onClose={() => {}}
+          onTrackSelect={() => {}}
+          onTrackRemove={() => {}}
+          onTrackReorder={() => {}}
+        />
+      </>
+    )
+
+    fireEvent.click(screen.getByText('Artist1'))
+    const input = screen.getByTestId('playlist-search-input') as HTMLInputElement
+    expect(input.value).toBe('Artist1')
+    expect(screen.getByText('Alpha Song')).toBeInTheDocument()
+    expect(screen.queryByText('Beta Song')).toBeNull()
+
+    fireEvent.change(input, { target: { value: '' } })
+    expect(screen.getByText('Beta Song')).toBeInTheDocument()
+  })
+})

--- a/react-spectrogram/src/components/__tests__/PlaylistSearch.test.tsx
+++ b/react-spectrogram/src/components/__tests__/PlaylistSearch.test.tsx
@@ -1,6 +1,7 @@
 import { render, screen, fireEvent } from '@testing-library/react'
 import { AudioTrack } from '@/types'
 import { vi } from 'vitest'
+import { usePlaylistSearchStore } from '@/stores/playlistSearchStore'
 
 vi.mock('@/utils/wasm', () => ({}), { virtual: true })
 
@@ -54,6 +55,10 @@ describe('PlaylistPanel search', () => {
       url: 'url3'
     }
   ]
+
+  afterEach(() => {
+    usePlaylistSearchStore.setState({ searchQuery: '' })
+  })
 
   it('filters tracks and provides suggestions', () => {
     render(

--- a/react-spectrogram/src/components/layout/MetadataPanel.tsx
+++ b/react-spectrogram/src/components/layout/MetadataPanel.tsx
@@ -1,6 +1,8 @@
 import { X, Music, User, Disc, Calendar, FileAudio } from 'lucide-react'
 import { AudioTrack } from '@/types'
 import { formatDuration, formatFileSize } from '@/utils/audio'
+import { useUIStore } from '@/stores/uiStore'
+import { usePlaylistSearchStore } from '@/stores/playlistSearchStore'
 
 // Helper function to format sample rate in kHz
 const formatSampleRate = (sampleRate: number): string => {
@@ -15,6 +17,14 @@ interface MetadataPanelProps {
 
 export function MetadataPanel({ track, isOpen, onClose }: MetadataPanelProps) {
   if (!isOpen) return null
+
+  const { setPlaylistPanelOpen } = useUIStore()
+  const { setSearchQuery } = usePlaylistSearchStore()
+
+  const handleMetadataSearch = (value: string) => {
+    setSearchQuery(value)
+    setPlaylistPanelOpen(true)
+  }
 
   const renderFallbackAlbumArt = () => (
     <div className="w-full h-48 bg-neutral-800 rounded-lg flex items-center justify-center">
@@ -120,7 +130,13 @@ export function MetadataPanel({ track, isOpen, onClose }: MetadataPanelProps) {
                   <User size={14} className="text-neutral-400 flex-shrink-0" />
                   <div className="min-w-0 flex-1">
                     <p className="text-xs text-neutral-400">Artist</p>
-                    <p className="text-sm text-neutral-100 truncate">{track.metadata.artist}</p>
+                    <button
+                      type="button"
+                      onClick={() => handleMetadataSearch(track.metadata.artist as string)}
+                      className="text-sm text-neutral-100 truncate bg-transparent p-0 text-left"
+                    >
+                      {track.metadata.artist}
+                    </button>
                   </div>
                 </div>
               )}
@@ -131,7 +147,13 @@ export function MetadataPanel({ track, isOpen, onClose }: MetadataPanelProps) {
                   <Disc size={14} className="text-neutral-400 flex-shrink-0" />
                   <div className="min-w-0 flex-1">
                     <p className="text-xs text-neutral-400">Album</p>
-                    <p className="text-sm text-neutral-100 truncate">{track.metadata.album}</p>
+                    <button
+                      type="button"
+                      onClick={() => handleMetadataSearch(track.metadata.album as string)}
+                      className="text-sm text-neutral-100 truncate bg-transparent p-0 text-left"
+                    >
+                      {track.metadata.album}
+                    </button>
                   </div>
                 </div>
               )}
@@ -142,7 +164,13 @@ export function MetadataPanel({ track, isOpen, onClose }: MetadataPanelProps) {
                   <Calendar size={14} className="text-neutral-400 flex-shrink-0" />
                   <div className="min-w-0 flex-1">
                     <p className="text-xs text-neutral-400">Year</p>
-                    <p className="text-sm text-neutral-100">{track.metadata.year}</p>
+                    <button
+                      type="button"
+                      onClick={() => handleMetadataSearch(String(track.metadata.year))}
+                      className="text-sm text-neutral-100 truncate bg-transparent p-0 text-left"
+                    >
+                      {track.metadata.year}
+                    </button>
                   </div>
                 </div>
               )}
@@ -153,7 +181,13 @@ export function MetadataPanel({ track, isOpen, onClose }: MetadataPanelProps) {
                   <Music size={14} className="text-neutral-400 flex-shrink-0" />
                   <div className="min-w-0 flex-1">
                     <p className="text-xs text-neutral-400">Genre</p>
-                    <p className="text-sm text-neutral-100 truncate">{track.metadata.genre}</p>
+                    <button
+                      type="button"
+                      onClick={() => handleMetadataSearch(track.metadata.genre as string)}
+                      className="text-sm text-neutral-100 truncate bg-transparent p-0 text-left"
+                    >
+                      {track.metadata.genre}
+                    </button>
                   </div>
                 </div>
               )}

--- a/react-spectrogram/src/components/layout/PlaylistPanel.tsx
+++ b/react-spectrogram/src/components/layout/PlaylistPanel.tsx
@@ -6,6 +6,7 @@ import { formatDuration } from '@/utils/audio'
 import { useAudioFile } from '@/hooks/useAudioFile'
 import { getFilesFromDataTransfer } from '@/utils/file'
 import { fuzzyMatch, fuzzyScore } from '@/utils/fuzzy'
+import { usePlaylistSearchStore } from '@/stores/playlistSearchStore'
 
 interface PlaylistPanelProps {
   tracks: AudioTrack[]
@@ -410,7 +411,7 @@ export function PlaylistPanel({
     setDropIndex(null)
   }
 
-  const [searchQuery, setSearchQuery] = useState('')
+  const { searchQuery, setSearchQuery } = usePlaylistSearchStore()
 
   const searchIndex = useMemo(
     () =>

--- a/react-spectrogram/src/stores/playlistSearchStore.ts
+++ b/react-spectrogram/src/stores/playlistSearchStore.ts
@@ -1,0 +1,11 @@
+import { create } from 'zustand'
+
+interface PlaylistSearchState {
+  searchQuery: string
+  setSearchQuery: (query: string) => void
+}
+
+export const usePlaylistSearchStore = create<PlaylistSearchState>((set) => ({
+  searchQuery: '',
+  setSearchQuery: (searchQuery) => set({ searchQuery })
+}))


### PR DESCRIPTION
## Summary
- allow clicking artist/album/genre/year in metadata panel to search playlist
- centralize playlist search query in zustand store
- cover clickable metadata search with tests

## Testing
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*
- `npm run test:coverage` *(fails: loadFromStorage is not a function)*

------
https://chatgpt.com/codex/tasks/task_e_68a4f967d35c832bb9903f0bb0d0e244