### PR TITLE
feat: refine upcoming track info

### DIFF
--- a/react-spectrogram/src/components/__tests__/UpcomingTrackInfo.test.tsx
+++ b/react-spectrogram/src/components/__tests__/UpcomingTrackInfo.test.tsx
@@ -41,41 +41,69 @@ vi.mock("../../components/spectrogram/CanvasWaveformSeekbar", () => ({
 
 describe("Upcoming track info", () => {
   beforeEach(() => {
-    const file1 = new File([""], "track1.mp3", { type: "audio/mpeg" });
-    const file2 = new File([""], "track2.mp3", { type: "audio/mpeg" });
-    const track1 = {
-      id: "1",
-      file: file1,
-      metadata: { title: "Track 1", artist: "Artist 1", album: "Album 1" },
-      duration: 60,
-      url: "track1",
-    };
-    const track2 = {
-      id: "2",
-      file: file2,
-      metadata: { title: "Track 2", artist: "Artist 2", album: "Album 2" },
-      duration: 60,
-      url: "track2",
-    };
-    mockState.currentTrack = track1;
-    mockState.playlist = [track1, track2];
-    mockState.currentTrackIndex = 0;
-    mockState.currentTime = 0;
+    mockState.currentTime = 55;
     mockState.duration = 60;
   });
 
-  it("shows next track when within last 10 seconds", () => {
-    mockState.currentTime = 55;
+  const createTrack = (
+    id: string,
+    title: string,
+    artist: string,
+    album: string,
+  ) => {
+    const file = new File([""], `${title}.mp3`, { type: "audio/mpeg" });
+    return {
+      id,
+      file,
+      metadata: { title, artist, album },
+      duration: 60,
+      url: id,
+    };
+  };
+
+  const setupPlaylist = (track1: any, track2: any) => {
+    mockState.currentTrack = track1;
+    mockState.playlist = [track1, track2];
+    mockState.currentTrackIndex = 0;
+  };
+
+  it("shows song when upcoming track has same artist and album", () => {
+    const track1 = createTrack("1", "Track 1", "Artist", "Album");
+    const track2 = createTrack("2", "Track 2", "Artist", "Album");
+    setupPlaylist(track1, track2);
     render(<Footer />);
-    expect(
-      screen.getByText("Coming up: Track 2 by Artist 2"),
-    ).toBeInTheDocument();
+    expect(screen.getByTestId("upcoming-track-info")).toHaveTextContent(
+      "Coming up: Track 2",
+    );
+  });
+
+  it("shows song and album when same artist different album", () => {
+    const track1 = createTrack("1", "Track 1", "Artist", "Album 1");
+    const track2 = createTrack("2", "Track 2", "Artist", "Album 2");
+    setupPlaylist(track1, track2);
+    render(<Footer />);
+    expect(screen.getByTestId("upcoming-track-info")).toHaveTextContent(
+      "Coming up: Track 2 from Album 2",
+    );
+  });
+
+  it("shows song and artist when different artist", () => {
+    const track1 = createTrack("1", "Track 1", "Artist 1", "Album 1");
+    const track2 = createTrack("2", "Track 2", "Artist 2", "Album 2");
+    setupPlaylist(track1, track2);
+    render(<Footer />);
+    expect(screen.getByTestId("upcoming-track-info")).toHaveTextContent(
+      "Coming up: Track 2 by Artist 2",
+    );
   });
 
   it("shows alternating info when not near end", () => {
+    const track1 = createTrack("1", "Track 1", "Artist 1", "Album 1");
+    const track2 = createTrack("2", "Track 2", "Artist 2", "Album 2");
+    setupPlaylist(track1, track2);
     mockState.currentTime = 30;
     render(<Footer />);
-    expect(screen.queryByText("Coming up: Track 2 by Artist 2")).toBeNull();
+    expect(screen.queryByTestId("upcoming-track-info")).toBeNull();
     expect(screen.getByTestId("alternating-info-text")).toHaveTextContent(
       "Artist 1",
     );

--- a/react-spectrogram/src/components/layout/Footer.tsx
+++ b/react-spectrogram/src/components/layout/Footer.tsx
@@ -50,7 +50,28 @@ export const Footer: React.FC = () => {
     ? playlist[currentTrackIndex + 1]
     : null;
   const showNextInfo =
-    !!currentTrack && hasUpcomingTrack && duration - currentTime <= NEXT_WINDOW_SEC;
+    !!currentTrack &&
+    hasUpcomingTrack &&
+    duration - currentTime <= NEXT_WINDOW_SEC;
+
+  const upcomingTrackInfo = useMemo(() => {
+    if (!currentTrack || !upcomingTrack) return "";
+
+    const song = upcomingTrack.metadata.title || upcomingTrack.file.name;
+    const currentArtist = currentTrack.metadata.artist;
+    const currentAlbum = currentTrack.metadata.album;
+    const upcomingArtist = upcomingTrack.metadata.artist;
+    const upcomingAlbum = upcomingTrack.metadata.album;
+
+    if (currentArtist === upcomingArtist) {
+      if (currentAlbum === upcomingAlbum) {
+        return song;
+      }
+      return `${song} from ${upcomingAlbum || "Unknown Album"}`;
+    }
+
+    return `${song} by ${upcomingArtist || "Unknown Artist"}`;
+  }, [currentTrack, upcomingTrack]);
 
   const trackInfoStyle = {
     width: `min(100%, ${INFO_MAX_CH}ch)`,
@@ -285,36 +306,29 @@ export const Footer: React.FC = () => {
           {layoutConfig.showAlbumArt && renderCurrentTrackAlbumArt()}
 
           {layoutConfig.showTrackInfo && currentTrack && (
-              <div
-                className={cn(
-                  "track-info-area",
-                  showNextInfo && "next-active",
-                )}
-                data-testid="track-info-area"
-                style={trackInfoStyle}
-              >
+            <div
+              className={cn("track-info-area", showNextInfo && "next-active")}
+              data-testid="track-info-area"
+              style={trackInfoStyle}
+            >
+              <MarqueeText
+                text={currentTrack.metadata.title || currentTrack.file.name}
+                className="track-title font-medium text-neutral-100"
+              />
+              {showNextInfo && upcomingTrack ? (
                 <MarqueeText
-                  text={currentTrack.metadata.title || currentTrack.file.name}
-                  className="track-title font-medium text-neutral-100"
+                  text={`Coming up: ${upcomingTrackInfo}`}
+                  className="next-info text-neutral-400"
+                  data-testid="upcoming-track-info"
                 />
-                {showNextInfo && upcomingTrack ? (
-                  <MarqueeText
-                    text={`Coming up: ${
-                      upcomingTrack.metadata.title || upcomingTrack.file.name
-                    } by ${
-                      upcomingTrack.metadata.artist || "Unknown Artist"
-                    }`}
-                    className="next-info text-neutral-400"
-                    data-testid="upcoming-track-info"
-                  />
-                ) : (
-                  <AlternatingInfo
-                    artist={currentTrack.metadata.artist || "Unknown Artist"}
-                    album={currentTrack.metadata.album || "Unknown Album"}
-                    className="text-neutral-400"
-                  />
-                )}
-              </div>
+              ) : (
+                <AlternatingInfo
+                  artist={currentTrack.metadata.artist || "Unknown Artist"}
+                  album={currentTrack.metadata.album || "Unknown Album"}
+                  className="text-neutral-400"
+                />
+              )}
+            </div>
           )}
         </div>
 


### PR DESCRIPTION
## Summary
- Differentiate upcoming track marquee to include album or artist based on similarity with current track
- Add unit tests for upcoming track info covering same album, different album, and different artist cases

## Testing
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*
- `npm run test:coverage` *(fails: loadFromStorage is not a function)*
- `npx vitest run src/components/__tests__/UpcomingTrackInfo.test.tsx --coverage` *(fails: removeEventListener called on an object that is not a valid instance of EventTarget)*

------
https://chatgpt.com/codex/tasks/task_e_68a4fa89fc88832b9b6e8083e03051da