### PR TITLE
refactor play/pause shortcut handling

### DIFF
--- a/react-spectrogram/src/components/__tests__/KeyboardShortcuts.test.tsx
+++ b/react-spectrogram/src/components/__tests__/KeyboardShortcuts.test.tsx
@@ -1,33 +1,39 @@
-import { render, screen, fireEvent, waitFor } from '@testing-library/react'
-import userEvent from '@testing-library/user-event'
-import { describe, it, expect, vi, beforeEach } from 'vitest'
-import App from '../../App'
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import App from "../../App";
 
 // Mock file input
-const createMockFile = (name: string, type: string, content: string = 'mock audio data') => {
-  return new File([content], name, { type })
-}
+const createMockFile = (
+  name: string,
+  type: string,
+  content: string = "mock audio data",
+) => {
+  return new File([content], name, { type });
+};
 
-describe('Keyboard Shortcut Functionality', () => {
-  let user: ReturnType<typeof userEvent.setup>
+describe("Keyboard Shortcut Functionality", () => {
+  let user: ReturnType<typeof userEvent.setup>;
 
   beforeEach(() => {
-    user = userEvent.setup()
-    vi.clearAllMocks()
-  })
+    user = userEvent.setup();
+    vi.clearAllMocks();
+  });
 
   const loadTestFile = async () => {
-    const file = createMockFile('test-song.mp3', 'audio/mpeg')
-    
+    const file = createMockFile("test-song.mp3", "audio/mpeg");
+
     // Mock audio context with test data
-    const mockAudioContext = global.AudioContext as any
+    const mockAudioContext = global.AudioContext as any;
     mockAudioContext.mockImplementation(() => ({
       ...mockAudioContext(),
-      decodeAudioData: vi.fn(() => Promise.resolve({
-        duration: 180, // 3 minutes
-        sampleRate: 44100,
-        getChannelData: vi.fn(() => new Float32Array(44100 * 180))
-      })),
+      decodeAudioData: vi.fn(() =>
+        Promise.resolve({
+          duration: 180, // 3 minutes
+          sampleRate: 44100,
+          getChannelData: vi.fn(() => new Float32Array(44100 * 180)),
+        }),
+      ),
       createBufferSource: vi.fn(() => ({
         connect: vi.fn(),
         start: vi.fn(),
@@ -47,500 +53,563 @@ describe('Keyboard Shortcut Functionality', () => {
         getByteFrequencyData: vi.fn(),
         getByteTimeDomainData: vi.fn(),
       })),
-    }))
+    }));
 
-    const fileInput = screen.getByTestId('file-input')
-    await user.upload(fileInput, file)
-    
+    const fileInput = screen.getByTestId("file-input");
+    await user.upload(fileInput, file);
+
     // Wait for file to be loaded
-    await waitFor(() => {
-      expect(screen.queryByText('Drop audio files here')).not.toBeInTheDocument()
-    }, { timeout: 3000 })
-  }
+    await waitFor(
+      () => {
+        expect(
+          screen.queryByText("Drop audio files here"),
+        ).not.toBeInTheDocument();
+      },
+      { timeout: 3000 },
+    );
+  };
 
-  describe('Play/Pause Shortcut (Spacebar)', () => {
-    it('should toggle playback with spacebar', async () => {
-      render(<App />)
-      await loadTestFile()
+  describe("Play/Pause Shortcuts", () => {
+    // Keys that should toggle playback
+    const playPauseKeys = [
+      { label: "Spacebar", key: " ", code: "Space" },
+      { label: "K key", key: "k", code: "KeyK" },
+    ];
 
-      // Focus the app to receive keyboard events
-      const appContainer = screen.getByTestId('app-container')
-      appContainer.focus()
+    playPauseKeys.forEach(({ label, key, code }) => {
+      it(`should toggle playback with ${label}`, async () => {
+        render(<App />);
+        await loadTestFile();
 
-      // Start playback with spacebar
-      await user.keyboard(' ')
+        // Focus the app to receive keyboard events
+        const appContainer = screen.getByTestId("app-container");
+        appContainer.focus();
+
+        // Start playback
+        await user.keyboard(key);
+        await waitFor(() => {
+          expect(screen.getByTestId("play-pause-icon")).toHaveAttribute(
+            "data-state",
+            "playing",
+          );
+        });
+
+        // Pause
+        await user.keyboard(key);
+        await waitFor(() => {
+          expect(screen.getByTestId("play-pause-icon")).toHaveAttribute(
+            "data-state",
+            "paused",
+          );
+        });
+
+        // Resume
+        await user.keyboard(key);
+        await waitFor(() => {
+          expect(screen.getByTestId("play-pause-icon")).toHaveAttribute(
+            "data-state",
+            "playing",
+          );
+        });
+      });
+
+      it(`should prevent default browser behavior for ${label}`, async () => {
+        render(<App />);
+        await loadTestFile();
+
+        const appContainer = screen.getByTestId("app-container");
+        appContainer.focus();
+
+        const preventDefaultSpy = vi.fn();
+
+        fireEvent.keyDown(appContainer, {
+          key,
+          code,
+          preventDefault: preventDefaultSpy,
+        });
+
+        expect(preventDefaultSpy).toHaveBeenCalled();
+      });
+
+      it(`should work even if play button is not clicked (${label})`, async () => {
+        render(<App />);
+        await loadTestFile();
+
+        const appContainer = screen.getByTestId("app-container");
+        appContainer.focus();
+
+        await user.keyboard(key);
+        await waitFor(() => {
+          expect(screen.getByTestId("play-pause-icon")).toHaveAttribute(
+            "data-state",
+            "playing",
+          );
+        });
+      });
+    });
+
+    it("should toggle playback when event.code is Space even if key is different", async () => {
+      render(<App />);
+      await loadTestFile();
+
+      const appContainer = screen.getByTestId("app-container");
+      appContainer.focus();
+
+      fireEvent.keyDown(appContainer, { code: "Space", key: "Spacebar" });
+
       await waitFor(() => {
-        expect(screen.getByTestId('play-pause-icon')).toHaveAttribute('data-state', 'playing')
-      })
+        expect(screen.getByTestId("play-pause-icon")).toHaveAttribute(
+          "data-state",
+          "playing",
+        );
+      });
+    });
+  });
 
-      // Pause with spacebar
-      await user.keyboard(' ')
-      await waitFor(() => {
-        expect(screen.getByTestId('play-pause-icon')).toHaveAttribute('data-state', 'paused')
-      })
+  describe("Seek Shortcuts (Arrow Keys)", () => {
+    it("should seek backward 10 seconds with left arrow", async () => {
+      render(<App />);
+      await loadTestFile();
 
-      // Resume with spacebar
-      await user.keyboard(' ')
-      await waitFor(() => {
-        expect(screen.getByTestId('play-pause-icon')).toHaveAttribute('data-state', 'playing')
-      })
-    })
-
-    it('should prevent page scroll when using spacebar', async () => {
-      render(<App />)
-      await loadTestFile()
-
-      const appContainer = screen.getByTestId('app-container')
-      appContainer.focus()
-
-      // Mock preventDefault
-      const preventDefaultSpy = vi.fn()
-      
-      // Simulate keydown event
-      fireEvent.keyDown(appContainer, {
-        key: ' ',
-        preventDefault: preventDefaultSpy
-      })
-
-      expect(preventDefaultSpy).toHaveBeenCalled()
-    })
-
-    it('should work even if play button is not clicked', async () => {
-      render(<App />)
-      await loadTestFile()
-
-      const appContainer = screen.getByTestId('app-container')
-      appContainer.focus()
-
-      // Use spacebar without clicking play button
-      await user.keyboard(' ')
-      await waitFor(() => {
-        expect(screen.getByTestId('play-pause-icon')).toHaveAttribute('data-state', 'playing')
-      })
-    })
-  })
-
-  describe('Seek Shortcuts (Arrow Keys)', () => {
-    it('should seek backward 10 seconds with left arrow', async () => {
-      render(<App />)
-      await loadTestFile()
-
-      const appContainer = screen.getByTestId('app-container')
-      appContainer.focus()
+      const appContainer = screen.getByTestId("app-container");
+      appContainer.focus();
 
       // Start playback to get some time elapsed
-      const playButton = screen.getByTitle('Play/Pause (Space)')
-      await user.click(playButton)
-      
-      await new Promise(resolve => setTimeout(resolve, 200)) // Let some time pass
-      
-      const initialTime = screen.getByTestId('current-time').textContent
-      
+      const playButton = screen.getByTitle("Play/Pause (Space)");
+      await user.click(playButton);
+
+      await new Promise((resolve) => setTimeout(resolve, 200)); // Let some time pass
+
+      const initialTime = screen.getByTestId("current-time").textContent;
+
       // Press left arrow to seek backward
-      await user.keyboard('{ArrowLeft}')
-      
+      await user.keyboard("{ArrowLeft}");
+
       await waitFor(() => {
-        const newTime = screen.getByTestId('current-time').textContent
-        expect(newTime).not.toBe(initialTime)
-      })
-    })
+        const newTime = screen.getByTestId("current-time").textContent;
+        expect(newTime).not.toBe(initialTime);
+      });
+    });
 
-    it('should seek forward 10 seconds with right arrow', async () => {
-      render(<App />)
-      await loadTestFile()
+    it("should seek forward 10 seconds with right arrow", async () => {
+      render(<App />);
+      await loadTestFile();
 
-      const appContainer = screen.getByTestId('app-container')
-      appContainer.focus()
+      const appContainer = screen.getByTestId("app-container");
+      appContainer.focus();
 
-      const initialTime = screen.getByTestId('current-time').textContent
-      
+      const initialTime = screen.getByTestId("current-time").textContent;
+
       // Press right arrow to seek forward
-      await user.keyboard('{ArrowRight}')
-      
+      await user.keyboard("{ArrowRight}");
+
       await waitFor(() => {
-        const newTime = screen.getByTestId('current-time').textContent
-        expect(newTime).not.toBe(initialTime)
-      })
-    })
+        const newTime = screen.getByTestId("current-time").textContent;
+        expect(newTime).not.toBe(initialTime);
+      });
+    });
 
-    it('should handle multiple arrow key presses', async () => {
-      render(<App />)
-      await loadTestFile()
+    it("should handle multiple arrow key presses", async () => {
+      render(<App />);
+      await loadTestFile();
 
-      const appContainer = screen.getByTestId('app-container')
-      appContainer.focus()
+      const appContainer = screen.getByTestId("app-container");
+      appContainer.focus();
 
-      const initialTime = screen.getByTestId('current-time').textContent
-      
+      const initialTime = screen.getByTestId("current-time").textContent;
+
       // Press right arrow multiple times
-      await user.keyboard('{ArrowRight}')
-      await user.keyboard('{ArrowRight}')
-      await user.keyboard('{ArrowRight}')
-      
+      await user.keyboard("{ArrowRight}");
+      await user.keyboard("{ArrowRight}");
+      await user.keyboard("{ArrowRight}");
+
       await waitFor(() => {
-        const newTime = screen.getByTestId('current-time').textContent
-        expect(newTime).not.toBe(initialTime)
-      })
-    })
+        const newTime = screen.getByTestId("current-time").textContent;
+        expect(newTime).not.toBe(initialTime);
+      });
+    });
 
-    it('should prevent default browser behavior for arrow keys', async () => {
-      render(<App />)
-      await loadTestFile()
+    it("should prevent default browser behavior for arrow keys", async () => {
+      render(<App />);
+      await loadTestFile();
 
-      const appContainer = screen.getByTestId('app-container')
-      appContainer.focus()
+      const appContainer = screen.getByTestId("app-container");
+      appContainer.focus();
 
       // Mock preventDefault
-      const preventDefaultSpy = vi.fn()
-      
+      const preventDefaultSpy = vi.fn();
+
       // Simulate keydown events
       fireEvent.keyDown(appContainer, {
-        key: 'ArrowLeft',
-        preventDefault: preventDefaultSpy
-      })
+        key: "ArrowLeft",
+        preventDefault: preventDefaultSpy,
+      });
 
       fireEvent.keyDown(appContainer, {
-        key: 'ArrowRight',
-        preventDefault: preventDefaultSpy
-      })
+        key: "ArrowRight",
+        preventDefault: preventDefaultSpy,
+      });
 
-      expect(preventDefaultSpy).toHaveBeenCalledTimes(2)
-    })
-  })
+      expect(preventDefaultSpy).toHaveBeenCalledTimes(2);
+    });
+  });
 
-  describe('Volume Control Shortcuts', () => {
-    it('should increase volume with up arrow', async () => {
-      render(<App />)
-      await loadTestFile()
+  describe("Volume Control Shortcuts", () => {
+    it("should increase volume with up arrow", async () => {
+      render(<App />);
+      await loadTestFile();
 
-      const appContainer = screen.getByTestId('app-container')
-      appContainer.focus()
+      const appContainer = screen.getByTestId("app-container");
+      appContainer.focus();
 
-      const volumeSlider = screen.getByTestId('volume-slider')
-      const initialVolume = volumeSlider.getAttribute('value') || '100'
-      
+      const volumeSlider = screen.getByTestId("volume-slider");
+      const initialVolume = volumeSlider.getAttribute("value") || "100";
+
       // Press up arrow to increase volume
-      await user.keyboard('{ArrowUp}')
-      
+      await user.keyboard("{ArrowUp}");
+
       await waitFor(() => {
-        const newVolume = volumeSlider.getAttribute('value')
-        expect(parseInt(newVolume || '0')).toBeGreaterThan(parseInt(initialVolume))
-      })
-    })
+        const newVolume = volumeSlider.getAttribute("value");
+        expect(parseInt(newVolume || "0")).toBeGreaterThan(
+          parseInt(initialVolume),
+        );
+      });
+    });
 
-    it('should decrease volume with down arrow', async () => {
-      render(<App />)
-      await loadTestFile()
+    it("should decrease volume with down arrow", async () => {
+      render(<App />);
+      await loadTestFile();
 
-      const appContainer = screen.getByTestId('app-container')
-      appContainer.focus()
+      const appContainer = screen.getByTestId("app-container");
+      appContainer.focus();
 
-      const volumeSlider = screen.getByTestId('volume-slider')
-      const initialVolume = volumeSlider.getAttribute('value') || '100'
-      
+      const volumeSlider = screen.getByTestId("volume-slider");
+      const initialVolume = volumeSlider.getAttribute("value") || "100";
+
       // Press down arrow to decrease volume
-      await user.keyboard('{ArrowDown}')
-      
+      await user.keyboard("{ArrowDown}");
+
       await waitFor(() => {
-        const newVolume = volumeSlider.getAttribute('value')
-        expect(parseInt(newVolume || '0')).toBeLessThan(parseInt(initialVolume))
-      })
-    })
+        const newVolume = volumeSlider.getAttribute("value");
+        expect(parseInt(newVolume || "0")).toBeLessThan(
+          parseInt(initialVolume),
+        );
+      });
+    });
 
-    it('should not go below 0% volume', async () => {
-      render(<App />)
-      await loadTestFile()
+    it("should not go below 0% volume", async () => {
+      render(<App />);
+      await loadTestFile();
 
-      const appContainer = screen.getByTestId('app-container')
-      appContainer.focus()
+      const appContainer = screen.getByTestId("app-container");
+      appContainer.focus();
 
       // Press down arrow many times to try to go below 0
       for (let i = 0; i < 20; i++) {
-        await user.keyboard('{ArrowDown}')
+        await user.keyboard("{ArrowDown}");
       }
-      
+
       await waitFor(() => {
-        const volumeSlider = screen.getByTestId('volume-slider')
-        const volume = volumeSlider.getAttribute('value')
-        expect(parseInt(volume || '0')).toBeGreaterThanOrEqual(0)
-      })
-    })
-  })
+        const volumeSlider = screen.getByTestId("volume-slider");
+        const volume = volumeSlider.getAttribute("value");
+        expect(parseInt(volume || "0")).toBeGreaterThanOrEqual(0);
+      });
+    });
+  });
 
-  describe('Mute Shortcut', () => {
-    it('should toggle mute with M key', async () => {
-      render(<App />)
-      await loadTestFile()
+  describe("Mute Shortcut", () => {
+    it("should toggle mute with M key", async () => {
+      render(<App />);
+      await loadTestFile();
 
-      const appContainer = screen.getByTestId('app-container')
-      appContainer.focus()
+      const appContainer = screen.getByTestId("app-container");
+      appContainer.focus();
 
       // Press M to mute
-      await user.keyboard('m')
+      await user.keyboard("m");
       await waitFor(() => {
-        const volumeSlider = screen.getByTestId('volume-slider')
-        expect(volumeSlider.getAttribute('value')).toBe('0')
-      })
+        const volumeSlider = screen.getByTestId("volume-slider");
+        expect(volumeSlider.getAttribute("value")).toBe("0");
+      });
 
       // Press M again to unmute
-      await user.keyboard('m')
+      await user.keyboard("m");
       await waitFor(() => {
-        const volumeSlider = screen.getByTestId('volume-slider')
-        expect(volumeSlider.getAttribute('value')).toBe('100')
-      })
-    })
+        const volumeSlider = screen.getByTestId("volume-slider");
+        expect(volumeSlider.getAttribute("value")).toBe("100");
+      });
+    });
 
-    it('should show muted icon when muted', async () => {
-      render(<App />)
-      await loadTestFile()
+    it("should show muted icon when muted", async () => {
+      render(<App />);
+      await loadTestFile();
 
-      const appContainer = screen.getByTestId('app-container')
-      appContainer.focus()
+      const appContainer = screen.getByTestId("app-container");
+      appContainer.focus();
 
       // Press M to mute
-      await user.keyboard('m')
+      await user.keyboard("m");
       await waitFor(() => {
-        const volumeIcon = screen.getByTestId('volume-icon')
-        expect(volumeIcon).toHaveAttribute('data-muted', 'true')
-      })
-    })
-  })
+        const volumeIcon = screen.getByTestId("volume-icon");
+        expect(volumeIcon).toHaveAttribute("data-muted", "true");
+      });
+    });
+  });
 
-  describe('File Open Shortcut', () => {
-    it('should open file dialog with Ctrl+O', async () => {
-      render(<App />)
+  describe("File Open Shortcut", () => {
+    it("should open file dialog with Ctrl+O", async () => {
+      render(<App />);
 
-      const appContainer = screen.getByTestId('app-container')
-      appContainer.focus()
+      const appContainer = screen.getByTestId("app-container");
+      appContainer.focus();
 
       // Mock file input click
-      const fileInput = screen.getByTestId('file-input')
-      const clickSpy = vi.spyOn(fileInput, 'click')
+      const fileInput = screen.getByTestId("file-input");
+      const clickSpy = vi.spyOn(fileInput, "click");
 
       // Press Ctrl+O
-      await user.keyboard('{Control>}o{/Control}')
-      
-      expect(clickSpy).toHaveBeenCalled()
-    })
+      await user.keyboard("{Control>}o{/Control}");
 
-    it('should open file dialog with O key', async () => {
-      render(<App />)
+      expect(clickSpy).toHaveBeenCalled();
+    });
 
-      const appContainer = screen.getByTestId('app-container')
-      appContainer.focus()
+    it("should open file dialog with O key", async () => {
+      render(<App />);
+
+      const appContainer = screen.getByTestId("app-container");
+      appContainer.focus();
 
       // Mock file input click
-      const fileInput = screen.getByTestId('file-input')
-      const clickSpy = vi.spyOn(fileInput, 'click')
+      const fileInput = screen.getByTestId("file-input");
+      const clickSpy = vi.spyOn(fileInput, "click");
 
       // Press O
-      await user.keyboard('o')
-      
-      expect(clickSpy).toHaveBeenCalled()
-    })
-  })
+      await user.keyboard("o");
 
-  describe('Playlist Navigation Shortcuts', () => {
-    it('should go to next track with Ctrl+Right', async () => {
-      render(<App />)
-      await loadTestFile()
+      expect(clickSpy).toHaveBeenCalled();
+    });
+  });
 
-      const appContainer = screen.getByTestId('app-container')
-      appContainer.focus()
+  describe("Playlist Navigation Shortcuts", () => {
+    it("should go to next track with Ctrl+Right", async () => {
+      render(<App />);
+      await loadTestFile();
+
+      const appContainer = screen.getByTestId("app-container");
+      appContainer.focus();
 
       // Mock next track functionality
-      const nextButton = screen.getByTitle('Next track (Ctrl+→)')
-      const clickSpy = vi.spyOn(nextButton, 'click')
+      const nextButton = screen.getByTitle("Next track (Ctrl+→)");
+      const clickSpy = vi.spyOn(nextButton, "click");
 
       // Press Ctrl+Right
-      await user.keyboard('{Control>}{ArrowRight}{/Control}')
-      
-      expect(clickSpy).toHaveBeenCalled()
-    })
+      await user.keyboard("{Control>}{ArrowRight}{/Control}");
 
-    it('should go to previous track with Ctrl+Left', async () => {
-      render(<App />)
-      await loadTestFile()
+      expect(clickSpy).toHaveBeenCalled();
+    });
 
-      const appContainer = screen.getByTestId('app-container')
-      appContainer.focus()
+    it("should go to previous track with Ctrl+Left", async () => {
+      render(<App />);
+      await loadTestFile();
+
+      const appContainer = screen.getByTestId("app-container");
+      appContainer.focus();
 
       // Mock previous track functionality
-      const prevButton = screen.getByTitle('Previous track (Ctrl+←)')
-      const clickSpy = vi.spyOn(prevButton, 'click')
+      const prevButton = screen.getByTitle("Previous track (Ctrl+←)");
+      const clickSpy = vi.spyOn(prevButton, "click");
 
       // Press Ctrl+Left
-      await user.keyboard('{Control>}{ArrowLeft}{/Control}')
-      
-      expect(clickSpy).toHaveBeenCalled()
-    })
-  })
+      await user.keyboard("{Control>}{ArrowLeft}{/Control}");
 
-  describe('Other Shortcuts', () => {
-    it('should open settings with S key', async () => {
-      render(<App />)
-      await loadTestFile()
+      expect(clickSpy).toHaveBeenCalled();
+    });
+  });
 
-      const appContainer = screen.getByTestId('app-container')
-      appContainer.focus()
+  describe("Other Shortcuts", () => {
+    it("should open settings with S key", async () => {
+      render(<App />);
+      await loadTestFile();
+
+      const appContainer = screen.getByTestId("app-container");
+      appContainer.focus();
 
       // Press S to open settings
-      await user.keyboard('s')
+      await user.keyboard("s");
       await waitFor(() => {
-        expect(screen.getByTestId('settings-panel')).toBeInTheDocument()
-      })
-    })
+        expect(screen.getByTestId("settings-panel")).toBeInTheDocument();
+      });
+    });
 
-    it('should open shortcut help with ? key', async () => {
-      render(<App />)
-      await loadTestFile()
+    it("should open shortcut help with ? key", async () => {
+      render(<App />);
+      await loadTestFile();
 
-      const appContainer = screen.getByTestId('app-container')
-      appContainer.focus()
+      const appContainer = screen.getByTestId("app-container");
+      appContainer.focus();
 
-      await user.keyboard('?')
+      await user.keyboard("?");
       await waitFor(() => {
-        expect(screen.getByTestId('shortcuts-modal')).toBeInTheDocument()
-      })
+        expect(screen.getByTestId("shortcuts-modal")).toBeInTheDocument();
+      });
 
-      await user.keyboard('{Escape}')
+      await user.keyboard("{Escape}");
       await waitFor(() => {
-        expect(screen.queryByTestId('shortcuts-modal')).not.toBeInTheDocument()
-      })
-    })
+        expect(screen.queryByTestId("shortcuts-modal")).not.toBeInTheDocument();
+      });
+    });
 
-    it('should close modals with Escape key', async () => {
-      render(<App />)
-      await loadTestFile()
+    it("should close modals with Escape key", async () => {
+      render(<App />);
+      await loadTestFile();
 
-      const appContainer = screen.getByTestId('app-container')
-      appContainer.focus()
+      const appContainer = screen.getByTestId("app-container");
+      appContainer.focus();
 
       // Open settings first
-      await user.keyboard('s')
+      await user.keyboard("s");
       await waitFor(() => {
-        expect(screen.getByTestId('settings-panel')).toBeInTheDocument()
-      })
+        expect(screen.getByTestId("settings-panel")).toBeInTheDocument();
+      });
 
       // Press Escape to close
-      await user.keyboard('{Escape}')
+      await user.keyboard("{Escape}");
       await waitFor(() => {
-        expect(screen.queryByTestId('settings-panel')).not.toBeInTheDocument()
-      })
-    })
-  })
+        expect(screen.queryByTestId("settings-panel")).not.toBeInTheDocument();
+      });
+    });
+  });
 
-  describe('Keyboard Focus Management', () => {
-    it('should work when app has focus', async () => {
-      render(<App />)
-      await loadTestFile()
+  describe("Keyboard Focus Management", () => {
+    it("should work when app has focus", async () => {
+      render(<App />);
+      await loadTestFile();
 
-      const appContainer = screen.getByTestId('app-container')
-      appContainer.focus()
+      const appContainer = screen.getByTestId("app-container");
+      appContainer.focus();
 
       // Test that shortcuts work
-      await user.keyboard(' ')
+      await user.keyboard(" ");
       await waitFor(() => {
-        expect(screen.getByTestId('play-pause-icon')).toHaveAttribute('data-state', 'playing')
-      })
-    })
+        expect(screen.getByTestId("play-pause-icon")).toHaveAttribute(
+          "data-state",
+          "playing",
+        );
+      });
+    });
 
-    it('should not work when app loses focus', async () => {
-      render(<App />)
-      await loadTestFile()
+    it("should not work when app loses focus", async () => {
+      render(<App />);
+      await loadTestFile();
 
       // Click outside the app to lose focus
-      const body = document.body
-      fireEvent.click(body)
+      const body = document.body;
+      fireEvent.click(body);
 
       // Try to use spacebar - should not affect playback
-      await user.keyboard(' ')
-      
+      await user.keyboard(" ");
+
       // Should still be in initial state
-      expect(screen.getByTestId('play-pause-icon')).toHaveAttribute('data-state', 'paused')
-    })
-  })
+      expect(screen.getByTestId("play-pause-icon")).toHaveAttribute(
+        "data-state",
+        "paused",
+      );
+    });
+  });
 
-  describe('Conflict with Browser Shortcuts', () => {
-    it('should prevent spacebar from scrolling page', async () => {
-      render(<App />)
-      await loadTestFile()
+  describe("Conflict with Browser Shortcuts", () => {
+    it("should prevent spacebar from scrolling page", async () => {
+      render(<App />);
+      await loadTestFile();
 
-      const appContainer = screen.getByTestId('app-container')
-      appContainer.focus()
+      const appContainer = screen.getByTestId("app-container");
+      appContainer.focus();
 
       // Mock preventDefault
-      const preventDefaultSpy = vi.fn()
-      
+      const preventDefaultSpy = vi.fn();
+
       // Simulate keydown event
       fireEvent.keyDown(appContainer, {
-        key: ' ',
-        preventDefault: preventDefaultSpy
-      })
+        key: " ",
+        preventDefault: preventDefaultSpy,
+      });
 
-      expect(preventDefaultSpy).toHaveBeenCalled()
-    })
+      expect(preventDefaultSpy).toHaveBeenCalled();
+    });
 
-    it('should prevent arrow keys from scrolling page', async () => {
-      render(<App />)
-      await loadTestFile()
+    it("should prevent arrow keys from scrolling page", async () => {
+      render(<App />);
+      await loadTestFile();
 
-      const appContainer = screen.getByTestId('app-container')
-      appContainer.focus()
+      const appContainer = screen.getByTestId("app-container");
+      appContainer.focus();
 
       // Mock preventDefault
-      const preventDefaultSpy = vi.fn()
-      
+      const preventDefaultSpy = vi.fn();
+
       // Simulate keydown events
-      const arrowKeys = ['ArrowLeft', 'ArrowRight', 'ArrowUp', 'ArrowDown']
-      arrowKeys.forEach(key => {
+      const arrowKeys = ["ArrowLeft", "ArrowRight", "ArrowUp", "ArrowDown"];
+      arrowKeys.forEach((key) => {
         fireEvent.keyDown(appContainer, {
           key,
-          preventDefault: preventDefaultSpy
-        })
-      })
+          preventDefault: preventDefaultSpy,
+        });
+      });
 
-      expect(preventDefaultSpy).toHaveBeenCalledTimes(4)
-    })
-  })
+      expect(preventDefaultSpy).toHaveBeenCalledTimes(4);
+    });
+  });
 
-  describe('Accessibility and Error Handling', () => {
-    it('should handle rapid key presses gracefully', async () => {
-      render(<App />)
-      await loadTestFile()
+  describe("Accessibility and Error Handling", () => {
+    it("should handle rapid key presses gracefully", async () => {
+      render(<App />);
+      await loadTestFile();
 
-      const appContainer = screen.getByTestId('app-container')
-      appContainer.focus()
+      const appContainer = screen.getByTestId("app-container");
+      appContainer.focus();
 
       // Rapidly press spacebar multiple times
-      await user.keyboard(' ')
-      await user.keyboard(' ')
-      await user.keyboard(' ')
-      await user.keyboard(' ')
+      await user.keyboard(" ");
+      await user.keyboard(" ");
+      await user.keyboard(" ");
+      await user.keyboard(" ");
 
       // Should end up in a consistent state
       await waitFor(() => {
-        const state = screen.getByTestId('play-pause-icon').getAttribute('data-state')
-        expect(['playing', 'paused', 'stopped']).toContain(state)
-      })
-    })
+        const state = screen
+          .getByTestId("play-pause-icon")
+          .getAttribute("data-state");
+        expect(["playing", "paused", "stopped"]).toContain(state);
+      });
+    });
 
-    it('should not crash on unsupported key combinations', async () => {
-      render(<App />)
-      await loadTestFile()
+    it("should not crash on unsupported key combinations", async () => {
+      render(<App />);
+      await loadTestFile();
 
-      const appContainer = screen.getByTestId('app-container')
-      appContainer.focus()
+      const appContainer = screen.getByTestId("app-container");
+      appContainer.focus();
 
       // Try various unsupported key combinations
-      const unsupportedKeys = ['q', 'w', 'e', 'r', 't', 'y', 'u', 'i', 'o', 'p']
-      
+      const unsupportedKeys = [
+        "q",
+        "w",
+        "e",
+        "r",
+        "t",
+        "y",
+        "u",
+        "i",
+        "o",
+        "p",
+      ];
+
       for (const key of unsupportedKeys) {
-        await user.keyboard(key)
+        await user.keyboard(key);
       }
 
       // App should still be functional
-      expect(screen.getByTestId('play-pause-icon')).toBeInTheDocument()
-    })
-  })
-})
+      expect(screen.getByTestId("play-pause-icon")).toBeInTheDocument();
+    });
+  });
+});

--- a/react-spectrogram/src/hooks/useKeyboardShortcuts.ts
+++ b/react-spectrogram/src/hooks/useKeyboardShortcuts.ts
@@ -1,8 +1,8 @@
-import { useEffect, useCallback } from 'react'
-import { useUIStore } from '@/stores/uiStore'
-import { useAudioStore } from '@/stores/audioStore'
-import { useAudioFile } from '@/hooks/useAudioFile'
-import { conditionalToast } from '@/utils/toast'
+import { useEffect, useCallback } from "react";
+import { useUIStore } from "@/stores/uiStore";
+import { useAudioStore } from "@/stores/audioStore";
+import { useAudioFile } from "@/hooks/useAudioFile";
+import { conditionalToast } from "@/utils/toast";
 
 export const useKeyboardShortcuts = () => {
   const {
@@ -13,296 +13,297 @@ export const useKeyboardShortcuts = () => {
     metadataPanelOpen,
     playlistPanelOpen,
     settingsPanelOpen,
-    shortcutsHelpOpen
-  } = useUIStore()
-  
-  const { 
-    isPlaying, 
-    isPaused, 
-    isStopped, 
-    currentTrack, 
-    playlist, 
-    currentTrackIndex,
-    volume,
-    isMuted,
-    currentTime,
-    duration
-  } = useAudioStore()
-  
-  const audioFile = useAudioFile()
+    shortcutsHelpOpen,
+  } = useUIStore();
 
-  // Handle keyboard events
-  const handleKeyDown = useCallback((event: KeyboardEvent) => {
-    // Don't handle shortcuts if user is typing in an input field
-    if (event.target instanceof HTMLInputElement || 
-        event.target instanceof HTMLTextAreaElement || 
-        event.target instanceof HTMLSelectElement) {
-      return
-    }
-
-    const { key, ctrlKey, shiftKey, metaKey, altKey } = event
-
-    // Spacebar - Play/Pause
-    if (key === ' ' && !ctrlKey && !shiftKey && !metaKey) {
-      event.preventDefault()
-      if (isStopped) {
-        if (currentTrack) {
-          audioFile.playTrack(currentTrack)
-        }
-      } else if (isPlaying) {
-        audioFile.pausePlayback()
-      } else {
-        audioFile.resumePlayback()
-      }
-      return
-    }
-
-    // K - Play/Pause (alternative to spacebar)
-    if (key.toLowerCase() === 'k' && !ctrlKey && !shiftKey && !metaKey) {
-      event.preventDefault()
-      if (isStopped) {
-        if (currentTrack) {
-          audioFile.playTrack(currentTrack)
-        }
-      } else if (isPlaying) {
-        audioFile.pausePlayback()
-      } else {
-        audioFile.resumePlayback()
-      }
-      return
-    }
-
-    // Arrow Left - Seek backward 5s
-    if (key === 'ArrowLeft' && !ctrlKey && !metaKey && !altKey) {
-      event.preventDefault()
-      if (currentTrack) {
-        const newTime = Math.max(0, currentTime - 5)
-        audioFile.seekTo(newTime)
-      }
-      return
-    }
-
-    // Arrow Right - Seek forward 5s
-    if (key === 'ArrowRight' && !ctrlKey && !metaKey && !altKey) {
-      event.preventDefault()
-      if (currentTrack) {
-        const newTime = Math.min(duration, currentTime + 5)
-        audioFile.seekTo(newTime)
-      }
-      return
-    }
-
-    // Ctrl/Cmd + Arrow Left - Previous track
-    if (key === 'ArrowLeft' && (ctrlKey || metaKey) && !altKey) {
-      event.preventDefault()
-      if (playlist.length > 0) {
-        const prevIndex = currentTrackIndex <= 0 ? playlist.length - 1 : currentTrackIndex - 1
-        const prevTrack = playlist[prevIndex]
-        if (prevTrack) {
-          audioFile.playTrack(prevTrack)
-        }
-      }
-      return
-    }
-
-    // Ctrl/Cmd + Arrow Right - Next track
-    if (key === 'ArrowRight' && (ctrlKey || metaKey) && !altKey) {
-      event.preventDefault()
-      if (playlist.length > 0) {
-        const nextIndex = (currentTrackIndex + 1) % playlist.length
-        const nextTrack = playlist[nextIndex]
-        if (nextTrack) {
-          audioFile.playTrack(nextTrack)
-        }
-      }
-      return
-    }
-
-    // Arrow Up - Volume up
-    if (key === 'ArrowUp' && !ctrlKey && !shiftKey && !metaKey) {
-      event.preventDefault()
-      const newVolume = Math.min(1, volume + 0.05)
-      audioFile.setAudioVolume(newVolume)
-      return
-    }
-
-    // Arrow Down - Volume down
-    if (key === 'ArrowDown' && !ctrlKey && !shiftKey && !metaKey) {
-      event.preventDefault()
-      const newVolume = Math.max(0, volume - 0.05)
-      audioFile.setAudioVolume(newVolume)
-      return
-    }
-
-    // J - 10 seconds back
-    if (key.toLowerCase() === 'j' && !ctrlKey && !metaKey && !altKey) {
-      event.preventDefault()
-      if (currentTrack) {
-        const newTime = Math.max(0, currentTime - 10)
-        audioFile.seekTo(newTime)
-      }
-      return
-    }
-
-    // L - 10 seconds forward
-    if (key.toLowerCase() === 'l' && !ctrlKey && !metaKey && !altKey) {
-      event.preventDefault()
-      if (currentTrack) {
-        const newTime = Math.min(duration, currentTime + 10)
-        audioFile.seekTo(newTime)
-      }
-      return
-    }
-
-    // M - Mute/Unmute
-    if (key.toLowerCase() === 'm' && !ctrlKey && !metaKey && !altKey) {
-      event.preventDefault()
-      audioFile.toggleMute()
-      return
-    }
-
-    // I - Toggle metadata panel
-    if (key.toLowerCase() === 'i' && !ctrlKey && !metaKey && !altKey) {
-      event.preventDefault()
-      setMetadataPanelOpen(!metadataPanelOpen)
-      return
-    }
-
-    // P - Toggle playlist panel
-    if (key.toLowerCase() === 'p' && !ctrlKey && !metaKey && !altKey) {
-      event.preventDefault()
-      setPlaylistPanelOpen(!playlistPanelOpen)
-      return
-    }
-
-    // S - Open settings
-    if (key.toLowerCase() === 's' && !ctrlKey && !metaKey && !altKey) {
-      event.preventDefault()
-      setSettingsPanelOpen(true)
-      return
-    }
-
-    // ? - Toggle shortcuts help
-    if (key === '?' && !ctrlKey && !altKey && !metaKey) {
-      event.preventDefault()
-      setShortcutsHelpOpen(!shortcutsHelpOpen)
-      return
-    }
-
-    // Ctrl/Cmd + Shift + S - Snapshot
-    if (key.toLowerCase() === 's' && (ctrlKey || metaKey) && shiftKey) {
-      event.preventDefault()
-      // TODO: Implement snapshot functionality
-      conditionalToast.success('Snapshot taken!')
-      return
-    }
-
-    // Escape - Close panels/modals
-    if (key === 'Escape') {
-      event.preventDefault()
-      if (settingsPanelOpen) {
-        setSettingsPanelOpen(false)
-      } else if (metadataPanelOpen) {
-        setMetadataPanelOpen(false)
-      } else if (playlistPanelOpen) {
-        setPlaylistPanelOpen(false)
-      } else if (shortcutsHelpOpen) {
-        setShortcutsHelpOpen(false)
-      }
-      return
-    }
-
-    // O - Open file dialog (if implemented)
-    if (key.toLowerCase() === 'o' && !ctrlKey && !shiftKey && !metaKey) {
-      event.preventDefault()
-      // This would trigger the file input, but we need to access the file input ref
-      // For now, we'll just show a toast
-      conditionalToast.info('Use the file button to open audio files')
-      return
-    }
-
-  }, [
+  const {
     isPlaying,
-    isPaused,
     isStopped,
     currentTrack,
     playlist,
     currentTrackIndex,
     volume,
-    isMuted,
     currentTime,
     duration,
-    metadataPanelOpen,
-    playlistPanelOpen,
-    settingsPanelOpen,
-    shortcutsHelpOpen,
-    audioFile,
-    setMetadataPanelOpen,
-    setPlaylistPanelOpen,
-    setSettingsPanelOpen,
-    setShortcutsHelpOpen
-  ])
+  } = useAudioStore();
+
+  const audioFile = useAudioFile();
+
+  // Helper to centralize play/pause logic so we don't duplicate state checks.
+  // This keeps keyboard handling lean and makes programmatic control easier.
+  const togglePlayPause = useCallback(() => {
+    // If nothing has been played yet but a track is selected, start it.
+    if (isStopped) {
+      if (currentTrack) {
+        audioFile.playTrack(currentTrack);
+      }
+      return;
+    }
+
+    // If currently playing, pause; otherwise resume from current position.
+    if (isPlaying) {
+      audioFile.pausePlayback();
+    } else {
+      audioFile.resumePlayback();
+    }
+  }, [audioFile, currentTrack, isPlaying, isStopped]);
+
+  // Handle keyboard events
+  const handleKeyDown = useCallback(
+    (event: KeyboardEvent) => {
+      // Don't handle shortcuts if user is typing in an input field
+      if (
+        event.target instanceof HTMLInputElement ||
+        event.target instanceof HTMLTextAreaElement ||
+        event.target instanceof HTMLSelectElement
+      ) {
+        return;
+      }
+
+      const { key, code, ctrlKey, shiftKey, metaKey, altKey } = event;
+
+      // Spacebar - Play/Pause
+      if (
+        (code === "Space" || key === " ") &&
+        !ctrlKey &&
+        !shiftKey &&
+        !metaKey
+      ) {
+        event.preventDefault();
+        togglePlayPause();
+        return;
+      }
+
+      // K - Play/Pause (alternative to spacebar)
+      if (key.toLowerCase() === "k" && !ctrlKey && !shiftKey && !metaKey) {
+        event.preventDefault();
+        togglePlayPause();
+        return;
+      }
+
+      // Arrow Left - Seek backward 5s
+      if (key === "ArrowLeft" && !ctrlKey && !metaKey && !altKey) {
+        event.preventDefault();
+        if (currentTrack) {
+          const newTime = Math.max(0, currentTime - 5);
+          audioFile.seekTo(newTime);
+        }
+        return;
+      }
+
+      // Arrow Right - Seek forward 5s
+      if (key === "ArrowRight" && !ctrlKey && !metaKey && !altKey) {
+        event.preventDefault();
+        if (currentTrack) {
+          const newTime = Math.min(duration, currentTime + 5);
+          audioFile.seekTo(newTime);
+        }
+        return;
+      }
+
+      // Ctrl/Cmd + Arrow Left - Previous track
+      if (key === "ArrowLeft" && (ctrlKey || metaKey) && !altKey) {
+        event.preventDefault();
+        if (playlist.length > 0) {
+          const prevIndex =
+            currentTrackIndex <= 0
+              ? playlist.length - 1
+              : currentTrackIndex - 1;
+          const prevTrack = playlist[prevIndex];
+          if (prevTrack) {
+            audioFile.playTrack(prevTrack);
+          }
+        }
+        return;
+      }
+
+      // Ctrl/Cmd + Arrow Right - Next track
+      if (key === "ArrowRight" && (ctrlKey || metaKey) && !altKey) {
+        event.preventDefault();
+        if (playlist.length > 0) {
+          const nextIndex = (currentTrackIndex + 1) % playlist.length;
+          const nextTrack = playlist[nextIndex];
+          if (nextTrack) {
+            audioFile.playTrack(nextTrack);
+          }
+        }
+        return;
+      }
+
+      // Arrow Up - Volume up
+      if (key === "ArrowUp" && !ctrlKey && !shiftKey && !metaKey) {
+        event.preventDefault();
+        const newVolume = Math.min(1, volume + 0.05);
+        audioFile.setAudioVolume(newVolume);
+        return;
+      }
+
+      // Arrow Down - Volume down
+      if (key === "ArrowDown" && !ctrlKey && !shiftKey && !metaKey) {
+        event.preventDefault();
+        const newVolume = Math.max(0, volume - 0.05);
+        audioFile.setAudioVolume(newVolume);
+        return;
+      }
+
+      // J - 10 seconds back
+      if (key.toLowerCase() === "j" && !ctrlKey && !metaKey && !altKey) {
+        event.preventDefault();
+        if (currentTrack) {
+          const newTime = Math.max(0, currentTime - 10);
+          audioFile.seekTo(newTime);
+        }
+        return;
+      }
+
+      // L - 10 seconds forward
+      if (key.toLowerCase() === "l" && !ctrlKey && !metaKey && !altKey) {
+        event.preventDefault();
+        if (currentTrack) {
+          const newTime = Math.min(duration, currentTime + 10);
+          audioFile.seekTo(newTime);
+        }
+        return;
+      }
+
+      // M - Mute/Unmute
+      if (key.toLowerCase() === "m" && !ctrlKey && !metaKey && !altKey) {
+        event.preventDefault();
+        audioFile.toggleMute();
+        return;
+      }
+
+      // I - Toggle metadata panel
+      if (key.toLowerCase() === "i" && !ctrlKey && !metaKey && !altKey) {
+        event.preventDefault();
+        setMetadataPanelOpen(!metadataPanelOpen);
+        return;
+      }
+
+      // P - Toggle playlist panel
+      if (key.toLowerCase() === "p" && !ctrlKey && !metaKey && !altKey) {
+        event.preventDefault();
+        setPlaylistPanelOpen(!playlistPanelOpen);
+        return;
+      }
+
+      // S - Open settings
+      if (key.toLowerCase() === "s" && !ctrlKey && !metaKey && !altKey) {
+        event.preventDefault();
+        setSettingsPanelOpen(true);
+        return;
+      }
+
+      // ? - Toggle shortcuts help
+      if (key === "?" && !ctrlKey && !altKey && !metaKey) {
+        event.preventDefault();
+        setShortcutsHelpOpen(!shortcutsHelpOpen);
+        return;
+      }
+
+      // Ctrl/Cmd + Shift + S - Snapshot
+      if (key.toLowerCase() === "s" && (ctrlKey || metaKey) && shiftKey) {
+        event.preventDefault();
+        // TODO: Implement snapshot functionality
+        conditionalToast.success("Snapshot taken!");
+        return;
+      }
+
+      // Escape - Close panels/modals
+      if (key === "Escape") {
+        event.preventDefault();
+        if (settingsPanelOpen) {
+          setSettingsPanelOpen(false);
+        } else if (metadataPanelOpen) {
+          setMetadataPanelOpen(false);
+        } else if (playlistPanelOpen) {
+          setPlaylistPanelOpen(false);
+        } else if (shortcutsHelpOpen) {
+          setShortcutsHelpOpen(false);
+        }
+        return;
+      }
+
+      // O - Open file dialog (if implemented)
+      if (key.toLowerCase() === "o" && !ctrlKey && !shiftKey && !metaKey) {
+        event.preventDefault();
+        // This would trigger the file input, but we need to access the file input ref
+        // For now, we'll just show a toast
+        conditionalToast.info("Use the file button to open audio files");
+        return;
+      }
+    },
+    [
+      playlist,
+      currentTrack,
+      currentTrackIndex,
+      volume,
+      currentTime,
+      duration,
+      metadataPanelOpen,
+      playlistPanelOpen,
+      settingsPanelOpen,
+      shortcutsHelpOpen,
+      audioFile,
+      setMetadataPanelOpen,
+      setPlaylistPanelOpen,
+      setSettingsPanelOpen,
+      setShortcutsHelpOpen,
+      togglePlayPause,
+    ],
+  );
 
   // Add event listener
   useEffect(() => {
-    window.addEventListener('keydown', handleKeyDown)
-    
+    window.addEventListener("keydown", handleKeyDown);
+
     return () => {
-      window.removeEventListener('keydown', handleKeyDown)
-    }
-  }, [handleKeyDown])
+      window.removeEventListener("keydown", handleKeyDown);
+    };
+  }, [handleKeyDown]);
 
   // Show keyboard shortcuts help on first visit
   useEffect(() => {
-    const hasSeenHelp = localStorage.getItem('spectrogram-keyboard-help')
+    const hasSeenHelp = localStorage.getItem("spectrogram-keyboard-help");
     if (!hasSeenHelp) {
       setTimeout(() => {
         conditionalToast.success(
-          '💡 Keyboard shortcuts available! Press ? to view all shortcuts.'
-        )
-        localStorage.setItem('spectrogram-keyboard-help', 'true')
-      }, 2000)
+          "💡 Keyboard shortcuts available! Press ? to view all shortcuts.",
+        );
+        localStorage.setItem("spectrogram-keyboard-help", "true");
+      }, 2000);
     }
-  }, [])
+  }, []);
 
   return {
     // Expose shortcut functions for programmatic use
-    togglePlayPause: () => {
-      if (isStopped) {
-        if (currentTrack) {
-          audioFile.playTrack(currentTrack)
-        }
-      } else if (isPlaying) {
-        audioFile.pausePlayback()
-      } else {
-        audioFile.resumePlayback()
-      }
-    },
+    togglePlayPause,
     previousTrack: () => {
       if (playlist.length > 0) {
-        const prevIndex = currentTrackIndex <= 0 ? playlist.length - 1 : currentTrackIndex - 1
-        const prevTrack = playlist[prevIndex]
+        const prevIndex =
+          currentTrackIndex <= 0 ? playlist.length - 1 : currentTrackIndex - 1;
+        const prevTrack = playlist[prevIndex];
         if (prevTrack) {
-          audioFile.playTrack(prevTrack)
+          audioFile.playTrack(prevTrack);
         }
       }
     },
     nextTrack: () => {
       if (playlist.length > 0) {
-        const nextIndex = (currentTrackIndex + 1) % playlist.length
-        const nextTrack = playlist[nextIndex]
+        const nextIndex = (currentTrackIndex + 1) % playlist.length;
+        const nextTrack = playlist[nextIndex];
         if (nextTrack) {
-          audioFile.playTrack(nextTrack)
+          audioFile.playTrack(nextTrack);
         }
       }
     },
     volumeUp: () => {
-      const newVolume = Math.min(1, volume + 0.05)
-      audioFile.setAudioVolume(newVolume)
+      const newVolume = Math.min(1, volume + 0.05);
+      audioFile.setAudioVolume(newVolume);
     },
     volumeDown: () => {
-      const newVolume = Math.max(0, volume - 0.05)
-      audioFile.setAudioVolume(newVolume)
+      const newVolume = Math.max(0, volume - 0.05);
+      audioFile.setAudioVolume(newVolume);
     },
     toggleMute: () => audioFile.toggleMute(),
     toggleMetadataPanel: () => setMetadataPanelOpen(!metadataPanelOpen),
@@ -310,7 +311,7 @@ export const useKeyboardShortcuts = () => {
     openSettings: () => setSettingsPanelOpen(true),
     takeSnapshot: () => {
       // TODO: Implement snapshot functionality
-      conditionalToast.success('Snapshot taken!')
-    }
-  }
-}
+      conditionalToast.success("Snapshot taken!");
+    },
+  };
+};


### PR DESCRIPTION
## Summary
- centralize play/pause logic in `useKeyboardShortcuts` for reuse
- ensure Space and "k" keys share toggle logic and handle `event.code`
- broaden keyboard shortcut tests to cover Space and "k" and prevent default scrolling

## Testing
- `npm run lint` *(fails: 146 problems in existing code)*
- `npm test` *(fails: 22 files failed, 75 tests failed, 42 errors)*
- `cargo test` *(fails: unclosed delimiter in tests/inverse_parallel.rs:141)*

------
https://chatgpt.com/codex/tasks/task_e_68a50ee506f0832ba6ff562b10b879f8