### PR TITLE
feat: enhance loop and shuffle handling

### DIFF
--- a/react-spectrogram/src/utils/PlaybackEngine.ts
+++ b/react-spectrogram/src/utils/PlaybackEngine.ts
@@ -275,18 +275,50 @@ class PlaybackEngine {
       setPlaying,
       setPaused,
       setStopped,
-      nextTrack,
       loopMode,
+      shuffle,
     } = useAudioStore.getState();
 
-    if (loopMode === 'one') {
+    const playlistLength = playlist.length;
+    if (playlistLength === 0) {
+      this.notify();
+      setPlaying(false);
+      setPaused(false);
+      setStopped(true);
+      return;
+    }
+
+    if (loopMode === "one") {
       playTrack(currentTrackIndex);
       return;
     }
 
-    const isLastTrack = currentTrackIndex >= playlist.length - 1;
-    if (!isLastTrack || loopMode === 'all') {
-      nextTrack();
+    if (shuffle) {
+      if (playlistLength <= 1 && loopMode === "off") {
+        this.notify();
+        setPlaying(false);
+        setPaused(false);
+        setStopped(true);
+        return;
+      }
+      let nextIndex = currentTrackIndex;
+      if (playlistLength > 1) {
+        do {
+          nextIndex = Math.floor(Math.random() * playlistLength);
+        } while (nextIndex === currentTrackIndex);
+      }
+      playTrack(nextIndex);
+      return;
+    }
+
+    const isLastTrack = currentTrackIndex >= playlistLength - 1;
+    if (!isLastTrack) {
+      playTrack(currentTrackIndex + 1);
+      return;
+    }
+
+    if (loopMode === "all") {
+      playTrack(0);
       return;
     }
 


### PR DESCRIPTION
## Summary
- improve `handleEnded` with explicit loop and shuffle logic
- add comprehensive tests for loop modes and shuffle behavior

## Testing
- `npm run lint`
- `npm run test:coverage` *(fails: No "default" export is defined on the "react-hot-toast" mock and missing Playwright dependencies)*
- `npx vitest run src/utils/__tests__/PlaybackEngine.test.ts -t "auto-advances"` *(passes with unhandled EventTarget error)*

------
https://chatgpt.com/codex/tasks/task_e_68a50b19bc9c832bb0927e685decc3ad