### PR TITLE
feat: auto advance to next track

### DIFF
--- a/react-spectrogram/src/utils/PlaybackEngine.ts
+++ b/react-spectrogram/src/utils/PlaybackEngine.ts
@@ -1,48 +1,49 @@
-import type { AudioTrack } from '@/types'
+import type { AudioTrack } from "@/types";
+import { useAudioStore } from "@/stores/audioStore";
 
 interface PlaybackState {
-  isPlaying: boolean
-  isPaused: boolean
-  isStopped: boolean
-  currentTime: number
-  duration: number
-  volume: number
-  isMuted: boolean
+  isPlaying: boolean;
+  isPaused: boolean;
+  isStopped: boolean;
+  currentTime: number;
+  duration: number;
+  volume: number;
+  isMuted: boolean;
 }
 
-type PlaybackCallback = (state: PlaybackState) => void
+type PlaybackCallback = (state: PlaybackState) => void;
 
 class PlaybackEngine {
-  private static instance: PlaybackEngine | null = null
+  private static instance: PlaybackEngine | null = null;
 
-  private audioContext: AudioContext | null = null
-  private gainNode: GainNode | null = null
-  private analyser: AnalyserNode | null = null
-  private source: AudioBufferSourceNode | null = null
-  private micSource: MediaStreamAudioSourceNode | null = null
-  private currentBuffer: AudioBuffer | null = null
-  private startTime = 0
-  private pausedAt = 0
-  private isPaused = false
-  private callbacks: Set<PlaybackCallback> = new Set()
-  private currentTime = 0
-  private animationFrameId: number | null = null
+  private audioContext: AudioContext | null = null;
+  private gainNode: GainNode | null = null;
+  private analyser: AnalyserNode | null = null;
+  private source: AudioBufferSourceNode | null = null;
+  private micSource: MediaStreamAudioSourceNode | null = null;
+  private currentBuffer: AudioBuffer | null = null;
+  private startTime = 0;
+  private pausedAt = 0;
+  private isPaused = false;
+  private callbacks: Set<PlaybackCallback> = new Set();
+  private currentTime = 0;
+  private animationFrameId: number | null = null;
 
-  private playRequestId = 0
-  private loadController: AbortController | null = null
+  private playRequestId = 0;
+  private loadController: AbortController | null = null;
 
   private constructor() {}
 
   static getInstance(): PlaybackEngine {
     if (!PlaybackEngine.instance) {
-      PlaybackEngine.instance = new PlaybackEngine()
+      PlaybackEngine.instance = new PlaybackEngine();
     }
-    return PlaybackEngine.instance
+    return PlaybackEngine.instance;
   }
 
   subscribe(cb: PlaybackCallback): () => void {
-    this.callbacks.add(cb)
-    return () => this.callbacks.delete(cb)
+    this.callbacks.add(cb);
+    return () => this.callbacks.delete(cb);
   }
 
   private notify() {
@@ -53,282 +54,327 @@ class PlaybackEngine {
       currentTime: this.getCurrentTime(),
       duration: this.getDuration(),
       volume: this.getVolume(),
-      isMuted: this.isMuted()
-    }
-    this.callbacks.forEach(cb => cb(state))
+      isMuted: this.isMuted(),
+    };
+    this.callbacks.forEach((cb) => cb(state));
   }
 
   private async initContext(): Promise<AudioContext> {
     if (!this.audioContext) {
-      const Ctx = window.AudioContext || (window as any).webkitAudioContext
-      this.audioContext = new Ctx()
-      this.gainNode = this.audioContext.createGain()
-      this.analyser = this.audioContext.createAnalyser()
-      this.analyser.fftSize = 2048
-      this.gainNode.connect(this.analyser)
-      this.analyser.connect(this.audioContext.destination)
-      this.gainNode.gain.value = 1
+      const Ctx = window.AudioContext || (window as any).webkitAudioContext;
+      this.audioContext = new Ctx();
+      this.gainNode = this.audioContext.createGain();
+      this.analyser = this.audioContext.createAnalyser();
+      this.analyser.fftSize = 2048;
+      this.gainNode.connect(this.analyser);
+      this.analyser.connect(this.audioContext.destination);
+      this.gainNode.gain.value = 1;
     }
-    if (this.audioContext.state === 'suspended') {
-      await this.audioContext.resume()
+    if (this.audioContext.state === "suspended") {
+      await this.audioContext.resume();
     }
-    return this.audioContext
+    return this.audioContext;
   }
 
   async initializeAudioContext(): Promise<AudioContext> {
-    return this.initContext()
+    return this.initContext();
   }
 
-  private async abortable<T>(promise: Promise<T>, controller: AbortController): Promise<T> {
+  private async abortable<T>(
+    promise: Promise<T>,
+    controller: AbortController,
+  ): Promise<T> {
     return await new Promise<T>((resolve, reject) => {
-      let finished = false
+      let finished = false;
       const onAbort = () => {
-        if (finished) return
-        finished = true
-        controller.signal.onabort = null
-        reject(new DOMException('Aborted', 'AbortError'))
-      }
-      controller.signal.onabort = onAbort
+        if (finished) return;
+        finished = true;
+        controller.signal.onabort = null;
+        reject(new DOMException("Aborted", "AbortError"));
+      };
+      controller.signal.onabort = onAbort;
       promise
-        .then(v => {
-          if (finished) return
-          finished = true
-          controller.signal.onabort = null
-          resolve(v)
+        .then((v) => {
+          if (finished) return;
+          finished = true;
+          controller.signal.onabort = null;
+          resolve(v);
         })
-        .catch(err => {
-          if (finished) return
-          finished = true
-          controller.signal.onabort = null
-          reject(err)
-        })
-    })
+        .catch((err) => {
+          if (finished) return;
+          finished = true;
+          controller.signal.onabort = null;
+          reject(err);
+        });
+    });
   }
 
   async load(track: AudioTrack): Promise<void> {
-    const requestId = ++this.playRequestId
-    this.loadController?.abort()
-    const controller = new AbortController()
-    this.loadController = controller
+    const requestId = ++this.playRequestId;
+    this.loadController?.abort();
+    const controller = new AbortController();
+    this.loadController = controller;
 
-    const context = await this.initContext()
+    const context = await this.initContext();
     // stop any current playback
-    this.stopSource()
+    this.stopSource();
 
     try {
-      const arrayBuffer = await this.abortable(track.file.arrayBuffer(), controller)
-      if (controller.signal.aborted || requestId !== this.playRequestId) throw new DOMException('Aborted', 'AbortError')
-      const decoded = await this.abortable((context.decodeAudioData as any)(arrayBuffer), controller)
-      if (controller.signal.aborted || requestId !== this.playRequestId) throw new DOMException('Aborted', 'AbortError')
-      this.currentBuffer = decoded
-      this.pausedAt = 0
-      this.isPaused = false
-      this.notify()
+      const arrayBuffer = await this.abortable(
+        track.file.arrayBuffer(),
+        controller,
+      );
+      if (controller.signal.aborted || requestId !== this.playRequestId)
+        throw new DOMException("Aborted", "AbortError");
+      const decoded = await this.abortable(
+        (context.decodeAudioData as any)(arrayBuffer),
+        controller,
+      );
+      if (controller.signal.aborted || requestId !== this.playRequestId)
+        throw new DOMException("Aborted", "AbortError");
+      this.currentBuffer = decoded;
+      this.pausedAt = 0;
+      this.isPaused = false;
+      this.notify();
     } catch (err: any) {
-      if (err.name === 'AbortError') {
+      if (err.name === "AbortError") {
         // Don't throw AbortError, just return silently
-        return
+        return;
       }
-      throw err
+      throw err;
     }
   }
 
   play(startAt = 0): void {
-    if (!this.currentBuffer || !this.audioContext) return
-    const context = this.audioContext
-    this.stopSource()
+    if (!this.currentBuffer || !this.audioContext) return;
+    const context = this.audioContext;
+    this.stopSource();
 
-    const source = context.createBufferSource()
-    source.buffer = this.currentBuffer
-    source.connect(this.gainNode!)
-    const requestId = this.playRequestId
+    const source = context.createBufferSource();
+    source.buffer = this.currentBuffer;
+    source.connect(this.gainNode!);
+    const requestId = this.playRequestId;
     source.onended = () => {
       if (requestId === this.playRequestId) {
-        this.handleEnded()
+        this.handleEnded();
       }
-    }
-    source.start(0, startAt)
-    this.startTime = context.currentTime - startAt
-    this.source = source
-    this.isPaused = false
-    this.updateTime()
-    this.notify()
+    };
+    source.start(0, startAt);
+    this.startTime = context.currentTime - startAt;
+    this.source = source;
+    this.isPaused = false;
+    this.updateTime();
+    this.notify();
   }
 
   pause(): void {
     if (this.source && this.audioContext) {
       try {
-        this.source.stop()
+        this.source.stop();
       } catch {}
-      this.pausedAt = this.audioContext.currentTime - this.startTime
-      this.source.disconnect()
-      this.source = null
-      this.isPaused = true
+      this.pausedAt = this.audioContext.currentTime - this.startTime;
+      this.source.disconnect();
+      this.source = null;
+      this.isPaused = true;
       if (this.animationFrameId) {
-        cancelAnimationFrame(this.animationFrameId)
-        this.animationFrameId = null
+        cancelAnimationFrame(this.animationFrameId);
+        this.animationFrameId = null;
       }
-      this.notify()
+      this.notify();
     }
   }
 
   resume(): void {
     if (this.isPaused) {
-      this.play(this.pausedAt)
+      this.play(this.pausedAt);
     }
   }
 
   stop(): void {
-    this.playRequestId++
-    this.stopSource()
-    this.currentBuffer = null
-    this.isPaused = false
-    this.pausedAt = 0
-    this.currentTime = 0
-    this.notify()
+    this.playRequestId++;
+    this.stopSource();
+    this.currentBuffer = null;
+    this.isPaused = false;
+    this.pausedAt = 0;
+    this.currentTime = 0;
+    this.notify();
   }
 
   seek(time: number): void {
-    if (!this.currentBuffer) return
-    const clamped = Math.max(0, Math.min(time, this.currentBuffer.duration))
+    if (!this.currentBuffer) return;
+    const clamped = Math.max(0, Math.min(time, this.currentBuffer.duration));
     if (this.isPaused) {
-      this.pausedAt = clamped
-      this.notify()
+      this.pausedAt = clamped;
+      this.notify();
     } else {
-      this.play(clamped)
+      this.play(clamped);
     }
   }
 
   async startMicrophone(stream: MediaStream): Promise<boolean> {
-    const context = await this.initContext()
-    this.stopSource()
+    const context = await this.initContext();
+    this.stopSource();
     try {
-      this.micSource?.disconnect()
+      this.micSource?.disconnect();
     } catch {}
-    this.micSource = context.createMediaStreamSource(stream)
-    this.micSource.connect(this.gainNode!)
-    this.currentBuffer = null
-    this.isPaused = false
-    this.playRequestId++
-    this.notify()
-    return true
+    this.micSource = context.createMediaStreamSource(stream);
+    this.micSource.connect(this.gainNode!);
+    this.currentBuffer = null;
+    this.isPaused = false;
+    this.playRequestId++;
+    this.notify();
+    return true;
   }
 
   stopMicrophone(): boolean {
     if (this.micSource) {
-      try { this.micSource.disconnect() } catch {}
-      this.micSource = null
-      this.notify()
+      try {
+        this.micSource.disconnect();
+      } catch {}
+      this.micSource = null;
+      this.notify();
     }
-    return true
+    return true;
   }
 
   setVolume(v: number): void {
     if (this.gainNode) {
-      this.gainNode.gain.value = Math.max(0, Math.min(1, v))
-      this.notify()
+      this.gainNode.gain.value = Math.max(0, Math.min(1, v));
+      this.notify();
     }
   }
 
   toggleMute(): void {
     if (this.gainNode) {
-      this.gainNode.gain.value = this.gainNode.gain.value > 0 ? 0 : 1
-      this.notify()
+      this.gainNode.gain.value = this.gainNode.gain.value > 0 ? 0 : 1;
+      this.notify();
     }
   }
 
   private updateTime = () => {
     if (this.source && this.audioContext) {
-      this.currentTime = Math.min(this.audioContext.currentTime - this.startTime, this.getDuration())
-      this.animationFrameId = requestAnimationFrame(this.updateTime)
-      this.notify()
+      this.currentTime = Math.min(
+        this.audioContext.currentTime - this.startTime,
+        this.getDuration(),
+      );
+      this.animationFrameId = requestAnimationFrame(this.updateTime);
+      this.notify();
     }
-  }
+  };
 
   private handleEnded(): void {
-    this.stopSource()
-    this.isPaused = false
-    this.pausedAt = 0
-    this.currentTime = 0
-    this.notify()
+    this.stopSource();
+    this.isPaused = false;
+    this.pausedAt = 0;
+    this.currentTime = 0;
+
+    const {
+      playlist,
+      currentTrackIndex,
+      playTrack,
+      setPlaying,
+      setPaused,
+      setStopped,
+    } = useAudioStore.getState();
+
+    const nextIndex = currentTrackIndex + 1;
+    if (nextIndex < playlist.length) {
+      // Auto-advance to the next track
+      playTrack(nextIndex);
+      return;
+    }
+
+    this.notify();
+    // No more tracks: ensure store reflects stopped state
+    setPlaying(false);
+    setPaused(false);
+    setStopped(true);
   }
 
   private stopSource() {
     if (this.source) {
-      try { this.source.stop() } catch {}
-      try { this.source.disconnect() } catch {}
-      this.source = null
+      try {
+        this.source.stop();
+      } catch {}
+      try {
+        this.source.disconnect();
+      } catch {}
+      this.source = null;
     }
     if (this.animationFrameId) {
-      cancelAnimationFrame(this.animationFrameId)
-      this.animationFrameId = null
+      cancelAnimationFrame(this.animationFrameId);
+      this.animationFrameId = null;
     }
   }
 
   // State getters
   isPlaying(): boolean {
-    return !!this.source && !this.isPaused
+    return !!this.source && !this.isPaused;
   }
 
   isStopped(): boolean {
-    return !this.source && !this.isPaused
+    return !this.source && !this.isPaused;
   }
 
   getCurrentTime(): number {
-    if (this.isPaused) return this.pausedAt
-    if (this.source && this.audioContext) return Math.min(this.audioContext.currentTime - this.startTime, this.getDuration())
-    return 0
+    if (this.isPaused) return this.pausedAt;
+    if (this.source && this.audioContext)
+      return Math.min(
+        this.audioContext.currentTime - this.startTime,
+        this.getDuration(),
+      );
+    return 0;
   }
 
   getDuration(): number {
-    return this.currentBuffer?.duration || 0
+    return this.currentBuffer?.duration || 0;
   }
 
   getVolume(): number {
-    return this.gainNode?.gain.value || 0
+    return this.gainNode?.gain.value || 0;
   }
 
   isMuted(): boolean {
-    return this.gainNode?.gain.value === 0
+    return this.gainNode?.gain.value === 0;
   }
 
   getAudioContext(): AudioContext | null {
-    return this.audioContext
+    return this.audioContext;
   }
 
   getFrequencyData(): Uint8Array | null {
-    if (!this.analyser) return null
-    
-    const bufferLength = this.analyser.frequencyBinCount
-    const dataArray = new Uint8Array(bufferLength)
-    this.analyser.getByteFrequencyData(dataArray)
-    
-    return dataArray
+    if (!this.analyser) return null;
+
+    const bufferLength = this.analyser.frequencyBinCount;
+    const dataArray = new Uint8Array(bufferLength);
+    this.analyser.getByteFrequencyData(dataArray);
+
+    return dataArray;
   }
 
   getTimeData(): Uint8Array | null {
-    if (!this.analyser) return null
-    
-    const bufferLength = this.analyser.frequencyBinCount
-    const dataArray = new Uint8Array(bufferLength)
-    this.analyser.getByteTimeDomainData(dataArray)
-    
-    return dataArray
+    if (!this.analyser) return null;
+
+    const bufferLength = this.analyser.frequencyBinCount;
+    const dataArray = new Uint8Array(bufferLength);
+    this.analyser.getByteTimeDomainData(dataArray);
+
+    return dataArray;
   }
 
   cleanup(): void {
-    this.stop()
-    this.stopMicrophone()
+    this.stop();
+    this.stopMicrophone();
     if (this.audioContext) {
-      this.audioContext.close()
-      this.audioContext = null
+      this.audioContext.close();
+      this.audioContext = null;
     }
-    this.gainNode = null
-    this.analyser = null
-    this.currentBuffer = null
-    this.callbacks.clear()
+    this.gainNode = null;
+    this.analyser = null;
+    this.currentBuffer = null;
+    this.callbacks.clear();
   }
 }
 
-export const playbackEngine = PlaybackEngine.getInstance()
-export type { PlaybackState, PlaybackCallback }
+export const playbackEngine = PlaybackEngine.getInstance();
+export type { PlaybackState, PlaybackCallback };

--- a/react-spectrogram/src/utils/__tests__/PlaybackEngine.test.ts
+++ b/react-spectrogram/src/utils/__tests__/PlaybackEngine.test.ts
@@ -1,73 +1,151 @@
-import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
-import { playbackEngine } from '../PlaybackEngine'
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { playbackEngine } from "../PlaybackEngine";
+import { useAudioStore } from "@/stores/audioStore";
 
 declare global {
   interface Window {
-    webkitAudioContext: typeof AudioContext
+    webkitAudioContext: typeof AudioContext;
   }
 }
 
 class MockSource {
-  connect = vi.fn()
-  start = vi.fn()
-  stop = vi.fn()
-  disconnect = vi.fn()
-  onended: (() => void) | null = null
-  buffer: AudioBuffer | null = null
+  connect = vi.fn();
+  start = vi.fn();
+  stop = vi.fn();
+  disconnect = vi.fn();
+  onended: (() => void) | null = null;
+  buffer: AudioBuffer | null = null;
 }
 
 class MockGain {
-  gain = { value: 1 }
-  connect = vi.fn()
+  gain = { value: 1 };
+  connect = vi.fn();
 }
 
 class MockAudioContext {
-  currentTime = 0
-  destination = {}
-  createGain() { return new MockGain() as any }
-  createBufferSource() { return new MockSource() as any }
-  resume = vi.fn().mockResolvedValue(undefined)
-  close = vi.fn().mockResolvedValue(undefined)
+  currentTime = 0;
+  destination = {};
+  createGain() {
+    return new MockGain() as any;
+  }
+  createBufferSource() {
+    return new MockSource() as any;
+  }
+  resume = vi.fn().mockResolvedValue(undefined);
+  close = vi.fn().mockResolvedValue(undefined);
   decodeAudioData(_arrayBuffer: ArrayBuffer) {
-    return new Promise<AudioBuffer>(resolve => {
-      setTimeout(() => resolve({ duration: 2 } as any), 0)
-    })
+    return new Promise<AudioBuffer>((resolve) => {
+      setTimeout(() => resolve({ duration: 2 } as any), 0);
+    });
   }
 }
 
 beforeEach(() => {
-  ;(global as any).AudioContext = MockAudioContext as any
-  ;(global as any).webkitAudioContext = MockAudioContext as any
-  ;(window as any).AudioContext = MockAudioContext as any
-  ;(window as any).webkitAudioContext = MockAudioContext as any
-})
+  (global as any).AudioContext = MockAudioContext as any;
+  (global as any).webkitAudioContext = MockAudioContext as any;
+  (window as any).AudioContext = MockAudioContext as any;
+  (window as any).webkitAudioContext = MockAudioContext as any;
+  useAudioStore.setState({
+    playlist: [],
+    currentTrackIndex: -1,
+    currentTrack: null,
+    isPlaying: false,
+    isPaused: false,
+    isStopped: true,
+  });
+});
 
 afterEach(() => {
-  playbackEngine.cleanup()
-  vi.clearAllMocks()
-})
+  playbackEngine.cleanup();
+  vi.clearAllMocks();
+});
 
-describe('PlaybackEngine', () => {
-  it('stops previous playback when a new track starts', async () => {
-    const track1 = { file: { arrayBuffer: async () => new ArrayBuffer(8) } } as any
-    const track2 = { file: { arrayBuffer: async () => new ArrayBuffer(8) } } as any
+describe("PlaybackEngine", () => {
+  it("stops previous playback when a new track starts", async () => {
+    const track1 = {
+      file: { arrayBuffer: async () => new ArrayBuffer(8) },
+    } as any;
+    const track2 = {
+      file: { arrayBuffer: async () => new ArrayBuffer(8) },
+    } as any;
 
-    await playbackEngine.load(track1)
-    playbackEngine.play()
-    const stopSpy = vi.spyOn((playbackEngine as any).source!, 'stop')
+    await playbackEngine.load(track1);
+    playbackEngine.play();
+    const stopSpy = vi.spyOn((playbackEngine as any).source!, "stop");
 
-    await playbackEngine.load(track2)
-    expect(stopSpy).toHaveBeenCalled()
-  })
+    await playbackEngine.load(track2);
+    expect(stopSpy).toHaveBeenCalled();
+  });
 
-  it('cancels pending decode when loading a new track', async () => {
-    const slowTrack = { file: { arrayBuffer: () => new Promise<ArrayBuffer>(resolve => setTimeout(() => resolve(new ArrayBuffer(8)), 50)) } } as any
-    const fastTrack = { file: { arrayBuffer: async () => new ArrayBuffer(8) } } as any
+  it("cancels pending decode when loading a new track", async () => {
+    const slowTrack = {
+      file: {
+        arrayBuffer: () =>
+          new Promise<ArrayBuffer>((resolve) =>
+            setTimeout(() => resolve(new ArrayBuffer(8)), 50),
+          ),
+      },
+    } as any;
+    const fastTrack = {
+      file: { arrayBuffer: async () => new ArrayBuffer(8) },
+    } as any;
 
-    const p1 = playbackEngine.load(slowTrack).catch(e => e)
-    await playbackEngine.load(fastTrack)
-    const result = await p1
-    expect(result).toBeInstanceOf(DOMException)
-    expect(result.name).toBe('AbortError')
-  })
-})
+    const p1 = playbackEngine.load(slowTrack).catch((e) => e);
+    await playbackEngine.load(fastTrack);
+    const result = await p1;
+    expect(result).toBeInstanceOf(DOMException);
+    expect(result.name).toBe("AbortError");
+  });
+
+  it("auto-advances to the next track when current track ends", () => {
+    const track1 = {
+      id: "1",
+      file: { arrayBuffer: async () => new ArrayBuffer(8) },
+    } as any;
+    const track2 = {
+      id: "2",
+      file: { arrayBuffer: async () => new ArrayBuffer(8) },
+    } as any;
+
+    useAudioStore.setState({
+      playlist: [track1, track2],
+      currentTrackIndex: 0,
+      currentTrack: track1,
+    });
+
+    const playSpy = vi
+      .spyOn(useAudioStore.getState(), "playTrack")
+      .mockResolvedValue(undefined);
+
+    (playbackEngine as any).handleEnded();
+
+    expect(playSpy).toHaveBeenCalledWith(1);
+  });
+
+  it("stops when there is no next track", () => {
+    const track1 = {
+      id: "1",
+      file: { arrayBuffer: async () => new ArrayBuffer(8) },
+    } as any;
+
+    useAudioStore.setState({
+      playlist: [track1],
+      currentTrackIndex: 0,
+      currentTrack: track1,
+    });
+
+    const playSpy = vi
+      .spyOn(useAudioStore.getState(), "playTrack")
+      .mockResolvedValue(undefined);
+    const setPlayingSpy = vi.spyOn(useAudioStore.getState(), "setPlaying");
+    const setPausedSpy = vi.spyOn(useAudioStore.getState(), "setPaused");
+    const setStoppedSpy = vi.spyOn(useAudioStore.getState(), "setStopped");
+
+    (playbackEngine as any).handleEnded();
+
+    expect(playSpy).not.toHaveBeenCalled();
+    expect(setPlayingSpy).toHaveBeenCalledWith(false);
+    expect(setPausedSpy).toHaveBeenCalledWith(false);
+    expect(setStoppedSpy).toHaveBeenCalledWith(true);
+  });
+});


### PR DESCRIPTION
## Summary
- auto-advance PlaybackEngine to next track using playlist state
- cover auto-advance and end-of-playlist cases with unit tests

## Testing
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*
- `npm test` *(fails: loadFromStorage is not a function)*
- `npm run test:coverage` *(fails: multiple tests and unhandled errors)*

------
https://chatgpt.com/codex/tasks/task_e_68a4faca34d8832b80e8ed11f5a08a2f