### PR TITLE
feat: persist audio playback preferences

### DIFF
--- a/react-spectrogram/src/stores/__tests__/audioPreferences.test.ts
+++ b/react-spectrogram/src/stores/__tests__/audioPreferences.test.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+// Match the key used in the store. Keeping it in a constant prevents
+// typos and mirrors production code.
+const PERSISTENCE_KEY = "audio-preferences";
+
+// Helper to load a fresh store instance after manipulating
+// localStorage. vitest's module cache is reset to ensure the store
+// re-reads persisted values.
+const initStore = async (
+  persisted?: { shuffle?: boolean; loopMode?: string }
+) => {
+  vi.resetModules();
+  if (persisted) {
+    localStorage.setItem(PERSISTENCE_KEY, JSON.stringify(persisted));
+  }
+  return await import("../audioStore");
+};
+
+describe("audioStore preferences", () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it("updates shuffle and persists", async () => {
+    const { useAudioStore, selectShuffle } = await initStore();
+    const setItemSpy = vi.spyOn(localStorage, "setItem");
+    useAudioStore.getState().setShuffle(true);
+    expect(selectShuffle(useAudioStore.getState())).toBe(true);
+    expect(setItemSpy).toHaveBeenCalledWith(
+      PERSISTENCE_KEY,
+      JSON.stringify({ shuffle: true, loopMode: "off" })
+    );
+  });
+
+  it("updates loopMode and persists", async () => {
+    const { useAudioStore, selectLoopMode } = await initStore();
+    const setItemSpy = vi.spyOn(localStorage, "setItem");
+    useAudioStore.getState().setLoopMode("all");
+    expect(selectLoopMode(useAudioStore.getState())).toBe("all");
+    expect(setItemSpy).toHaveBeenCalledWith(
+      PERSISTENCE_KEY,
+      JSON.stringify({ shuffle: false, loopMode: "all" })
+    );
+  });
+
+  it("validates persisted settings", async () => {
+    const { __loadPersistedPreferencesForTest } = await initStore();
+
+    // Invalid JSON results in defaults
+    localStorage.setItem(PERSISTENCE_KEY, "{ notjson");
+    expect(__loadPersistedPreferencesForTest()).toEqual({
+      shuffle: false,
+      loopMode: "off",
+    });
+
+    // Invalid value types also fall back to defaults
+    localStorage.setItem(
+      PERSISTENCE_KEY,
+      JSON.stringify({ shuffle: "yes", loopMode: "maybe" })
+    );
+    expect(__loadPersistedPreferencesForTest()).toEqual({
+      shuffle: false,
+      loopMode: "off",
+    });
+  });
+});

--- a/react-spectrogram/src/types/index.ts
+++ b/react-spectrogram/src/types/index.ts
@@ -157,22 +157,41 @@ export interface UIState {
 }
 
 // Audio State types
+
+/**
+ * Supported looping behaviours for playlist playback.
+ * Using a dedicated type alias keeps runtime validation cheap and
+ * centralizes the allowed values.
+ */
+export type LoopMode = "off" | "one" | "all";
+
 export interface AudioState {
+  // Playback state
   isPlaying: boolean;
   isPaused: boolean;
   isStopped: boolean;
+
+  // Timing
   currentTime: number;
   duration: number;
+
+  // Output levels
   volume: number;
   isMuted: boolean;
+
+  // Track and playlist info
   currentTrack: AudioTrack | null;
   playlist: AudioTrack[];
   currentTrackIndex: number;
+
+  // Recording and device state
   isLive: boolean;
   isMicrophoneActive: boolean;
   inputDevice: string | null;
+
+  // User playback preferences
   shuffle: boolean;
-  loopMode: "off" | "one" | "all";
+  loopMode: LoopMode;
 }
 
 // Keyboard shortcuts
@@ -291,7 +310,10 @@ export interface WASMModule {
 export interface AppError {
   code: string;
   message: string;
-  details?: any;
+  // Additional error context from arbitrary sources.
+  // Using `unknown` avoids the pitfalls of `any` while still allowing
+  // flexibility for callers to narrow the type as needed.
+  details?: unknown;
 }
 
 // Toast notification types


### PR DESCRIPTION
## Summary
- persist shuffle and loop mode in audio store
- expose selectors for shuffle and loop mode
- test audio preference transitions and persistence

## Testing
- `npm test src/stores`
- `npx eslint src/stores/audioStore.ts src/types/index.ts src/stores/__tests__/audioPreferences.test.ts`
- `npm run test:coverage src/stores` *(fails: TypeError 'removeEventListener')*

------
https://chatgpt.com/codex/tasks/task_e_68a50ee9d588832bb7516d7fba26ff6b