### PR TITLE
feat: add shuffle and loop modes to audio player

### DIFF
--- a/react-spectrogram/src/components/__tests__/AlbumArt.test.tsx
+++ b/react-spectrogram/src/components/__tests__/AlbumArt.test.tsx
@@ -1,10 +1,10 @@
-import { render, screen } from '@testing-library/react'
-import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { PlaylistPanel } from '../layout/PlaylistPanel'
-import { AudioTrack } from '@/types'
+import { render, screen } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { PlaylistPanel } from "../layout/PlaylistPanel";
+import { AudioTrack } from "@/types";
 
 // Mock the stores and hooks
-vi.mock('../../../stores/audioStore', () => ({
+vi.mock("../../../stores/audioStore", () => ({
   useAudioStore: () => ({
     isPlaying: false,
     isStopped: true,
@@ -15,10 +15,16 @@ vi.mock('../../../stores/audioStore', () => ({
     currentTrack: null,
     playlist: [],
     currentTrackIndex: -1,
-  })
-}))
+    shuffle: false,
+    loopMode: "off",
+    setShuffle: vi.fn(),
+    setLoopMode: vi.fn(),
+    nextTrack: vi.fn(),
+    previousTrack: vi.fn(),
+  }),
+}));
 
-vi.mock('../../../hooks/useAudioFile', () => ({
+vi.mock("../../../hooks/useAudioFile", () => ({
   useAudioFile: () => ({
     playTrack: vi.fn(),
     pausePlayback: vi.fn(),
@@ -27,43 +33,43 @@ vi.mock('../../../hooks/useAudioFile', () => ({
     seekTo: vi.fn(),
     setAudioVolume: vi.fn(),
     toggleMute: vi.fn(),
-  })
-}))
+  }),
+}));
 
 // Mock URL.createObjectURL and URL.revokeObjectURL
-const mockCreateObjectURL = vi.fn()
-const mockRevokeObjectURL = vi.fn()
+const mockCreateObjectURL = vi.fn();
+const mockRevokeObjectURL = vi.fn();
 
-Object.defineProperty(global, 'URL', {
+Object.defineProperty(global, "URL", {
   value: {
     createObjectURL: mockCreateObjectURL,
     revokeObjectURL: mockRevokeObjectURL,
   },
   writable: true,
-})
+});
 
-describe('Album Art Display', () => {
+describe("Album Art Display", () => {
   beforeEach(() => {
-    vi.clearAllMocks()
-    mockCreateObjectURL.mockReturnValue('blob:mock-url')
-  })
+    vi.clearAllMocks();
+    mockCreateObjectURL.mockReturnValue("blob:mock-url");
+  });
 
-  it('should display album art in playlist panel when available', () => {
+  it("should display album art in playlist panel when available", () => {
     const mockTrack: AudioTrack = {
-      id: '1',
-      file: new File(['test'], 'test.mp3', { type: 'audio/mp3' }),
+      id: "1",
+      file: new File(["test"], "test.mp3", { type: "audio/mp3" }),
       metadata: {
-        title: 'Test Song',
-        artist: 'Test Artist',
-        album: 'Test Album',
-        album_art: new Uint8Array([0x89, 0x50, 0x4E, 0x47]), // PNG header
-        album_art_mime: 'image/png',
+        title: "Test Song",
+        artist: "Test Artist",
+        album: "Test Album",
+        album_art: new Uint8Array([0x89, 0x50, 0x4e, 0x47]), // PNG header
+        album_art_mime: "image/png",
         duration: 180,
-        format: 'mp3'
+        format: "mp3",
       },
       duration: 180,
-      url: 'blob:test'
-    }
+      url: "blob:test",
+    };
 
     render(
       <PlaylistPanel
@@ -74,29 +80,29 @@ describe('Album Art Display', () => {
         onTrackSelect={vi.fn()}
         onTrackRemove={vi.fn()}
         onTrackReorder={vi.fn()}
-      />
-    )
+      />,
+    );
 
     // Check that album art is rendered
-    const albumArt = screen.getByAltText('Album Art')
-    expect(albumArt).toBeInTheDocument()
-    expect(albumArt).toHaveClass('w-10', 'h-10', 'object-cover', 'rounded-md')
-  })
+    const albumArt = screen.getByAltText("Album Art");
+    expect(albumArt).toBeInTheDocument();
+    expect(albumArt).toHaveClass("w-10", "h-10", "object-cover", "rounded-md");
+  });
 
-  it('should display fallback icon when album art is not available', () => {
+  it("should display fallback icon when album art is not available", () => {
     const mockTrack: AudioTrack = {
-      id: '1',
-      file: new File(['test'], 'test.mp3', { type: 'audio/mp3' }),
+      id: "1",
+      file: new File(["test"], "test.mp3", { type: "audio/mp3" }),
       metadata: {
-        title: 'Test Song',
-        artist: 'Test Artist',
-        album: 'Test Album',
+        title: "Test Song",
+        artist: "Test Artist",
+        album: "Test Album",
         duration: 180,
-        format: 'mp3'
+        format: "mp3",
       },
       duration: 180,
-      url: 'blob:test'
-    }
+      url: "blob:test",
+    };
 
     render(
       <PlaylistPanel
@@ -107,37 +113,39 @@ describe('Album Art Display', () => {
         onTrackSelect={vi.fn()}
         onTrackRemove={vi.fn()}
         onTrackReorder={vi.fn()}
-      />
-    )
+      />,
+    );
 
     // Check that fallback icon is rendered
-    const fallbackIcon = screen.getByTestId('playlist-panel').querySelector('.text-neutral-500')
-    expect(fallbackIcon).toBeInTheDocument()
-  })
+    const fallbackIcon = screen
+      .getByTestId("playlist-panel")
+      .querySelector(".text-neutral-500");
+    expect(fallbackIcon).toBeInTheDocument();
+  });
 
-  it('should handle different image formats correctly', () => {
+  it("should handle different image formats correctly", () => {
     const testCases = [
-      { mime: 'image/jpeg', data: new Uint8Array([0xFF, 0xD8, 0xFF, 0xE0]) },
-      { mime: 'image/png', data: new Uint8Array([0x89, 0x50, 0x4E, 0x47]) },
-      { mime: 'image/gif', data: new Uint8Array([0x47, 0x49, 0x46, 0x38]) }
-    ]
+      { mime: "image/jpeg", data: new Uint8Array([0xff, 0xd8, 0xff, 0xe0]) },
+      { mime: "image/png", data: new Uint8Array([0x89, 0x50, 0x4e, 0x47]) },
+      { mime: "image/gif", data: new Uint8Array([0x47, 0x49, 0x46, 0x38]) },
+    ];
 
     testCases.forEach(({ mime, data }) => {
       const mockTrack: AudioTrack = {
-        id: '1',
-        file: new File(['test'], 'test.mp3', { type: 'audio/mp3' }),
+        id: "1",
+        file: new File(["test"], "test.mp3", { type: "audio/mp3" }),
         metadata: {
-          title: 'Test Song',
-          artist: 'Test Artist',
-          album: 'Test Album',
+          title: "Test Song",
+          artist: "Test Artist",
+          album: "Test Album",
           album_art: data,
           album_art_mime: mime,
           duration: 180,
-          format: 'mp3'
+          format: "mp3",
         },
         duration: 180,
-        url: 'blob:test'
-      }
+        url: "blob:test",
+      };
 
       const { unmount } = render(
         <PlaylistPanel
@@ -148,14 +156,14 @@ describe('Album Art Display', () => {
           onTrackSelect={vi.fn()}
           onTrackRemove={vi.fn()}
           onTrackReorder={vi.fn()}
-        />
-      )
+        />,
+      );
 
-      const albumArt = screen.getByAltText('Album Art')
-      expect(albumArt).toBeInTheDocument()
-      
+      const albumArt = screen.getByAltText("Album Art");
+      expect(albumArt).toBeInTheDocument();
+
       // Clean up before next iteration
-      unmount()
-    })
-  })
-})
+      unmount();
+    });
+  });
+});

--- a/react-spectrogram/src/components/__tests__/App.test.tsx
+++ b/react-spectrogram/src/components/__tests__/App.test.tsx
@@ -1,9 +1,9 @@
-import { render, screen } from '@testing-library/react'
-import { describe, it, expect, vi } from 'vitest'
-import App from '../../App'
+import { render, screen } from "@testing-library/react";
+import { describe, it, expect, vi } from "vitest";
+import App from "../../App";
 
 // Mock the stores and hooks
-vi.mock('../../stores/audioStore', () => ({
+vi.mock("../../stores/audioStore", () => ({
   useAudioStore: () => ({
     currentTrack: null,
     playlist: [],
@@ -19,10 +19,16 @@ vi.mock('../../stores/audioStore', () => ({
     isMuted: false,
     isLive: false,
     isMicrophoneActive: false,
-  })
-}))
+    shuffle: false,
+    loopMode: "off",
+    setShuffle: vi.fn(),
+    setLoopMode: vi.fn(),
+    nextTrack: vi.fn(),
+    previousTrack: vi.fn(),
+  }),
+}));
 
-vi.mock('../../stores/uiStore', () => ({
+vi.mock("../../stores/uiStore", () => ({
   useUIStore: () => ({
     isMobile: false,
     metadataPanelOpen: false,
@@ -34,60 +40,60 @@ vi.mock('../../stores/uiStore', () => ({
     setSettingsPanelOpen: vi.fn(),
     setShortcutsHelpOpen: vi.fn(),
     toggleShortcutsHelp: vi.fn(),
-  })
-}))
+  }),
+}));
 
-vi.mock('../../stores/settingsStore', () => ({
+vi.mock("../../stores/settingsStore", () => ({
   useSettingsStore: () => ({
-    theme: 'dark',
+    theme: "dark",
     updateSettings: vi.fn(),
-  })
-}))
+  }),
+}));
 
-vi.mock('../../hooks/useKeyboardShortcuts', () => ({
+vi.mock("../../hooks/useKeyboardShortcuts", () => ({
   useKeyboardShortcuts: vi.fn(),
-}))
+}));
 
-vi.mock('../../hooks/useScreenSize', () => ({
+vi.mock("../../hooks/useScreenSize", () => ({
   useScreenSize: () => ({ isMobile: false, isTablet: false }),
-}))
+}));
 
-vi.mock('../../utils/wasm', () => ({
+vi.mock("../../utils/wasm", () => ({
   initWASM: vi.fn(),
-}))
+}));
 
-describe('App', () => {
-  it('renders without crashing', () => {
-    render(<App />)
-    expect(screen.getByTestId('app-container')).toBeInTheDocument()
-  })
+describe("App", () => {
+  it("renders without crashing", () => {
+    render(<App />);
+    expect(screen.getByTestId("app-container")).toBeInTheDocument();
+  });
 
-  it('renders header with app title', () => {
-    render(<App />)
-    expect(screen.getByText('Spectrogram')).toBeInTheDocument()
-  })
+  it("renders header with app title", () => {
+    render(<App />);
+    expect(screen.getByText("Spectrogram")).toBeInTheDocument();
+  });
 
-  it('renders footer with controls', () => {
-    render(<App />)
-    expect(screen.getByTestId('footer')).toBeInTheDocument()
-    expect(screen.getByTestId('play-pause-button')).toBeInTheDocument()
-  })
+  it("renders footer with controls", () => {
+    render(<App />);
+    expect(screen.getByTestId("footer")).toBeInTheDocument();
+    expect(screen.getByTestId("play-pause-button")).toBeInTheDocument();
+  });
 
-  it('renders spectrogram view', () => {
-    render(<App />)
-    expect(screen.getByTestId('spectrogram-view')).toBeInTheDocument()
-  })
+  it("renders spectrogram view", () => {
+    render(<App />);
+    expect(screen.getByTestId("spectrogram-view")).toBeInTheDocument();
+  });
 
-  it('shows drop zone when no track is loaded', () => {
-    render(<App />)
-    expect(screen.getByTestId('drop-zone')).toBeInTheDocument()
-    expect(screen.getByText('Drop audio files here')).toBeInTheDocument()
-  })
+  it("shows drop zone when no track is loaded", () => {
+    render(<App />);
+    expect(screen.getByTestId("drop-zone")).toBeInTheDocument();
+    expect(screen.getByText("Drop audio files here")).toBeInTheDocument();
+  });
 
-  it('preserves existing body classes when applying theme', () => {
-    document.body.className = 'keep-me'
-    render(<App />)
-    expect(document.body.classList.contains('keep-me')).toBe(true)
-    expect(document.body.classList.contains('theme-dark')).toBe(true)
-  })
-})
+  it("preserves existing body classes when applying theme", () => {
+    document.body.className = "keep-me";
+    render(<App />);
+    expect(document.body.classList.contains("keep-me")).toBe(true);
+    expect(document.body.classList.contains("theme-dark")).toBe(true);
+  });
+});

--- a/react-spectrogram/src/components/__tests__/AppCleanup.test.tsx
+++ b/react-spectrogram/src/components/__tests__/AppCleanup.test.tsx
@@ -1,7 +1,7 @@
-import { render } from '@testing-library/react'
-import { describe, it, expect, vi } from 'vitest'
+import { render } from "@testing-library/react";
+import { describe, it, expect, vi } from "vitest";
 
-vi.mock('../../stores/audioStore', () => ({
+vi.mock("../../stores/audioStore", () => ({
   useAudioStore: () => ({
     currentTrack: null,
     playlist: [],
@@ -17,10 +17,16 @@ vi.mock('../../stores/audioStore', () => ({
     isMuted: false,
     isLive: false,
     isMicrophoneActive: false,
-  })
-}))
+    shuffle: false,
+    loopMode: "off",
+    setShuffle: vi.fn(),
+    setLoopMode: vi.fn(),
+    nextTrack: vi.fn(),
+    previousTrack: vi.fn(),
+  }),
+}));
 
-vi.mock('../../stores/uiStore', () => ({
+vi.mock("../../stores/uiStore", () => ({
   useUIStore: () => ({
     isMobile: false,
     metadataPanelOpen: false,
@@ -32,46 +38,45 @@ vi.mock('../../stores/uiStore', () => ({
     setSettingsPanelOpen: vi.fn(),
     setShortcutsHelpOpen: vi.fn(),
     toggleShortcutsHelp: vi.fn(),
-  })
-}))
+  }),
+}));
 
-vi.mock('../../stores/settingsStore', () => ({
+vi.mock("../../stores/settingsStore", () => ({
   useSettingsStore: () => ({
-    theme: 'dark',
+    theme: "dark",
     updateSettings: vi.fn(),
     loadFromStorage: vi.fn(),
-  })
-}))
+  }),
+}));
 
-vi.mock('../../hooks/useKeyboardShortcuts', () => ({
+vi.mock("../../hooks/useKeyboardShortcuts", () => ({
   useKeyboardShortcuts: vi.fn(),
-}))
+}));
 
-vi.mock('../../hooks/useScreenSize', () => ({
+vi.mock("../../hooks/useScreenSize", () => ({
   useScreenSize: () => ({ isMobile: false, isTablet: false }),
-}))
+}));
 
-vi.mock('../../utils/wasm', () => ({
+vi.mock("../../utils/wasm", () => ({
   initWASM: vi.fn(() => Promise.resolve()),
   extractMetadata: vi.fn().mockResolvedValue({}),
   generateAmplitudeEnvelope: vi.fn().mockResolvedValue(new Float32Array()),
-}))
+}));
 
-vi.mock('../../utils/audioPlayer', () => ({
+vi.mock("../../utils/audioPlayer", () => ({
   audioPlayer: {
     cleanup: vi.fn(),
     subscribe: vi.fn(() => () => {}),
   },
-}))
+}));
 
-import App from '../../App'
-import { audioPlayer } from '../../utils/audioPlayer'
+import App from "../../App";
+import { audioPlayer } from "../../utils/audioPlayer";
 
-describe('App cleanup', () => {
-  it('cleans up audio resources on unmount', () => {
-    const { unmount } = render(<App />)
-    unmount()
-    expect(audioPlayer.cleanup).toHaveBeenCalled()
-  })
-})
-
+describe("App cleanup", () => {
+  it("cleans up audio resources on unmount", () => {
+    const { unmount } = render(<App />);
+    unmount();
+    expect(audioPlayer.cleanup).toHaveBeenCalled();
+  });
+});

--- a/react-spectrogram/src/components/__tests__/AudioFileLoading.test.tsx
+++ b/react-spectrogram/src/components/__tests__/AudioFileLoading.test.tsx
@@ -1,6 +1,6 @@
-import { render, screen } from '@testing-library/react'
-import { describe, it, expect, vi, beforeEach } from 'vitest'
-import App from '../../App'
+import { render, screen } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import App from "../../App";
 
 // Mock the audio hooks
 const mockUseAudioFile = vi.fn(() => ({
@@ -18,13 +18,13 @@ const mockUseAudioFile = vi.fn(() => ({
   getTimeData: vi.fn(() => new Uint8Array(1024)),
   cleanup: vi.fn(),
   initAudioContext: vi.fn(),
-}))
+}));
 
-vi.mock('../../hooks/useAudioFile', () => ({
-  useAudioFile: mockUseAudioFile
-}))
+vi.mock("../../hooks/useAudioFile", () => ({
+  useAudioFile: mockUseAudioFile,
+}));
 
-vi.mock('../../hooks/useMicrophone', () => ({
+vi.mock("../../hooks/useMicrophone", () => ({
   useMicrophone: () => ({
     isInitialized: false,
     isRequestingPermission: false,
@@ -40,19 +40,19 @@ vi.mock('../../hooks/useMicrophone', () => ({
     stopAnalysis: vi.fn(),
     getInputLevel: vi.fn(),
     initAudioContext: vi.fn(),
-  })
-}))
+  }),
+}));
 
-vi.mock('../../hooks/useKeyboardShortcuts', () => ({
-  useKeyboardShortcuts: vi.fn()
-}))
+vi.mock("../../hooks/useKeyboardShortcuts", () => ({
+  useKeyboardShortcuts: vi.fn(),
+}));
 
-vi.mock('../../hooks/useScreenSize', () => ({
-  useScreenSize: () => ({ isMobile: false, isTablet: false })
-}))
+vi.mock("../../hooks/useScreenSize", () => ({
+  useScreenSize: () => ({ isMobile: false, isTablet: false }),
+}));
 
 // Mock the stores
-vi.mock('../../stores/audioStore', () => ({
+vi.mock("../../stores/audioStore", () => ({
   useAudioStore: () => ({
     isPlaying: false,
     isPaused: false,
@@ -67,6 +67,10 @@ vi.mock('../../stores/audioStore', () => ({
     isLive: false,
     isMicrophoneActive: false,
     inputDevice: null,
+    shuffle: false,
+    loopMode: "off",
+    setShuffle: vi.fn(),
+    setLoopMode: vi.fn(),
     addToPlaylist: vi.fn(),
     setCurrentTrack: vi.fn(),
     setPlaying: vi.fn(),
@@ -87,10 +91,10 @@ vi.mock('../../stores/audioStore', () => ({
     toggleMute: vi.fn(),
     seekTo: vi.fn(),
     updateVolume: vi.fn(),
-  })
-}))
+  }),
+}));
 
-vi.mock('../../stores/uiStore', () => ({
+vi.mock("../../stores/uiStore", () => ({
   useUIStore: () => ({
     metadataPanelOpen: false,
     playlistPanelOpen: false,
@@ -112,17 +116,17 @@ vi.mock('../../stores/uiStore', () => ({
     toggleShortcutsHelp: vi.fn(),
     closeAllPanels: vi.fn(),
     updateScreenSize: vi.fn(),
-  })
-}))
+  }),
+}));
 
-vi.mock('../../stores/settingsStore', () => ({
+vi.mock("../../stores/settingsStore", () => ({
   useSettingsStore: () => ({
-    theme: 'dark',
-    amplitudeScale: 'db',
-    frequencyScale: 'logarithmic',
-    resolution: 'medium',
+    theme: "dark",
+    amplitudeScale: "db",
+    frequencyScale: "logarithmic",
+    resolution: "medium",
     refreshRate: 60,
-    colormap: 'viridis',
+    colormap: "viridis",
     showLegend: true,
     setTheme: vi.fn(),
     setAmplitudeScale: vi.fn(),
@@ -135,31 +139,31 @@ vi.mock('../../stores/settingsStore', () => ({
     resetToDefaults: vi.fn(),
     loadFromStorage: vi.fn(),
     saveToStorage: vi.fn(),
-  })
-}))
+  }),
+}));
 
-describe('AudioFileLoading', () => {
+describe("AudioFileLoading", () => {
   beforeEach(() => {
-    vi.clearAllMocks()
-  })
+    vi.clearAllMocks();
+  });
 
-  it('should render the app with file loading functionality', async () => {
-    render(<App />)
-    
+  it("should render the app with file loading functionality", async () => {
+    render(<App />);
+
     // Check that the app loads without errors
-    expect(screen.getByTestId('app-container')).toBeInTheDocument()
-    
-    // Check that the file input is present
-    expect(screen.getByTestId('file-input')).toBeInTheDocument()
-    
-    // Check that the open file button is present
-    expect(screen.getByTestId('open-file-button')).toBeInTheDocument()
-    
-    // Check that the drop zone is visible when no file is loaded
-    expect(screen.getByTestId('drop-zone')).toBeInTheDocument()
-  })
+    expect(screen.getByTestId("app-container")).toBeInTheDocument();
 
-  it('should show loading state when file is being processed', async () => {
+    // Check that the file input is present
+    expect(screen.getByTestId("file-input")).toBeInTheDocument();
+
+    // Check that the open file button is present
+    expect(screen.getByTestId("open-file-button")).toBeInTheDocument();
+
+    // Check that the drop zone is visible when no file is loaded
+    expect(screen.getByTestId("drop-zone")).toBeInTheDocument();
+  });
+
+  it("should show loading state when file is being processed", async () => {
     // Mock loading state
     mockUseAudioFile.mockReturnValue({
       isLoading: true,
@@ -176,19 +180,19 @@ describe('AudioFileLoading', () => {
       getTimeData: vi.fn(() => new Uint8Array(1024)),
       cleanup: vi.fn(),
       initAudioContext: vi.fn(),
-    })
+    });
 
-    render(<App />)
-    
+    render(<App />);
+
     // Check that loading indicator is shown
-    expect(screen.getByTestId('loading-indicator')).toBeInTheDocument()
-  })
+    expect(screen.getByTestId("loading-indicator")).toBeInTheDocument();
+  });
 
-  it('should handle file loading errors gracefully', async () => {
+  it("should handle file loading errors gracefully", async () => {
     // Mock error state
     mockUseAudioFile.mockReturnValue({
       isLoading: false,
-      error: 'Failed to load audio file',
+      error: "Failed to load audio file",
       loadAudioFiles: vi.fn(),
       playTrack: vi.fn(),
       stopPlayback: vi.fn(),
@@ -201,11 +205,11 @@ describe('AudioFileLoading', () => {
       getTimeData: vi.fn(() => new Uint8Array(1024)),
       cleanup: vi.fn(),
       initAudioContext: vi.fn(),
-    })
+    });
 
-    render(<App />)
-    
+    render(<App />);
+
     // The app should still render even with errors
-    expect(screen.getByTestId('app-container')).toBeInTheDocument()
-  })
-})
+    expect(screen.getByTestId("app-container")).toBeInTheDocument();
+  });
+});

--- a/react-spectrogram/src/components/__tests__/Footer.test.tsx
+++ b/react-spectrogram/src/components/__tests__/Footer.test.tsx
@@ -14,6 +14,12 @@ vi.mock("../../../stores/audioStore", () => ({
     currentTrack: null,
     playlist: [],
     currentTrackIndex: -1,
+    shuffle: false,
+    loopMode: "off",
+    setShuffle: vi.fn(),
+    setLoopMode: vi.fn(),
+    nextTrack: vi.fn(),
+    previousTrack: vi.fn(),
   }),
 }));
 

--- a/react-spectrogram/src/components/__tests__/FooterInteractions.test.tsx
+++ b/react-spectrogram/src/components/__tests__/FooterInteractions.test.tsx
@@ -1,0 +1,71 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, it, expect, vi } from "vitest";
+import { Footer } from "../layout/Footer";
+
+const mockState: any = {
+  isPlaying: false,
+  isStopped: true,
+  currentTime: 0,
+  duration: 0,
+  volume: 1,
+  isMuted: false,
+  currentTrack: null,
+  playlist: [],
+  currentTrackIndex: -1,
+  shuffle: false,
+  loopMode: "off" as const,
+  setShuffle: vi.fn((v: boolean) => {
+    mockState.shuffle = v;
+  }),
+  setLoopMode: vi.fn((v: "off" | "one" | "all") => {
+    mockState.loopMode = v;
+  }),
+  nextTrack: vi.fn(),
+  previousTrack: vi.fn(),
+};
+
+vi.mock("../../../stores/audioStore", () => ({
+  useAudioStore: () => mockState,
+}));
+
+vi.mock("../../../hooks/useAudioFile", () => ({
+  useAudioFile: () => ({
+    playTrack: vi.fn(),
+    pausePlayback: vi.fn(),
+    resumePlayback: vi.fn(),
+    stopPlayback: vi.fn(),
+    seekTo: vi.fn(),
+    setAudioVolume: vi.fn(),
+    toggleMute: vi.fn(),
+  }),
+}));
+
+vi.mock("../../../hooks/useScreenSize", () => ({
+  useScreenSize: () => ({ isMobile: false, isTablet: false }),
+}));
+
+vi.mock("../../../components/spectrogram/CanvasWaveformSeekbar", () => ({
+  CanvasWaveformSeekbar: () => <div data-testid="seekbar" />,
+}));
+
+describe("Footer interactions", () => {
+  it("toggles shuffle and loop mode", async () => {
+    const user = userEvent.setup();
+    const { rerender } = render(<Footer />);
+
+    const shuffleBtn = screen.getByTestId("shuffle-button");
+    await user.click(shuffleBtn);
+    expect(mockState.setShuffle).toHaveBeenCalledWith(true);
+    mockState.shuffle = true;
+    rerender(<Footer />);
+    expect(shuffleBtn).toHaveClass("bg-neutral-700");
+
+    const repeatBtn = screen.getByTestId("repeat-button");
+    await user.click(repeatBtn);
+    expect(mockState.setLoopMode).toHaveBeenCalledWith("all");
+    mockState.loopMode = "all";
+    rerender(<Footer />);
+    expect(repeatBtn).toHaveClass("bg-neutral-700");
+  });
+});

--- a/react-spectrogram/src/components/__tests__/IntegrationTests.test.tsx
+++ b/react-spectrogram/src/components/__tests__/IntegrationTests.test.tsx
@@ -1,6 +1,6 @@
-import { render, screen } from '@testing-library/react'
-import { describe, it, expect, vi, beforeEach } from 'vitest'
-import App from '../../App'
+import { render, screen } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import App from "../../App";
 
 // Mock all hooks and stores
 const mockUseAudioFile = vi.fn(() => ({
@@ -18,7 +18,7 @@ const mockUseAudioFile = vi.fn(() => ({
   getTimeData: vi.fn(() => new Uint8Array(1024)),
   cleanup: vi.fn(),
   initAudioContext: vi.fn(),
-}))
+}));
 
 const mockUseMicrophone = vi.fn(() => ({
   startMicrophone: vi.fn(),
@@ -26,16 +26,16 @@ const mockUseMicrophone = vi.fn(() => ({
   isInitialized: false,
   isRequestingPermission: false,
   error: null,
-}))
+}));
 
 const mockUseKeyboardShortcuts = vi.fn(() => ({
   isEnabled: true,
-}))
+}));
 
 const mockUseScreenSize = vi.fn(() => ({
   isMobile: false,
   isTablet: false,
-}))
+}));
 
 const mockUseAudioStore = vi.fn(() => ({
   currentTrack: null,
@@ -48,6 +48,11 @@ const mockUseAudioStore = vi.fn(() => ({
   volume: 1,
   isMuted: false,
   playlist: [],
+  currentTrackIndex: -1,
+  shuffle: false,
+  loopMode: "off",
+  setShuffle: vi.fn(),
+  setLoopMode: vi.fn(),
   togglePlayPause: vi.fn(),
   stopPlayback: vi.fn(),
   nextTrack: vi.fn(),
@@ -58,7 +63,7 @@ const mockUseAudioStore = vi.fn(() => ({
   addToPlaylist: vi.fn(),
   removeFromPlaylist: vi.fn(),
   clearPlaylist: vi.fn(),
-}))
+}));
 
 const mockUseUIStore = vi.fn(() => ({
   isMetadataOpen: false,
@@ -73,15 +78,15 @@ const mockUseUIStore = vi.fn(() => ({
   toggleFullscreen: vi.fn(),
   shortcutsHelpOpen: false,
   setShortcutsHelpOpen: vi.fn(),
-}))
+}));
 
 const mockUseSettingsStore = vi.fn(() => ({
-  theme: 'dark' as const,
-  amplitudeScale: 'db' as const,
-  frequencyScale: 'logarithmic' as const,
-  resolution: 'medium' as const,
+  theme: "dark" as const,
+  amplitudeScale: "db" as const,
+  frequencyScale: "logarithmic" as const,
+  resolution: "medium" as const,
   refreshRate: 60,
-  colormap: 'viridis',
+  colormap: "viridis",
   showLegend: true,
   setTheme: vi.fn(),
   setAmplitudeScale: vi.fn(),
@@ -90,119 +95,119 @@ const mockUseSettingsStore = vi.fn(() => ({
   setRefreshRate: vi.fn(),
   setColormap: vi.fn(),
   setShowLegend: vi.fn(),
-}))
+}));
 
-vi.mock('../../hooks/useAudioFile', () => ({
-  useAudioFile: mockUseAudioFile
-}))
+vi.mock("../../hooks/useAudioFile", () => ({
+  useAudioFile: mockUseAudioFile,
+}));
 
-vi.mock('../../hooks/useMicrophone', () => ({
-  useMicrophone: mockUseMicrophone
-}))
+vi.mock("../../hooks/useMicrophone", () => ({
+  useMicrophone: mockUseMicrophone,
+}));
 
-vi.mock('../../hooks/useKeyboardShortcuts', () => ({
-  useKeyboardShortcuts: mockUseKeyboardShortcuts
-}))
+vi.mock("../../hooks/useKeyboardShortcuts", () => ({
+  useKeyboardShortcuts: mockUseKeyboardShortcuts,
+}));
 
-vi.mock('../../hooks/useScreenSize', () => ({
-  useScreenSize: mockUseScreenSize
-}))
+vi.mock("../../hooks/useScreenSize", () => ({
+  useScreenSize: mockUseScreenSize,
+}));
 
-vi.mock('../../stores/audioStore', () => ({
-  useAudioStore: mockUseAudioStore
-}))
+vi.mock("../../stores/audioStore", () => ({
+  useAudioStore: mockUseAudioStore,
+}));
 
-vi.mock('../../stores/uiStore', () => ({
-  useUIStore: mockUseUIStore
-}))
+vi.mock("../../stores/uiStore", () => ({
+  useUIStore: mockUseUIStore,
+}));
 
-vi.mock('../../stores/settingsStore', () => ({
-  useSettingsStore: mockUseSettingsStore
-}))
+vi.mock("../../stores/settingsStore", () => ({
+  useSettingsStore: mockUseSettingsStore,
+}));
 
-describe('Integration Tests', () => {
+describe("Integration Tests", () => {
   beforeEach(() => {
-    vi.clearAllMocks()
-  })
+    vi.clearAllMocks();
+  });
 
-  describe('App Initialization', () => {
-    it('should render all main components', () => {
-      render(<App />)
-      
+  describe("App Initialization", () => {
+    it("should render all main components", () => {
+      render(<App />);
+
       // Check for main layout components
-      expect(screen.getByTestId('header')).toBeInTheDocument()
-      expect(screen.getByTestId('footer')).toBeInTheDocument()
-      expect(screen.getByTestId('spectrogram-view')).toBeInTheDocument()
-    })
+      expect(screen.getByTestId("header")).toBeInTheDocument();
+      expect(screen.getByTestId("footer")).toBeInTheDocument();
+      expect(screen.getByTestId("spectrogram-view")).toBeInTheDocument();
+    });
 
-    it('should show drop zone when no audio is loaded', () => {
-      render(<App />)
-      expect(screen.getByText('Drop audio files here')).toBeInTheDocument()
-    })
+    it("should show drop zone when no audio is loaded", () => {
+      render(<App />);
+      expect(screen.getByText("Drop audio files here")).toBeInTheDocument();
+    });
 
-    it('should have all control buttons available', () => {
-      render(<App />)
-      
-      expect(screen.getByTitle('Open audio file (O)')).toBeInTheDocument()
-      expect(screen.getByTitle('Play/Pause (Space)')).toBeInTheDocument()
-      expect(screen.getByTitle('Stop (S)')).toBeInTheDocument()
-      expect(screen.getByTitle('Previous track (Ctrl+←)')).toBeInTheDocument()
-      expect(screen.getByTitle('Next track (Ctrl+→)')).toBeInTheDocument()
-      expect(screen.getByTitle('Settings (S)')).toBeInTheDocument()
-    })
-  })
+    it("should have all control buttons available", () => {
+      render(<App />);
 
-  describe('Audio File Loading', () => {
-    it('should handle file loading through UI', () => {
-      render(<App />)
-      
-      const fileButton = screen.getByTitle('Open audio file (O)')
-      expect(fileButton).toBeInTheDocument()
-      
+      expect(screen.getByTitle("Open audio file (O)")).toBeInTheDocument();
+      expect(screen.getByTitle("Play/Pause (Space)")).toBeInTheDocument();
+      expect(screen.getByTitle("Stop (S)")).toBeInTheDocument();
+      expect(screen.getByTitle("Previous track (Ctrl+←)")).toBeInTheDocument();
+      expect(screen.getByTitle("Next track (Ctrl+→)")).toBeInTheDocument();
+      expect(screen.getByTitle("Settings (S)")).toBeInTheDocument();
+    });
+  });
+
+  describe("Audio File Loading", () => {
+    it("should handle file loading through UI", () => {
+      render(<App />);
+
+      const fileButton = screen.getByTitle("Open audio file (O)");
+      expect(fileButton).toBeInTheDocument();
+
       // Mock file input functionality
-      const fileInput = document.createElement('input')
-      fileInput.type = 'file'
-      fileInput.accept = 'audio/*'
-      expect(fileInput).toBeInTheDocument()
-    })
-  })
+      const fileInput = document.createElement("input");
+      fileInput.type = "file";
+      fileInput.accept = "audio/*";
+      expect(fileInput).toBeInTheDocument();
+    });
+  });
 
-  describe('Playback Controls', () => {
-    it('should have all playback controls present', () => {
-      render(<App />)
-      
-      expect(screen.getByTestId('play-pause-button')).toBeInTheDocument()
-      expect(screen.getByTestId('stop-button')).toBeInTheDocument()
-      expect(screen.getByTestId('previous-button')).toBeInTheDocument()
-      expect(screen.getByTestId('next-button')).toBeInTheDocument()
-      expect(screen.getByTestId('volume-control')).toBeInTheDocument()
-      expect(screen.getByTestId('progress-bar')).toBeInTheDocument()
-    })
-  })
+  describe("Playback Controls", () => {
+    it("should have all playback controls present", () => {
+      render(<App />);
 
-  describe('Settings Panel', () => {
-    it('should open settings panel when settings button is clicked', () => {
-      render(<App />)
-      
-      const settingsButton = screen.getByTitle('Settings (S)')
-      expect(settingsButton).toBeInTheDocument()
-    })
-  })
+      expect(screen.getByTestId("play-pause-button")).toBeInTheDocument();
+      expect(screen.getByTestId("stop-button")).toBeInTheDocument();
+      expect(screen.getByTestId("previous-button")).toBeInTheDocument();
+      expect(screen.getByTestId("next-button")).toBeInTheDocument();
+      expect(screen.getByTestId("volume-control")).toBeInTheDocument();
+      expect(screen.getByTestId("progress-bar")).toBeInTheDocument();
+    });
+  });
 
-  describe('Spectrogram Display', () => {
-    it('should render spectrogram canvas', () => {
-      render(<App />)
-      
-      const canvas = document.querySelector('canvas')
-      expect(canvas).toBeInTheDocument()
-    })
+  describe("Settings Panel", () => {
+    it("should open settings panel when settings button is clicked", () => {
+      render(<App />);
 
-    it('should show legend when enabled', () => {
-      render(<App />)
-      
+      const settingsButton = screen.getByTitle("Settings (S)");
+      expect(settingsButton).toBeInTheDocument();
+    });
+  });
+
+  describe("Spectrogram Display", () => {
+    it("should render spectrogram canvas", () => {
+      render(<App />);
+
+      const canvas = document.querySelector("canvas");
+      expect(canvas).toBeInTheDocument();
+    });
+
+    it("should show legend when enabled", () => {
+      render(<App />);
+
       // Legend should be visible by default
-      const legend = screen.getByTestId('spectrogram-legend')
-      expect(legend).toBeInTheDocument()
-    })
-  })
-})
+      const legend = screen.getByTestId("spectrogram-legend");
+      expect(legend).toBeInTheDocument();
+    });
+  });
+});

--- a/react-spectrogram/src/components/__tests__/Layout.test.tsx
+++ b/react-spectrogram/src/components/__tests__/Layout.test.tsx
@@ -1,9 +1,9 @@
-import { render, screen } from '@testing-library/react'
-import { describe, it, expect, vi } from 'vitest'
-import App from '../../App'
+import { render, screen } from "@testing-library/react";
+import { describe, it, expect, vi } from "vitest";
+import App from "../../App";
 
 // Mock the stores and hooks
-vi.mock('../../stores/audioStore', () => ({
+vi.mock("../../stores/audioStore", () => ({
   useAudioStore: () => ({
     currentTrack: null,
     playlist: [],
@@ -19,10 +19,16 @@ vi.mock('../../stores/audioStore', () => ({
     isMuted: false,
     isLive: false,
     isMicrophoneActive: false,
-  })
-}))
+    shuffle: false,
+    loopMode: "off",
+    setShuffle: vi.fn(),
+    setLoopMode: vi.fn(),
+    nextTrack: vi.fn(),
+    previousTrack: vi.fn(),
+  }),
+}));
 
-vi.mock('../../stores/uiStore', () => ({
+vi.mock("../../stores/uiStore", () => ({
   useUIStore: () => ({
     isMobile: false,
     metadataPanelOpen: false,
@@ -34,25 +40,25 @@ vi.mock('../../stores/uiStore', () => ({
     setSettingsPanelOpen: vi.fn(),
     setShortcutsHelpOpen: vi.fn(),
     toggleShortcutsHelp: vi.fn(),
-  })
-}))
+  }),
+}));
 
-vi.mock('../../stores/settingsStore', () => ({
+vi.mock("../../stores/settingsStore", () => ({
   useSettingsStore: () => ({
-    theme: 'dark',
+    theme: "dark",
     updateSettings: vi.fn(),
-  })
-}))
+  }),
+}));
 
-vi.mock('../../hooks/useKeyboardShortcuts', () => ({
+vi.mock("../../hooks/useKeyboardShortcuts", () => ({
   useKeyboardShortcuts: vi.fn(),
-}))
+}));
 
-vi.mock('../../hooks/useScreenSize', () => ({
+vi.mock("../../hooks/useScreenSize", () => ({
   useScreenSize: () => ({ isMobile: false, isTablet: false }),
-}))
+}));
 
-vi.mock('../../hooks/useAudioFile', () => ({
+vi.mock("../../hooks/useAudioFile", () => ({
   useAudioFile: () => ({
     playTrack: vi.fn(),
     pausePlayback: vi.fn(),
@@ -61,91 +67,91 @@ vi.mock('../../hooks/useAudioFile', () => ({
     seekTo: vi.fn(),
     setAudioVolume: vi.fn(),
     toggleMute: vi.fn(),
-  })
-}))
+  }),
+}));
 
-vi.mock('../../utils/wasm', () => ({
+vi.mock("../../utils/wasm", () => ({
   initWASM: vi.fn().mockResolvedValue({}),
-}))
+}));
 
-describe('Layout System', () => {
-  it('renders the app with proper layout structure', () => {
-    render(<App />)
-    
+describe("Layout System", () => {
+  it("renders the app with proper layout structure", () => {
+    render(<App />);
+
     // Check that the main app container has the correct layout class
-    const appContainer = screen.getByTestId('app-container')
-    expect(appContainer).toHaveClass('app-layout')
-  })
+    const appContainer = screen.getByTestId("app-container");
+    expect(appContainer).toHaveClass("app-layout");
+  });
 
-  it('renders the header', () => {
-    render(<App />)
-    
-    const header = screen.getByTestId('header')
-    expect(header).toBeInTheDocument()
-  })
+  it("renders the header", () => {
+    render(<App />);
 
-  it('renders the footer controls with proper height', () => {
-    render(<App />)
-    
-    const footer = screen.getByTestId('footer')
-    expect(footer).toBeInTheDocument()
-    expect(footer).toHaveClass('footer-controls')
-  })
+    const header = screen.getByTestId("header");
+    expect(header).toBeInTheDocument();
+  });
 
-  it('renders the spectrogram view', () => {
-    render(<App />)
-    
-    const spectrogramView = screen.getByTestId('spectrogram-view')
-    expect(spectrogramView).toBeInTheDocument()
-  })
+  it("renders the footer controls with proper height", () => {
+    render(<App />);
 
-  it('renders the playlist panel by default', () => {
-    render(<App />)
-    
+    const footer = screen.getByTestId("footer");
+    expect(footer).toBeInTheDocument();
+    expect(footer).toHaveClass("footer-controls");
+  });
+
+  it("renders the spectrogram view", () => {
+    render(<App />);
+
+    const spectrogramView = screen.getByTestId("spectrogram-view");
+    expect(spectrogramView).toBeInTheDocument();
+  });
+
+  it("renders the playlist panel by default", () => {
+    render(<App />);
+
     // The playlist panel should be visible by default
-    const playlistPanel = screen.getByTestId('playlist-panel')
-    expect(playlistPanel).toBeInTheDocument()
-  })
+    const playlistPanel = screen.getByTestId("playlist-panel");
+    expect(playlistPanel).toBeInTheDocument();
+  });
 
-  it('does not render metadata panel by default', () => {
-    render(<App />)
-    
+  it("does not render metadata panel by default", () => {
+    render(<App />);
+
     // The metadata panel should not be visible by default
-    const metadataPanel = screen.queryByTestId('metadata-panel')
-    expect(metadataPanel).not.toBeInTheDocument()
-  })
+    const metadataPanel = screen.queryByTestId("metadata-panel");
+    expect(metadataPanel).not.toBeInTheDocument();
+  });
 
-  it('renders transport controls in footer', () => {
-    render(<App />)
-    
+  it("renders transport controls in footer", () => {
+    render(<App />);
+
     // Check for transport control buttons
-    expect(screen.getByTestId('play-pause-button')).toBeInTheDocument()
-    expect(screen.getByTestId('previous-track-button')).toBeInTheDocument()
-    expect(screen.getByTestId('next-track-button')).toBeInTheDocument()
-    expect(screen.getByTestId('stop-button')).toBeInTheDocument()
-  })
+    expect(screen.getByTestId("play-pause-button")).toBeInTheDocument();
+    expect(screen.getByTestId("previous-track-button")).toBeInTheDocument();
+    expect(screen.getByTestId("next-track-button")).toBeInTheDocument();
+    expect(screen.getByTestId("stop-button")).toBeInTheDocument();
+  });
 
-  it('renders volume controls in footer', () => {
-    render(<App />)
-    
+  it("renders volume controls in footer", () => {
+    render(<App />);
+
     // Check for volume controls
-    expect(screen.getByTestId('mute-button')).toBeInTheDocument()
-    expect(screen.getByTestId('volume-slider')).toBeInTheDocument()
-  })
+    expect(screen.getByTestId("mute-button")).toBeInTheDocument();
+    expect(screen.getByTestId("volume-slider")).toBeInTheDocument();
+  });
 
-  it('renders progress bar in footer', () => {
-    render(<App />)
-    
+  it("renders progress bar in footer", () => {
+    render(<App />);
+
     // Check for progress bar
-    expect(screen.getByTestId('progress-bar')).toBeInTheDocument()
-    expect(screen.getByTestId('progress-fill')).toBeInTheDocument()
-  })
+    expect(screen.getByTestId("progress-bar")).toBeInTheDocument();
+    expect(screen.getByTestId("progress-fill")).toBeInTheDocument();
+  });
 
-  it('renders time display in footer', () => {
-    render(<App />)
-    
+  it("renders time display in footer", () => {
+    render(<App />);
+
     // Check for time display
-    expect(screen.getByTestId('current-time')).toBeInTheDocument()
-    expect(screen.getByTestId('total-duration')).toBeInTheDocument()
-  })
-})
+    expect(screen.getByTestId("current-time")).toBeInTheDocument();
+    expect(screen.getByTestId("total-duration")).toBeInTheDocument();
+  });
+});

--- a/react-spectrogram/src/components/__tests__/PlaybackControls.test.tsx
+++ b/react-spectrogram/src/components/__tests__/PlaybackControls.test.tsx
@@ -1,9 +1,9 @@
-import { render, screen } from '@testing-library/react'
-import { describe, it, expect, vi, beforeEach } from 'vitest'
-import App from '../../App'
+import { render, screen } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import App from "../../App";
 
 // Mock the audio hooks
-vi.mock('../../hooks/useAudioFile', () => ({
+vi.mock("../../hooks/useAudioFile", () => ({
   useAudioFile: () => ({
     isLoading: false,
     error: null,
@@ -19,10 +19,10 @@ vi.mock('../../hooks/useAudioFile', () => ({
     getTimeData: vi.fn(() => new Uint8Array(1024)),
     cleanup: vi.fn(),
     initAudioContext: vi.fn(),
-  })
-}))
+  }),
+}));
 
-vi.mock('../../hooks/useMicrophone', () => ({
+vi.mock("../../hooks/useMicrophone", () => ({
   useMicrophone: () => ({
     isInitialized: false,
     isRequestingPermission: false,
@@ -38,19 +38,19 @@ vi.mock('../../hooks/useMicrophone', () => ({
     stopAnalysis: vi.fn(),
     getInputLevel: vi.fn(),
     initAudioContext: vi.fn(),
-  })
-}))
+  }),
+}));
 
-vi.mock('../../hooks/useKeyboardShortcuts', () => ({
-  useKeyboardShortcuts: vi.fn()
-}))
+vi.mock("../../hooks/useKeyboardShortcuts", () => ({
+  useKeyboardShortcuts: vi.fn(),
+}));
 
-vi.mock('../../hooks/useScreenSize', () => ({
-  useScreenSize: () => ({ isMobile: false, isTablet: false })
-}))
+vi.mock("../../hooks/useScreenSize", () => ({
+  useScreenSize: () => ({ isMobile: false, isTablet: false }),
+}));
 
 // Mock the stores
-vi.mock('../../stores/audioStore', () => ({
+vi.mock("../../stores/audioStore", () => ({
   useAudioStore: () => ({
     isPlaying: false,
     isPaused: false,
@@ -65,6 +65,10 @@ vi.mock('../../stores/audioStore', () => ({
     isLive: false,
     isMicrophoneActive: false,
     inputDevice: null,
+    shuffle: false,
+    loopMode: "off",
+    setShuffle: vi.fn(),
+    setLoopMode: vi.fn(),
     addToPlaylist: vi.fn(),
     setCurrentTrack: vi.fn(),
     setPlaying: vi.fn(),
@@ -85,10 +89,10 @@ vi.mock('../../stores/audioStore', () => ({
     toggleMute: vi.fn(),
     seekTo: vi.fn(),
     updateVolume: vi.fn(),
-  })
-}))
+  }),
+}));
 
-vi.mock('../../stores/uiStore', () => ({
+vi.mock("../../stores/uiStore", () => ({
   useUIStore: () => ({
     metadataPanelOpen: false,
     playlistPanelOpen: false,
@@ -110,17 +114,17 @@ vi.mock('../../stores/uiStore', () => ({
     toggleShortcutsHelp: vi.fn(),
     closeAllPanels: vi.fn(),
     updateScreenSize: vi.fn(),
-  })
-}))
+  }),
+}));
 
-vi.mock('../../stores/settingsStore', () => ({
+vi.mock("../../stores/settingsStore", () => ({
   useSettingsStore: () => ({
-    theme: 'dark',
-    amplitudeScale: 'db',
-    frequencyScale: 'logarithmic',
-    resolution: 'medium',
+    theme: "dark",
+    amplitudeScale: "db",
+    frequencyScale: "logarithmic",
+    resolution: "medium",
     refreshRate: 60,
-    colormap: 'viridis',
+    colormap: "viridis",
     showLegend: true,
     setTheme: vi.fn(),
     setAmplitudeScale: vi.fn(),
@@ -133,39 +137,39 @@ vi.mock('../../stores/settingsStore', () => ({
     resetToDefaults: vi.fn(),
     loadFromStorage: vi.fn(),
     saveToStorage: vi.fn(),
-  })
-}))
+  }),
+}));
 
-describe('PlaybackControls', () => {
+describe("PlaybackControls", () => {
   beforeEach(() => {
-    vi.clearAllMocks()
-  })
+    vi.clearAllMocks();
+  });
 
-  it('should render playback controls', async () => {
-    render(<App />)
-    
+  it("should render playback controls", async () => {
+    render(<App />);
+
     // Check that playback controls are present
-    expect(screen.getByTestId('play-pause-button')).toBeInTheDocument()
-    expect(screen.getByTestId('stop-button')).toBeInTheDocument()
-    expect(screen.getByTestId('previous-track-button')).toBeInTheDocument()
-    expect(screen.getByTestId('next-track-button')).toBeInTheDocument()
-    expect(screen.getByTestId('volume-slider')).toBeInTheDocument()
-    expect(screen.getByTestId('mute-button')).toBeInTheDocument()
-  })
+    expect(screen.getByTestId("play-pause-button")).toBeInTheDocument();
+    expect(screen.getByTestId("stop-button")).toBeInTheDocument();
+    expect(screen.getByTestId("previous-track-button")).toBeInTheDocument();
+    expect(screen.getByTestId("next-track-button")).toBeInTheDocument();
+    expect(screen.getByTestId("volume-slider")).toBeInTheDocument();
+    expect(screen.getByTestId("mute-button")).toBeInTheDocument();
+  });
 
-  it('should show time display', async () => {
-    render(<App />)
-    
+  it("should show time display", async () => {
+    render(<App />);
+
     // Check that time display is present
-    expect(screen.getByTestId('current-time')).toBeInTheDocument()
-    expect(screen.getByTestId('total-duration')).toBeInTheDocument()
-  })
+    expect(screen.getByTestId("current-time")).toBeInTheDocument();
+    expect(screen.getByTestId("total-duration")).toBeInTheDocument();
+  });
 
-  it('should show progress bar', async () => {
-    render(<App />)
-    
+  it("should show progress bar", async () => {
+    render(<App />);
+
     // Check that progress bar is present
-    expect(screen.getByTestId('progress-bar')).toBeInTheDocument()
-    expect(screen.getByTestId('progress-fill')).toBeInTheDocument()
-  })
-})
+    expect(screen.getByTestId("progress-bar")).toBeInTheDocument();
+    expect(screen.getByTestId("progress-fill")).toBeInTheDocument();
+  });
+});

--- a/react-spectrogram/src/components/__tests__/UpcomingTrackInfo.test.tsx
+++ b/react-spectrogram/src/components/__tests__/UpcomingTrackInfo.test.tsx
@@ -13,6 +13,12 @@ const mockState: any = {
   currentTrack: null,
   playlist: [],
   currentTrackIndex: 0,
+  shuffle: false,
+  loopMode: "off",
+  setShuffle: vi.fn(),
+  setLoopMode: vi.fn(),
+  nextTrack: vi.fn(),
+  previousTrack: vi.fn(),
 };
 
 vi.mock("../../stores/audioStore", () => ({

--- a/react-spectrogram/src/components/layout/Footer.tsx
+++ b/react-spectrogram/src/components/layout/Footer.tsx
@@ -39,6 +39,12 @@ export const Footer: React.FC = () => {
     currentTrack,
     playlist,
     currentTrackIndex,
+    shuffle,
+    loopMode,
+    setShuffle,
+    setLoopMode,
+    nextTrack: nextTrackAction,
+    previousTrack: previousTrackAction,
   } = useAudioStore();
 
   const { isMobile, isTablet } = useScreenSize();
@@ -129,6 +135,16 @@ export const Footer: React.FC = () => {
     audioFile.toggleMute();
   }, [audioFile]);
 
+  const toggleShuffle = useCallback(() => {
+    setShuffle(!shuffle);
+  }, [shuffle, setShuffle]);
+
+  const toggleLoopMode = useCallback(() => {
+    const next =
+      loopMode === "off" ? "all" : loopMode === "all" ? "one" : "off";
+    setLoopMode(next);
+  }, [loopMode, setLoopMode]);
+
   // Transport controls
   const togglePlayPause = useCallback(() => {
     if (isStopped) {
@@ -149,25 +165,12 @@ export const Footer: React.FC = () => {
   }, [audioFile]);
 
   const previousTrack = useCallback(() => {
-    if (playlist.length === 0) return;
-
-    const prevIndex =
-      currentTrackIndex <= 0 ? playlist.length - 1 : currentTrackIndex - 1;
-    const prevTrack = playlist[prevIndex];
-    if (prevTrack) {
-      audioFile.playTrack(prevTrack);
-    }
-  }, [playlist, currentTrackIndex, audioFile]);
+    previousTrackAction();
+  }, [previousTrackAction]);
 
   const nextTrack = useCallback(() => {
-    if (playlist.length === 0) return;
-
-    const nextIndex = (currentTrackIndex + 1) % playlist.length;
-    const nextTrack = playlist[nextIndex];
-    if (nextTrack) {
-      audioFile.playTrack(nextTrack);
-    }
-  }, [playlist, currentTrackIndex, audioFile]);
+    nextTrackAction();
+  }, [nextTrackAction]);
 
   // Determine layout configuration based on screen size
   const layoutConfig = useMemo(() => {
@@ -458,27 +461,33 @@ export const Footer: React.FC = () => {
           {layoutConfig.showAdditionalControls && (
             <div className="flex items-center gap-1">
               <button
+                data-testid="shuffle-button"
                 className={cn(
                   "p-1 rounded transition-colors duration-200",
                   "hover:bg-neutral-800 active:bg-neutral-700",
                   "text-neutral-400 hover:text-neutral-200",
                   "min-w-[28px] min-h-[28px] flex items-center justify-center",
+                  shuffle && "text-neutral-200 bg-neutral-700",
                 )}
                 title="Shuffle"
                 aria-label="Shuffle playlist"
+                onClick={toggleShuffle}
               >
                 <Shuffle size={16} />
               </button>
 
               <button
+                data-testid="repeat-button"
                 className={cn(
                   "p-1 rounded transition-colors duration-200",
                   "hover:bg-neutral-800 active:bg-neutral-700",
                   "text-neutral-400 hover:text-neutral-200",
                   "min-w-[28px] min-h-[28px] flex items-center justify-center",
+                  loopMode !== "off" && "text-neutral-200 bg-neutral-700",
                 )}
                 title="Repeat"
                 aria-label="Repeat playlist"
+                onClick={toggleLoopMode}
               >
                 <Repeat size={16} />
               </button>

--- a/react-spectrogram/src/stores/__tests__/shuffle.test.ts
+++ b/react-spectrogram/src/stores/__tests__/shuffle.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { useAudioStore } from "../audioStore";
+import type { AudioTrack } from "@/types";
+
+vi.mock("@/utils/audioPlayer", () => ({
+  audioPlayer: {
+    playTrack: vi.fn().mockResolvedValue(undefined),
+    stopPlayback: vi.fn(),
+    pausePlayback: vi.fn(),
+    resumePlayback: vi.fn(),
+    toggleMute: vi.fn(),
+    seekTo: vi.fn(),
+    setVolume: vi.fn(),
+  },
+}));
+
+describe("audioStore shuffle", () => {
+  const tracks: AudioTrack[] = [1, 2, 3].map((n) => ({
+    id: `${n}`,
+    file: new File([], `${n}.mp3`),
+    metadata: { title: `${n}`, artist: "a", album: "b", duration: 0 },
+    duration: 0,
+    url: `${n}`,
+  }));
+
+  beforeEach(() => {
+    useAudioStore.setState({
+      playlist: tracks,
+      currentTrackIndex: 0,
+      currentTrack: tracks[0],
+      shuffle: false,
+    });
+    vi.clearAllMocks();
+  });
+
+  it("shuffles through tracks without repetition and supports previous", async () => {
+    const store = useAudioStore.getState();
+    store.setShuffle(true);
+    vi.spyOn(Math, "random").mockReturnValueOnce(0.1).mockReturnValueOnce(0.9);
+
+    await store.nextTrack();
+    expect(useAudioStore.getState().currentTrackIndex).toBe(1);
+    await store.nextTrack();
+    expect(useAudioStore.getState().currentTrackIndex).toBe(2);
+    await store.previousTrack();
+    expect(useAudioStore.getState().currentTrackIndex).toBe(1);
+  });
+});

--- a/react-spectrogram/src/stores/audioStore.ts
+++ b/react-spectrogram/src/stores/audioStore.ts
@@ -1,37 +1,39 @@
-import { create } from 'zustand'
-import { subscribeWithSelector } from 'zustand/middleware'
-import { AudioState, AudioTrack } from '@/types'
-import { playbackEngine } from '@/utils/PlaybackEngine'
-import { audioPlayer } from '@/utils/audioPlayer'
-import { revokeTrackUrl } from '@/utils/audio'
+import { create } from "zustand";
+import { subscribeWithSelector } from "zustand/middleware";
+import { AudioState, AudioTrack } from "@/types";
+import { playbackEngine } from "@/utils/PlaybackEngine";
+import { audioPlayer } from "@/utils/audioPlayer";
+import { revokeTrackUrl } from "@/utils/audio";
 
 interface AudioStore extends AudioState {
   // Actions
-  setPlaying: (playing: boolean) => void
-  setPaused: (paused: boolean) => void
-  setStopped: (stopped: boolean) => void
-  setCurrentTime: (time: number) => void
-  setDuration: (duration: number) => void
-  setVolume: (volume: number) => void
-  setMuted: (muted: boolean) => void
-  setCurrentTrack: (track: AudioTrack | null) => void
-  setPlaylist: (tracks: AudioTrack[]) => void
-  addToPlaylist: (track: AudioTrack) => void
-  updateTrack: (id: string, updates: Partial<AudioTrack>) => void
-  removeFromPlaylist: (index: number) => void
-  reorderPlaylist: (fromIndex: number, toIndex: number) => void
-  setCurrentTrackIndex: (index: number) => void
-  setLive: (live: boolean) => void
-  setMicrophoneActive: (active: boolean) => void
-  setInputDevice: (device: string | null) => void
-  nextTrack: () => Promise<void>
-  previousTrack: () => Promise<void>
-  playTrack: (index: number) => Promise<void>
-  stopPlayback: () => void
-  togglePlayPause: () => Promise<void>
-  toggleMute: () => void
-  seekTo: (time: number) => void
-  updateVolume: (volume: number) => void
+  setPlaying: (playing: boolean) => void;
+  setPaused: (paused: boolean) => void;
+  setStopped: (stopped: boolean) => void;
+  setCurrentTime: (time: number) => void;
+  setDuration: (duration: number) => void;
+  setVolume: (volume: number) => void;
+  setMuted: (muted: boolean) => void;
+  setCurrentTrack: (track: AudioTrack | null) => void;
+  setPlaylist: (tracks: AudioTrack[]) => void;
+  addToPlaylist: (track: AudioTrack) => void;
+  updateTrack: (id: string, updates: Partial<AudioTrack>) => void;
+  removeFromPlaylist: (index: number) => void;
+  reorderPlaylist: (fromIndex: number, toIndex: number) => void;
+  setCurrentTrackIndex: (index: number) => void;
+  setLive: (live: boolean) => void;
+  setMicrophoneActive: (active: boolean) => void;
+  setInputDevice: (device: string | null) => void;
+  setShuffle: (shuffle: boolean) => void;
+  setLoopMode: (mode: "off" | "one" | "all") => void;
+  nextTrack: () => Promise<void>;
+  previousTrack: () => Promise<void>;
+  playTrack: (index: number) => Promise<void>;
+  stopPlayback: () => void;
+  togglePlayPause: () => Promise<void>;
+  toggleMute: () => void;
+  seekTo: (time: number) => void;
+  updateVolume: (volume: number) => void;
 }
 
 const initialState: AudioState = {
@@ -48,177 +50,247 @@ const initialState: AudioState = {
   isLive: false,
   isMicrophoneActive: false,
   inputDevice: null,
-}
+  shuffle: false,
+  loopMode: "off",
+};
 
 export const useAudioStore = create<AudioStore>()(
-  subscribeWithSelector((set, get) => ({
-    ...initialState,
+  subscribeWithSelector((set, get) => {
+    let shuffleHistory: number[] = [];
+    let historyIndex = -1;
+    return {
+      ...initialState,
 
-    setPlaying: (playing) => set({ isPlaying: playing, isPaused: !playing, isStopped: false }),
-    setPaused: (paused) => set({ isPaused: paused, isPlaying: !paused }),
-    setStopped: (stopped) => set({ isStopped: stopped, isPlaying: false, isPaused: false }),
-    setCurrentTime: (time) => set({ currentTime: Math.max(0, Math.min(time, get().duration)) }),
-    setDuration: (duration) => set({ duration: Math.max(0, duration) }),
-    setVolume: (volume) => set({ volume: Math.max(0, Math.min(1, volume)) }),
-    setMuted: (muted) => set({ isMuted: muted }),
-    setCurrentTrack: (track) => set({ currentTrack: track }),
-    setPlaylist: (tracks) => set({ playlist: tracks }),
-    
-    addToPlaylist: (track) => {
-      const { playlist } = get()
-      set({ playlist: [...playlist, track] })
-    },
+      setPlaying: (playing) =>
+        set({ isPlaying: playing, isPaused: !playing, isStopped: false }),
+      setPaused: (paused) => set({ isPaused: paused, isPlaying: !paused }),
+      setStopped: (stopped) =>
+        set({ isStopped: stopped, isPlaying: false, isPaused: false }),
+      setCurrentTime: (time) =>
+        set({ currentTime: Math.max(0, Math.min(time, get().duration)) }),
+      setDuration: (duration) => set({ duration: Math.max(0, duration) }),
+      setVolume: (volume) => set({ volume: Math.max(0, Math.min(1, volume)) }),
+      setMuted: (muted) => set({ isMuted: muted }),
+      setCurrentTrack: (track) => set({ currentTrack: track }),
+      setPlaylist: (tracks) => set({ playlist: tracks }),
 
-    updateTrack: (id, updates) => {
-      const { playlist, currentTrack } = get()
-      const index = playlist.findIndex(t => t.id === id)
-      if (index === -1) return
-      const updatedTrack = { ...playlist[index], ...updates }
-      const newPlaylist = [...playlist]
-      newPlaylist[index] = updatedTrack
-      const newState: Partial<AudioState> & { playlist: AudioTrack[] } = {
-        playlist: newPlaylist,
-      }
-      if (currentTrack && currentTrack.id === id) {
-        newState.currentTrack = updatedTrack
-      }
-      set(newState)
-    },
+      addToPlaylist: (track) => {
+        const { playlist } = get();
+        set({ playlist: [...playlist, track] });
+      },
 
-    removeFromPlaylist: (index) => {
-      const { playlist, currentTrackIndex } = get()
-      const trackToRemove = playlist[index]
-      const newPlaylist = playlist.filter((_, i) => i !== index)
-      let newCurrentIndex = currentTrackIndex
-
-      if (index <= currentTrackIndex && currentTrackIndex > 0) {
-        newCurrentIndex = currentTrackIndex - 1
-      }
-
-      set({
-        playlist: newPlaylist,
-        currentTrackIndex: newCurrentIndex,
-        currentTrack: newCurrentIndex >= 0 ? newPlaylist[newCurrentIndex] : null
-      })
-
-      if (trackToRemove) {
-        revokeTrackUrl(trackToRemove)
-      }
-    },
-    
-    reorderPlaylist: (fromIndex, toIndex) => {
-      const { playlist } = get()
-      const newPlaylist = [...playlist]
-      const [movedTrack] = newPlaylist.splice(fromIndex, 1)
-      newPlaylist.splice(toIndex, 0, movedTrack)
-      
-      let newCurrentIndex = get().currentTrackIndex
-      if (fromIndex === newCurrentIndex) {
-        newCurrentIndex = toIndex
-      } else if (fromIndex < newCurrentIndex && toIndex >= newCurrentIndex) {
-        newCurrentIndex--
-      } else if (fromIndex > newCurrentIndex && toIndex <= newCurrentIndex) {
-        newCurrentIndex++
-      }
-      
-      set({ 
-        playlist: newPlaylist,
-        currentTrackIndex: newCurrentIndex,
-        currentTrack: newCurrentIndex >= 0 ? newPlaylist[newCurrentIndex] : null
-      })
-    },
-    
-    setCurrentTrackIndex: (index) => {
-      const { playlist } = get()
-      const track = index >= 0 && index < playlist.length ? playlist[index] : null
-      set({ currentTrackIndex: index, currentTrack: track })
-    },
-    
-    setLive: (live) => set({ isLive: live }),
-    setMicrophoneActive: (active) => set({ isMicrophoneActive: active }),
-    setInputDevice: (device) => set({ inputDevice: device }),
-    
-    nextTrack: async () => {
-      const { playlist, currentTrackIndex } = get()
-      if (playlist.length === 0) return
-
-      const nextIndex = (currentTrackIndex + 1) % playlist.length
-      const nextTrack = playlist[nextIndex]
-      if (nextTrack) {
-        set({
-          currentTrackIndex: nextIndex,
-          currentTrack: nextTrack,
-          isPlaying: true,
-          isPaused: false,
-          isStopped: false,
-          currentTime: 0
-        })
-        // Actually play the track
-        await audioPlayer.playTrack(nextTrack)
-      }
-    },
-    previousTrack: async () => {
-      const { playlist, currentTrackIndex } = get()
-      if (playlist.length === 0) return
-
-      const prevIndex = currentTrackIndex <= 0 ? playlist.length - 1 : currentTrackIndex - 1
-      const prevTrack = playlist[prevIndex]
-      if (prevTrack) {
-        set({
-          currentTrackIndex: prevIndex,
-          currentTrack: prevTrack,
-          isPlaying: true,
-          isPaused: false,
-          isStopped: false,
-          currentTime: 0
-        })
-        // Actually play the track
-        await audioPlayer.playTrack(prevTrack)
-      }
-    },
-    playTrack: async (index) => {
-      const { playlist } = get()
-      if (index < 0 || index >= playlist.length) return
-
-      const track = playlist[index]
-      set({
-        currentTrackIndex: index,
-        currentTrack: track,
-        isPlaying: true,
-        isPaused: false,
-        isStopped: false,
-        currentTime: 0
-      })
-      // Actually play the track
-      await audioPlayer.playTrack(track)
-    },
-
-    stopPlayback: () => {
-      audioPlayer.stopPlayback()
-    },
-    togglePlayPause: async () => {
-      const { isPlaying, isStopped, currentTrack } = get()
-      if (isStopped) {
-        if (currentTrack) {
-          await audioPlayer.playTrack(currentTrack)
+      updateTrack: (id, updates) => {
+        const { playlist, currentTrack } = get();
+        const index = playlist.findIndex((t) => t.id === id);
+        if (index === -1) return;
+        const updatedTrack = { ...playlist[index], ...updates };
+        const newPlaylist = [...playlist];
+        newPlaylist[index] = updatedTrack;
+        const newState: Partial<AudioState> & { playlist: AudioTrack[] } = {
+          playlist: newPlaylist,
+        };
+        if (currentTrack && currentTrack.id === id) {
+          newState.currentTrack = updatedTrack;
         }
-      } else if (isPlaying) {
-        audioPlayer.pausePlayback()
-      } else {
-        await audioPlayer.resumePlayback()
-      }
-    },
+        set(newState);
+      },
 
-    toggleMute: () => {
-      audioPlayer.toggleMute()
-    },
+      removeFromPlaylist: (index) => {
+        const { playlist, currentTrackIndex } = get();
+        const trackToRemove = playlist[index];
+        const newPlaylist = playlist.filter((_, i) => i !== index);
+        let newCurrentIndex = currentTrackIndex;
 
-    seekTo: (time) => {
-      audioPlayer.seekTo(time)
-    },
+        if (index <= currentTrackIndex && currentTrackIndex > 0) {
+          newCurrentIndex = currentTrackIndex - 1;
+        }
 
-    updateVolume: (volume) => {
-      audioPlayer.setVolume(volume)
-    },
-  }))
-)
+        set({
+          playlist: newPlaylist,
+          currentTrackIndex: newCurrentIndex,
+          currentTrack:
+            newCurrentIndex >= 0 ? newPlaylist[newCurrentIndex] : null,
+        });
+
+        if (trackToRemove) {
+          revokeTrackUrl(trackToRemove);
+        }
+      },
+
+      reorderPlaylist: (fromIndex, toIndex) => {
+        const { playlist } = get();
+        const newPlaylist = [...playlist];
+        const [movedTrack] = newPlaylist.splice(fromIndex, 1);
+        newPlaylist.splice(toIndex, 0, movedTrack);
+
+        let newCurrentIndex = get().currentTrackIndex;
+        if (fromIndex === newCurrentIndex) {
+          newCurrentIndex = toIndex;
+        } else if (fromIndex < newCurrentIndex && toIndex >= newCurrentIndex) {
+          newCurrentIndex--;
+        } else if (fromIndex > newCurrentIndex && toIndex <= newCurrentIndex) {
+          newCurrentIndex++;
+        }
+
+        set({
+          playlist: newPlaylist,
+          currentTrackIndex: newCurrentIndex,
+          currentTrack:
+            newCurrentIndex >= 0 ? newPlaylist[newCurrentIndex] : null,
+        });
+      },
+
+      setCurrentTrackIndex: (index) => {
+        const { playlist } = get();
+        const track =
+          index >= 0 && index < playlist.length ? playlist[index] : null;
+        set({ currentTrackIndex: index, currentTrack: track });
+      },
+
+      setLive: (live) => set({ isLive: live }),
+      setMicrophoneActive: (active) => set({ isMicrophoneActive: active }),
+      setInputDevice: (device) => set({ inputDevice: device }),
+      setShuffle: (shuffle) => {
+        const current = get().currentTrackIndex;
+        shuffleHistory = shuffle && current >= 0 ? [current] : [];
+        historyIndex = shuffleHistory.length - 1;
+        set({ shuffle });
+      },
+      setLoopMode: (mode) => set({ loopMode: mode }),
+
+      nextTrack: async () => {
+        const { playlist, currentTrackIndex, shuffle } = get();
+        if (playlist.length === 0) return;
+
+        let nextIndex = 0;
+        if (shuffle) {
+          if (historyIndex < shuffleHistory.length - 1) {
+            historyIndex++;
+            nextIndex = shuffleHistory[historyIndex];
+          } else {
+            const available = playlist
+              .map((_, i) => i)
+              .filter(
+                (i) => i !== currentTrackIndex && !shuffleHistory.includes(i),
+              );
+            if (available.length === 0) {
+              shuffleHistory =
+                currentTrackIndex >= 0 ? [currentTrackIndex] : [];
+              const rest = playlist
+                .map((_, i) => i)
+                .filter((i) => i !== currentTrackIndex);
+              nextIndex = rest[Math.floor(Math.random() * rest.length)];
+              shuffleHistory.push(nextIndex);
+              historyIndex = shuffleHistory.length - 1;
+            } else {
+              nextIndex =
+                available[Math.floor(Math.random() * available.length)];
+              shuffleHistory.push(nextIndex);
+              historyIndex = shuffleHistory.length - 1;
+            }
+          }
+        } else {
+          nextIndex = (currentTrackIndex + 1) % playlist.length;
+        }
+        const nextTrack = playlist[nextIndex];
+        if (nextTrack) {
+          set({
+            currentTrackIndex: nextIndex,
+            currentTrack: nextTrack,
+            isPlaying: true,
+            isPaused: false,
+            isStopped: false,
+            currentTime: 0,
+          });
+          await audioPlayer.playTrack(nextTrack);
+        }
+      },
+      previousTrack: async () => {
+        const { playlist, currentTrackIndex, shuffle } = get();
+        if (playlist.length === 0) return;
+
+        let prevIndex = 0;
+        if (shuffle) {
+          if (historyIndex > 0) {
+            historyIndex--;
+            prevIndex = shuffleHistory[historyIndex];
+          } else {
+            const available = playlist
+              .map((_, i) => i)
+              .filter((i) => i !== currentTrackIndex);
+            prevIndex = available[Math.floor(Math.random() * available.length)];
+            shuffleHistory.unshift(prevIndex);
+            historyIndex = 0;
+          }
+        } else {
+          prevIndex =
+            currentTrackIndex <= 0
+              ? playlist.length - 1
+              : currentTrackIndex - 1;
+        }
+        const prevTrack = playlist[prevIndex];
+        if (prevTrack) {
+          set({
+            currentTrackIndex: prevIndex,
+            currentTrack: prevTrack,
+            isPlaying: true,
+            isPaused: false,
+            isStopped: false,
+            currentTime: 0,
+          });
+          await audioPlayer.playTrack(prevTrack);
+        }
+      },
+      playTrack: async (index) => {
+        const { playlist, shuffle } = get();
+        if (index < 0 || index >= playlist.length) return;
+
+        const track = playlist[index];
+        if (shuffle) {
+          shuffleHistory = [
+            ...shuffleHistory.slice(0, historyIndex + 1),
+            index,
+          ];
+          historyIndex = shuffleHistory.length - 1;
+        }
+        set({
+          currentTrackIndex: index,
+          currentTrack: track,
+          isPlaying: true,
+          isPaused: false,
+          isStopped: false,
+          currentTime: 0,
+        });
+        await audioPlayer.playTrack(track);
+      },
+
+      stopPlayback: () => {
+        audioPlayer.stopPlayback();
+      },
+      togglePlayPause: async () => {
+        const { isPlaying, isStopped, currentTrack } = get();
+        if (isStopped) {
+          if (currentTrack) {
+            await audioPlayer.playTrack(currentTrack);
+          }
+        } else if (isPlaying) {
+          audioPlayer.pausePlayback();
+        } else {
+          await audioPlayer.resumePlayback();
+        }
+      },
+
+      toggleMute: () => {
+        audioPlayer.toggleMute();
+      },
+
+      seekTo: (time) => {
+        audioPlayer.seekTo(time);
+      },
+
+      updateVolume: (volume) => {
+        audioPlayer.setVolume(volume);
+      },
+    };
+  }),
+);

--- a/react-spectrogram/src/types/index.ts
+++ b/react-spectrogram/src/types/index.ts
@@ -40,7 +40,7 @@ export interface APIKeyStatus {
 
 // Artwork sources and results
 export interface ArtworkSource {
-  type: 'embedded' | 'musicbrainz' | 'acoustid' | 'filename' | 'placeholder';
+  type: "embedded" | "musicbrainz" | "acoustid" | "filename" | "placeholder";
   url?: string;
   data?: Uint8Array;
   mimeType?: string;
@@ -64,7 +64,7 @@ export interface ArtworkResult {
 export interface MusicBrainzRelease {
   id: string;
   title: string;
-  'artist-credit': Array<{
+  "artist-credit": Array<{
     name: string;
     artist?: {
       id: string;
@@ -120,10 +120,10 @@ export interface AudioTrack {
 }
 
 export interface SpectrogramSettings {
-  theme: 'dark' | 'light' | 'neon' | 'high-contrast';
-  amplitudeScale: 'linear' | 'logarithmic' | 'db';
-  frequencyScale: 'linear' | 'logarithmic';
-  resolution: 'low' | 'medium' | 'high';
+  theme: "dark" | "light" | "neon" | "high-contrast";
+  amplitudeScale: "linear" | "logarithmic" | "db";
+  frequencyScale: "linear" | "logarithmic";
+  resolution: "low" | "medium" | "high";
   refreshRate: 30 | 60;
   colormap: string;
   showLegend: boolean;
@@ -171,6 +171,8 @@ export interface AudioState {
   isLive: boolean;
   isMicrophoneActive: boolean;
   inputDevice: string | null;
+  shuffle: boolean;
+  loopMode: "off" | "one" | "all";
 }
 
 // Keyboard shortcuts
@@ -209,7 +211,7 @@ export interface SpectrogramRenderer {
 
 // Event types
 export interface SpectrogramEvent {
-  type: 'click' | 'hover' | 'drag';
+  type: "click" | "hover" | "drag";
   position: { x: number; y: number };
   frequency?: number;
   time?: number;
@@ -266,10 +268,10 @@ export interface SettingsPanelProps {
 }
 
 // Utility types
-export type Theme = 'dark' | 'light' | 'neon' | 'high-contrast';
-export type AmplitudeScale = 'linear' | 'logarithmic' | 'db';
-export type FrequencyScale = 'linear' | 'logarithmic';
-export type Resolution = 'low' | 'medium' | 'high';
+export type Theme = "dark" | "light" | "neon" | "high-contrast";
+export type AmplitudeScale = "linear" | "logarithmic" | "db";
+export type FrequencyScale = "linear" | "logarithmic";
+export type Resolution = "low" | "medium" | "high";
 export type RefreshRate = 30 | 60;
 
 // WASM types
@@ -278,7 +280,10 @@ export interface WASMModule {
     fileData: Uint8Array,
     filename: string,
   ) => WasmAudioMetadata | null;
-  compute_spectrogram: (audioData: Float32Array, sampleRate: number) => SpectrogramData;
+  compute_spectrogram: (
+    audioData: Float32Array,
+    sampleRate: number,
+  ) => SpectrogramData;
   compute_waveform: (audioData: Float32Array) => number[];
 }
 
@@ -292,7 +297,7 @@ export interface AppError {
 // Toast notification types
 export interface Toast {
   id: string;
-  type: 'success' | 'error' | 'warning' | 'info';
+  type: "success" | "error" | "warning" | "info";
   title: string;
   message?: string;
   duration?: number;

--- a/react-spectrogram/src/utils/PlaybackEngine.ts
+++ b/react-spectrogram/src/utils/PlaybackEngine.ts
@@ -275,17 +275,22 @@ class PlaybackEngine {
       setPlaying,
       setPaused,
       setStopped,
+      nextTrack,
+      loopMode,
     } = useAudioStore.getState();
 
-    const nextIndex = currentTrackIndex + 1;
-    if (nextIndex < playlist.length) {
-      // Auto-advance to the next track
-      playTrack(nextIndex);
+    if (loopMode === 'one') {
+      playTrack(currentTrackIndex);
+      return;
+    }
+
+    const isLastTrack = currentTrackIndex >= playlist.length - 1;
+    if (!isLastTrack || loopMode === 'all') {
+      nextTrack();
       return;
     }
 
     this.notify();
-    // No more tracks: ensure store reflects stopped state
     setPlaying(false);
     setPaused(false);
     setStopped(true);


### PR DESCRIPTION
## Summary
- add `shuffle` state and loop modes to audio store
- hook up shuffle/repeat buttons in the footer
- handle loop modes in playback engine
- cover new behavior with tests

## Testing
- `npm run lint` *(fails: 'contentFingerprint' is assigned a value but never used ...)*
- `npm test` *(fails: TypeError: loadFromStorage is not a function)*

------
https://chatgpt.com/codex/tasks/task_e_68a506f4c838832bb94dcf205672314c