### PR TITLE
feat: improve upcoming track formatting

### DIFF
--- a/react-spectrogram/src/components/__tests__/UpcomingTrackInfo.test.tsx
+++ b/react-spectrogram/src/components/__tests__/UpcomingTrackInfo.test.tsx
@@ -97,6 +97,82 @@ describe("Upcoming track info", () => {
     );
   });
 
+  it("shows only song when title matches upcoming artist", () => {
+    const track1 = createTrack("1", "Track 1", "Artist 1", "Album 1");
+    const track2 = createTrack(
+      "2",
+      "Black Sabbath",
+      "Black Sabbath",
+      "Album 2",
+    );
+    setupPlaylist(track1, track2);
+    render(<Footer />);
+    expect(screen.getByTestId("upcoming-track-info")).toHaveTextContent(
+      "Coming up: Black Sabbath",
+    );
+  });
+
+  it("shows only song when title matches upcoming album", () => {
+    const track1 = createTrack("1", "Track 1", "Artist", "Album 1");
+    const track2 = createTrack("2", "Album 2", "Artist", "Album 2");
+    setupPlaylist(track1, track2);
+    render(<Footer />);
+    expect(screen.getByTestId("upcoming-track-info")).toHaveTextContent(
+      "Coming up: Album 2",
+    );
+  });
+
+  it("ignores case and whitespace differences", () => {
+    const track1 = createTrack("1", "Track 1", "Artist", "Album");
+    const track2 = createTrack("2", "Track 2", " artist ", " album ");
+    setupPlaylist(track1, track2);
+    render(<Footer />);
+    expect(screen.getByTestId("upcoming-track-info")).toHaveTextContent(
+      "Coming up: Track 2",
+    );
+  });
+
+  it("normalizes album variants", () => {
+    const track1 = createTrack("1", "Track 1", "Artist", "Album");
+    const track2 = createTrack(
+      "2",
+      "Track 2",
+      "Artist",
+      "Album (Deluxe Edition)",
+    );
+    setupPlaylist(track1, track2);
+    render(<Footer />);
+    expect(screen.getByTestId("upcoming-track-info")).toHaveTextContent(
+      "Coming up: Track 2",
+    );
+  });
+
+  it("falls back to album when artist missing", () => {
+    const track1 = createTrack("1", "Track 1", "Artist", "Album 1");
+    const track2 = {
+      ...createTrack("2", "Track 2", "", "Album 2"),
+      metadata: { title: "Track 2", artist: "", album: "Album 2" },
+    };
+    setupPlaylist(track1, track2);
+    render(<Footer />);
+    expect(screen.getByTestId("upcoming-track-info")).toHaveTextContent(
+      "Coming up: Track 2 from Album 2",
+    );
+  });
+
+  it("falls back to song when album missing", () => {
+    const track1 = createTrack("1", "Track 1", "Artist", "Album 1");
+    const track2 = {
+      ...createTrack("2", "Track 2", "Artist", ""),
+      metadata: { title: "Track 2", artist: "Artist", album: "" },
+    };
+    setupPlaylist(track1, track2);
+    render(<Footer />);
+    expect(screen.getByTestId("upcoming-track-info")).toHaveTextContent(
+      "Coming up: Track 2",
+    );
+  });
+
   it("shows alternating info when not near end", () => {
     const track1 = createTrack("1", "Track 1", "Artist 1", "Album 1");
     const track2 = createTrack("2", "Track 2", "Artist 2", "Album 2");

--- a/react-spectrogram/src/components/layout/Footer.tsx
+++ b/react-spectrogram/src/components/layout/Footer.tsx
@@ -63,14 +63,42 @@ export const Footer: React.FC = () => {
     const upcomingArtist = upcomingTrack.metadata.artist;
     const upcomingAlbum = upcomingTrack.metadata.album;
 
-    if (currentArtist === upcomingArtist) {
-      if (currentAlbum === upcomingAlbum) {
-        return song;
-      }
-      return `${song} from ${upcomingAlbum || "Unknown Album"}`;
+    const normalize = (s?: string | null) => s?.trim().toLowerCase() ?? "";
+    const normalizeAlbum = (s?: string | null) =>
+      normalize(
+        s
+          ?.replace(/\((?:deluxe|special|expanded|remastered)[^)]*\)/gi, "")
+          ?.replace(/\[(?:deluxe|special|expanded|remastered)[^\]]*\]/gi, "")
+          ?.replace(/-(?:deluxe|special|expanded|remastered)[^-]*$/gi, ""),
+      );
+
+    const nSong = normalize(song);
+    const nCurrentArtist = normalize(currentArtist);
+    const nCurrentAlbum = normalizeAlbum(currentAlbum);
+    const nUpcomingArtist = normalize(upcomingArtist);
+    const nUpcomingAlbum = normalizeAlbum(upcomingAlbum);
+
+    const sameArtist =
+      nCurrentArtist && nUpcomingArtist && nCurrentArtist === nUpcomingArtist;
+    const sameAlbum =
+      nCurrentAlbum && nUpcomingAlbum && nCurrentAlbum === nUpcomingAlbum;
+
+    if (
+      (nSong && nSong === nUpcomingArtist) ||
+      (nSong && nSong === nUpcomingAlbum)
+    ) {
+      return song;
     }
 
-    return `${song} by ${upcomingArtist || "Unknown Artist"}`;
+    if (sameArtist) {
+      if (sameAlbum) return song;
+      if (upcomingAlbum) return `${song} from ${upcomingAlbum}`;
+      return song;
+    }
+
+    if (upcomingArtist) return `${song} by ${upcomingArtist}`;
+    if (upcomingAlbum) return `${song} from ${upcomingAlbum}`;
+    return song;
   }, [currentTrack, upcomingTrack]);
 
   const trackInfoStyle = {


### PR DESCRIPTION
## Summary
- normalize metadata and album variants when determining upcoming track info
- cover more edge cases with tests for missing metadata and identical names

## Testing
- `npm run lint`
- `npm run test:coverage` *(fails: TypeError: 'removeEventListener' called on an object that is not a valid instance of EventTarget)*

------
https://chatgpt.com/codex/tasks/task_e_68a500518734832bad13de5896c4a71e