### PR TITLE
feat: add usage statistics tracking

### DIFF
--- a/react-spectrogram/src/components/__tests__/StatisticsPanel.test.tsx
+++ b/react-spectrogram/src/components/__tests__/StatisticsPanel.test.tsx
@@ -1,0 +1,47 @@
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { describe, it, beforeEach, expect, vi } from "vitest";
+import { StatisticsPanel } from "@/components/layout/StatisticsPanel";
+import {
+  recordPlayStart,
+  recordPlayProgress,
+  recordPlayEnd,
+  resetStats,
+  configureUsageStats,
+} from "@/utils/usageStats";
+
+vi.mock("@/utils/toast", () => ({ directToast: vi.fn() }));
+
+beforeEach(async () => {
+  await resetStats();
+  configureUsageStats({ playThresholdSeconds: 1 });
+  await recordPlayStart({ id: "a", title: "Alpha" });
+  await recordPlayProgress("a", 1);
+  await recordPlayEnd("a");
+  await recordPlayStart({ id: "b", title: "Beta" });
+  await recordPlayProgress("b", 1);
+  await recordPlayEnd("b");
+});
+
+describe("StatisticsPanel", () => {
+  it("filters tracks by search", async () => {
+    render(<StatisticsPanel />);
+    await screen.findByText("Alpha");
+    const input = screen.getByPlaceholderText("Search songs...");
+    fireEvent.change(input, { target: { value: "bet" } });
+    await waitFor(() => {
+      expect(screen.queryByText("Alpha")).toBeNull();
+      expect(screen.getByText("Beta")).toBeInTheDocument();
+    });
+  });
+
+  it("resets statistics", async () => {
+    vi.spyOn(window, "confirm").mockReturnValue(true);
+    render(<StatisticsPanel />);
+    await screen.findByText("Alpha");
+    const resetBtn = screen.getByText("Reset Statistics");
+    fireEvent.click(resetBtn);
+    await waitFor(() => {
+      expect(screen.getByText("Songs: 0")).toBeInTheDocument();
+    });
+  });
+});

--- a/react-spectrogram/src/components/layout/SettingsPanel.tsx
+++ b/react-spectrogram/src/components/layout/SettingsPanel.tsx
@@ -1,9 +1,10 @@
 import React, { useState } from 'react'
-import { X, Palette, Sliders, Monitor, Zap, Key, Image, Check, AlertCircle, Loader2, Database } from 'lucide-react'
+import { X, Palette, Sliders, Monitor, Zap, Key, Image, Check, AlertCircle, Loader2, Database, BarChart } from 'lucide-react'
 import { SpectrogramSettings, Theme, AmplitudeScale, FrequencyScale, Resolution, RefreshRate } from '@/types'
 import { cn } from '@/utils/cn'
 import { directToast } from '@/utils/toast'
 import { MetadataStorePanel } from './MetadataStorePanel'
+import { StatisticsPanel } from './StatisticsPanel'
 
 interface SettingsPanelProps {
   settings: SpectrogramSettings
@@ -19,7 +20,7 @@ export function SettingsPanel({
   onSettingsChange,
 }: SettingsPanelProps) {
   const [validatingKeys, setValidatingKeys] = useState<{ [key: string]: boolean }>({})
-  const [activeTab, setActiveTab] = useState<'general' | 'artwork' | 'api' | 'database'>('general')
+  const [activeTab, setActiveTab] = useState<'general' | 'artwork' | 'api' | 'database' | 'stats'>('general')
 
   if (!isOpen) return null
 
@@ -177,6 +178,18 @@ export function SettingsPanel({
           >
             <Key size={16} className="inline mr-2" />
             API Keys
+          </button>
+          <button
+            onClick={() => setActiveTab('stats')}
+            className={cn(
+              'flex-1 px-4 py-3 text-sm font-medium transition-colors',
+              activeTab === 'stats'
+                ? 'text-accent-blue border-b-2 border-accent-blue'
+                : 'text-neutral-400 hover:text-neutral-200'
+            )}
+          >
+            <BarChart size={16} className="inline mr-2" />
+            Statistics
           </button>
           <button
             onClick={() => setActiveTab('database')}
@@ -486,6 +499,10 @@ export function SettingsPanel({
                 </div>
               </div>
             </div>
+          )}
+
+          {activeTab === 'stats' && (
+            <StatisticsPanel />
           )}
 
           {activeTab === 'database' && (

--- a/react-spectrogram/src/components/layout/StatisticsPanel.tsx
+++ b/react-spectrogram/src/components/layout/StatisticsPanel.tsx
@@ -1,0 +1,190 @@
+import React, { useEffect, useState, useMemo } from "react";
+import {
+  getStats,
+  resetStats,
+  flushDatabase,
+  UsageStatsSummary,
+} from "@/utils/usageStats";
+import { directToast } from "@/utils/toast";
+
+// Minimal statistics display used inside the Settings panel. It intentionally
+// keeps rendering logic lightweight to avoid blocking the main thread. Large
+// tables are paginated to avoid DOM thrashing.
+
+interface StatisticsPanelProps {
+  className?: string;
+}
+
+// Hard limit for rows rendered at once. This prevents the UI from locking up
+// with extremely large libraries.
+const PAGE_SIZE = 1000;
+
+export function StatisticsPanel({ className }: StatisticsPanelProps) {
+  const [stats, setStats] = useState<UsageStatsSummary | null>(null);
+  const [page, setPage] = useState(0);
+  const [search, setSearch] = useState("");
+
+  useEffect(() => {
+    refresh();
+  }, []);
+
+  const refresh = async () => {
+    const s = await getStats();
+    setStats(s);
+  };
+
+  const filteredTracks = useMemo(() => {
+    if (!stats) return [];
+    return stats.tracks
+      .filter(
+        (t) => !search || t.title?.toLowerCase().includes(search.toLowerCase()),
+      )
+      .sort((a, b) => b.playCount - a.playCount);
+  }, [stats, search]);
+
+  const paginated = filteredTracks.slice(
+    page * PAGE_SIZE,
+    (page + 1) * PAGE_SIZE,
+  );
+
+  const exportJSON = () => {
+    if (!stats) return;
+    const blob = new Blob([JSON.stringify(stats, null, 2)], {
+      type: "application/json",
+    });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement("a");
+    a.href = url;
+    a.download = "usage-stats.json";
+    a.click();
+    URL.revokeObjectURL(url);
+  };
+
+  const exportCSV = () => {
+    if (!stats) return;
+    const header = "id,title,artist,album,genre,plays,duration,lastPlayed\n";
+    const rows = stats.tracks
+      .map((t) =>
+        [
+          t.id,
+          t.title ?? "",
+          t.artist ?? "",
+          t.album ?? "",
+          t.genre ?? "",
+          t.playCount,
+          t.totalDuration,
+          t.lastPlayed,
+        ]
+          .map((v) => `"${String(v).replace(/"/g, '""')}"`)
+          .join(","),
+      )
+      .join("\n");
+    const blob = new Blob([header + rows], { type: "text/csv" });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement("a");
+    a.href = url;
+    a.download = "usage-stats.csv";
+    a.click();
+    URL.revokeObjectURL(url);
+  };
+
+  const handleReset = async () => {
+    if (!window.confirm("Reset usage statistics?")) return;
+    await resetStats();
+    await refresh();
+    directToast("Statistics reset");
+  };
+
+  const handleFlush = async () => {
+    if (!window.confirm("Flush ALL application data? This is irreversible."))
+      return;
+    await flushDatabase();
+    await refresh();
+    directToast("Database flushed");
+  };
+
+  if (!stats) {
+    return <div className={className}>Loading statistics...</div>;
+  }
+
+  return (
+    <div className={className}>
+      {/* Totals */}
+      <div className="grid grid-cols-2 gap-4 mb-4 text-sm">
+        <div className="panel p-2">Songs: {stats.totalSongs}</div>
+        <div className="panel p-2">Artists: {stats.totalArtists}</div>
+        <div className="panel p-2">Albums: {stats.totalAlbums}</div>
+        <div className="panel p-2">Genres: {stats.totalGenres}</div>
+        <div className="panel p-2">Total Plays: {stats.totalPlays}</div>
+        <div className="panel p-2">
+          Total Time: {stats.totalPlayTime.toFixed(1)}s
+        </div>
+      </div>
+
+      {/* Controls */}
+      <div className="flex items-center gap-2 mb-4">
+        <input
+          className="input flex-1"
+          placeholder="Search songs..."
+          value={search}
+          onChange={(e) => setSearch(e.target.value)}
+        />
+        <button className="btn" onClick={exportJSON}>
+          JSON
+        </button>
+        <button className="btn" onClick={exportCSV}>
+          CSV
+        </button>
+        <button className="btn" onClick={handleReset}>
+          Reset Statistics
+        </button>
+        <button className="btn" onClick={handleFlush}>
+          Flush Database
+        </button>
+      </div>
+
+      {/* Table */}
+      <table className="w-full text-sm">
+        <thead>
+          <tr>
+            <th className="text-left">Title</th>
+            <th className="text-left">Plays</th>
+            <th className="text-left">Duration</th>
+          </tr>
+        </thead>
+        <tbody>
+          {paginated.map((t) => (
+            <tr key={t.id}>
+              <td>{t.title ?? t.id}</td>
+              <td>{t.playCount}</td>
+              <td>{t.totalDuration.toFixed(1)}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+
+      {/* Pagination */}
+      {filteredTracks.length > PAGE_SIZE && (
+        <div className="flex justify-between mt-2 text-sm">
+          <button
+            className="btn"
+            disabled={page === 0}
+            onClick={() => setPage((p) => p - 1)}
+          >
+            Prev
+          </button>
+          <span>
+            Page {page + 1} / {Math.ceil(filteredTracks.length / PAGE_SIZE)}
+          </span>
+          <button
+            className="btn"
+            disabled={(page + 1) * PAGE_SIZE >= filteredTracks.length}
+            onClick={() => setPage((p) => p + 1)}
+          >
+            Next
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/react-spectrogram/src/utils/__tests__/usageStats.test.ts
+++ b/react-spectrogram/src/utils/__tests__/usageStats.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import {
+  recordPlayStart,
+  recordPlayProgress,
+  recordPlayEnd,
+  getStats,
+  resetStats,
+  configureUsageStats,
+} from "@/utils/usageStats";
+
+// Use small threshold to speed up tests
+beforeEach(async () => {
+  await resetStats();
+  configureUsageStats({ playThresholdSeconds: 3 });
+});
+
+describe("usageStats", () => {
+  it("counts play only after threshold", async () => {
+    await recordPlayStart({ id: "a", title: "Song A" });
+    await recordPlayProgress("a", 2);
+    await recordPlayEnd("a");
+    let stats = await getStats();
+    expect(stats.totalPlays).toBe(0);
+    expect(stats.totalPlayTime).toBe(2);
+
+    // second play exceeding threshold
+    await recordPlayStart({ id: "a", title: "Song A" });
+    await recordPlayProgress("a", 4);
+    await recordPlayEnd("a");
+    stats = await getStats();
+    expect(stats.totalPlays).toBe(1);
+    expect(stats.totalPlayTime).toBe(6);
+  });
+
+  it("ignores invalid progress", async () => {
+    await recordPlayStart({ id: "b" });
+    await recordPlayProgress("b", -5);
+    await recordPlayProgress("b", Number.NaN);
+    await recordPlayEnd("b");
+    const stats = await getStats();
+    expect(stats.totalPlayTime).toBe(0);
+  });
+
+  it("handles rapid track switching", async () => {
+    await recordPlayStart({ id: "a" });
+    await recordPlayProgress("a", 2);
+    await recordPlayStart({ id: "b" });
+    await recordPlayProgress("b", 4);
+    await recordPlayEnd("b");
+    await recordPlayEnd("a");
+    const stats = await getStats();
+    const trackA = stats.tracks.find((t) => t.id === "a")!;
+    const trackB = stats.tracks.find((t) => t.id === "b")!;
+    expect(trackA.playCount).toBe(0);
+    expect(trackA.totalDuration).toBe(2);
+    expect(trackB.playCount).toBe(1);
+    expect(trackB.totalDuration).toBe(4);
+  });
+});

--- a/react-spectrogram/src/utils/usageStats.ts
+++ b/react-spectrogram/src/utils/usageStats.ts
@@ -1,0 +1,322 @@
+// Extensive usage statistics tracking for audio playback
+// This module is intentionally defensive and paranoid: all operations
+// validate inputs and fail fast. All magic numbers are replaced with
+// well named constants so behaviour is explicit and configurable.
+
+// The statistics are persisted to IndexedDB when available. During tests
+// or in environments without IndexedDB support we fall back to an
+// in-memory map. The API surface mirrors the real implementation so the
+// rest of the app can remain agnostic of the storage backend.
+
+// ---------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------
+
+export interface TrackMetadata {
+  id: string; // Unique identifier for the track (hash, url, etc.)
+  title?: string;
+  artist?: string;
+  album?: string;
+  genre?: string;
+}
+
+export interface TrackStats {
+  id: string;
+  playCount: number;
+  totalDuration: number; // seconds
+  lastPlayed: number; // epoch ms
+  // The following properties are stored redundantly to make per-artist / per-genre
+  // aggregations fast without touching other databases. Keeping them here also
+  // allows us to compute unique counts without joining.
+  title?: string;
+  artist?: string;
+  album?: string;
+  genre?: string;
+}
+
+export interface UsageStatsSummary {
+  // Totals across all tracks
+  totalSongs: number;
+  totalArtists: number;
+  totalAlbums: number;
+  totalGenres: number;
+  totalPlayTime: number; // seconds
+  totalPlays: number; // number of completed plays
+  // Raw track stats for tables / further aggregation
+  tracks: TrackStats[];
+}
+
+// ---------------------------------------------------------------------
+// Constants – tunable but never inline
+// ---------------------------------------------------------------------
+
+// Database configuration
+const DB_NAME = "SpectrogramUsageDB";
+const DB_VERSION = 1;
+const STORE_NAME = "track_stats";
+
+// Play count threshold: a track only counts as "played" after this many
+// seconds have elapsed in the current session. The default comes from the
+// product requirement but can be overridden by configure().
+const DEFAULT_PLAY_THRESHOLD_SECONDS = 30;
+
+// Internal flush interval. We batch writes so we do not thrash IndexedDB.
+const FLUSH_INTERVAL_MS = 5_000;
+
+// ---------------------------------------------------------------------
+// Helper utilities
+// ---------------------------------------------------------------------
+
+function getIndexedDB(): IDBFactory | null {
+  try {
+    return globalThis.indexedDB ?? null;
+  } catch {
+    return null;
+  }
+}
+
+// ---------------------------------------------------------------------
+// UsageStats class
+// ---------------------------------------------------------------------
+
+class UsageStats {
+  private dbPromise: Promise<IDBDatabase | null> | null = null;
+  private memoryStore: Map<string, TrackStats> = new Map();
+
+  // Tracks currently in-progress playback sessions. Each entry holds the
+  // accumulated playback duration in seconds and whether the play count has
+  // already been incremented for the session.
+  private activeSessions: Map<string, { played: number; counted: boolean }> =
+    new Map();
+
+  private playThreshold = DEFAULT_PLAY_THRESHOLD_SECONDS;
+  private flushTimer: ReturnType<typeof setTimeout> | null = null;
+  private pendingWrites: Set<string> = new Set();
+
+  configure({ playThresholdSeconds }: { playThresholdSeconds?: number }): void {
+    if (
+      playThresholdSeconds !== undefined &&
+      Number.isFinite(playThresholdSeconds) &&
+      playThresholdSeconds > 0
+    ) {
+      this.playThreshold = playThresholdSeconds;
+    }
+  }
+
+  // -------------------------------------------------------------------
+  // IndexedDB management
+  // -------------------------------------------------------------------
+
+  private async openDB(): Promise<IDBDatabase | null> {
+    if (!getIndexedDB()) return null;
+    if (this.dbPromise) return this.dbPromise;
+
+    this.dbPromise = new Promise((resolve, reject) => {
+      const request = getIndexedDB()!.open(DB_NAME, DB_VERSION);
+
+      request.onerror = () => reject(request.error);
+
+      request.onupgradeneeded = (event) => {
+        const db = (event.target as IDBOpenDBRequest).result;
+        const store = db.createObjectStore(STORE_NAME, { keyPath: "id" });
+        store.createIndex("artist", "artist", { unique: false });
+        store.createIndex("album", "album", { unique: false });
+        store.createIndex("genre", "genre", { unique: false });
+      };
+
+      request.onsuccess = () => resolve(request.result);
+    });
+
+    return this.dbPromise;
+  }
+
+  private async getStore(
+    mode: IDBTransactionMode,
+  ): Promise<IDBObjectStore | null> {
+    const db = await this.openDB();
+    if (!db) return null;
+    const tx = db.transaction(STORE_NAME, mode);
+    return tx.objectStore(STORE_NAME);
+  }
+
+  private async readAll(): Promise<TrackStats[]> {
+    const store = await this.getStore("readonly");
+    if (!store) {
+      return Array.from(this.memoryStore.values());
+    }
+    return new Promise((resolve, reject) => {
+      const request = store.getAll();
+      request.onsuccess = () => resolve(request.result as TrackStats[]);
+      request.onerror = () => reject(request.error);
+    });
+  }
+
+  private async read(id: string): Promise<TrackStats | undefined> {
+    if (!id) return undefined;
+    const store = await this.getStore("readonly");
+    if (!store) {
+      return this.memoryStore.get(id);
+    }
+    return new Promise((resolve, reject) => {
+      const request = store.get(id);
+      request.onsuccess = () =>
+        resolve(request.result as TrackStats | undefined);
+      request.onerror = () => reject(request.error);
+    });
+  }
+
+  private async write(stat: TrackStats): Promise<void> {
+    const store = await this.getStore("readwrite");
+    if (!store) {
+      this.memoryStore.set(stat.id, stat);
+      return;
+    }
+    await new Promise<void>((resolve, reject) => {
+      const request = store.put(stat);
+      request.onsuccess = () => resolve();
+      request.onerror = () => reject(request.error);
+    });
+  }
+
+  private scheduleFlush(): void {
+    if (this.flushTimer) return;
+    this.flushTimer = setTimeout(async () => {
+      const ids = Array.from(this.pendingWrites);
+      this.pendingWrites.clear();
+      this.flushTimer = null;
+      for (const id of ids) {
+        const stat = await this.read(id);
+        if (stat) await this.write(stat);
+      }
+    }, FLUSH_INTERVAL_MS);
+  }
+
+  // -------------------------------------------------------------------
+  // Public API
+  // -------------------------------------------------------------------
+
+  async recordPlayStart(meta: TrackMetadata): Promise<void> {
+    if (!meta || !meta.id) return;
+    if (this.activeSessions.has(meta.id)) return; // Ignore double starts
+    this.activeSessions.set(meta.id, { played: 0, counted: false });
+    // Ensure we have a record for this track so totals are correct even if the
+    // track never passes the play threshold.
+    const existing = await this.read(meta.id);
+    if (!existing) {
+      const stat: TrackStats = {
+        id: meta.id,
+        playCount: 0,
+        totalDuration: 0,
+        lastPlayed: 0,
+        title: meta.title,
+        artist: meta.artist,
+        album: meta.album,
+        genre: meta.genre,
+      };
+      await this.write(stat);
+    }
+  }
+
+  async recordPlayProgress(id: string, seconds: number): Promise<void> {
+    const session = this.activeSessions.get(id);
+    if (!session) return; // Unknown session
+    if (!Number.isFinite(seconds) || seconds <= 0) return; // Invalid input
+
+    session.played += seconds;
+
+    if (!session.counted && session.played >= this.playThreshold) {
+      // We only count the play once per session
+      const stat = (await this.read(id))!;
+      stat.playCount += 1;
+      stat.lastPlayed = Date.now();
+      this.pendingWrites.add(id);
+      session.counted = true;
+      this.scheduleFlush();
+    }
+  }
+
+  async recordPlayEnd(id: string): Promise<void> {
+    const session = this.activeSessions.get(id);
+    if (!session) return;
+    const stat = (await this.read(id))!;
+    stat.totalDuration += session.played;
+    stat.lastPlayed = Date.now();
+    this.pendingWrites.add(id);
+    this.scheduleFlush();
+    this.activeSessions.delete(id);
+  }
+
+  async getStats(): Promise<UsageStatsSummary> {
+    const tracks = await this.readAll();
+    // Compute aggregate totals. We intentionally avoid allocating large
+    // intermediate structures to keep memory usage small even for large
+    // libraries.
+    let totalPlayTime = 0;
+    let totalPlays = 0;
+    const artists = new Set<string>();
+    const albums = new Set<string>();
+    const genres = new Set<string>();
+
+    for (const t of tracks) {
+      totalPlayTime += t.totalDuration;
+      totalPlays += t.playCount;
+      if (t.artist) artists.add(t.artist);
+      if (t.album) albums.add(t.album);
+      if (t.genre) genres.add(t.genre);
+    }
+
+    return {
+      totalSongs: tracks.length,
+      totalArtists: artists.size,
+      totalAlbums: albums.size,
+      totalGenres: genres.size,
+      totalPlayTime,
+      totalPlays,
+      tracks,
+    };
+  }
+
+  async resetStats(): Promise<void> {
+    this.activeSessions.clear();
+    this.pendingWrites.clear();
+    const store = await this.getStore("readwrite");
+    if (!store) {
+      this.memoryStore.clear();
+      return;
+    }
+    await new Promise<void>((resolve, reject) => {
+      const request = store.clear();
+      request.onsuccess = () => resolve();
+      request.onerror = () => reject(request.error);
+    });
+  }
+
+  async flushDatabase(): Promise<void> {
+    const db = await this.openDB();
+    if (db) {
+      db.close();
+      await new Promise<void>((resolve) => {
+        const req = getIndexedDB()!.deleteDatabase(DB_NAME);
+        req.onsuccess = () => resolve();
+        req.onerror = () => resolve(); // Ignore errors, nothing we can do
+      });
+    }
+    this.memoryStore.clear();
+    this.activeSessions.clear();
+    this.pendingWrites.clear();
+    this.dbPromise = null;
+  }
+}
+
+// Singleton instance
+export const usageStats = new UsageStats();
+
+// Re-export public methods for convenience and to keep a stable API surface.
+export const recordPlayStart = usageStats.recordPlayStart.bind(usageStats);
+export const recordPlayProgress =
+  usageStats.recordPlayProgress.bind(usageStats);
+export const recordPlayEnd = usageStats.recordPlayEnd.bind(usageStats);
+export const getStats = usageStats.getStats.bind(usageStats);
+export const resetStats = usageStats.resetStats.bind(usageStats);
+export const flushDatabase = usageStats.flushDatabase.bind(usageStats);
+export const configureUsageStats = usageStats.configure.bind(usageStats);


### PR DESCRIPTION
## Summary
- track per-song play count and duration with IndexedDB fallback
- surface statistics UI with export and reset controls
- hook statistics view into settings panel

## Testing
- `npx --yes prettier react-spectrogram/src/utils/usageStats.ts react-spectrogram/src/components/layout/StatisticsPanel.tsx react-spectrogram/src/utils/__tests__/usageStats.test.ts react-spectrogram/src/components/__tests__/StatisticsPanel.test.tsx --write`
- `npm --prefix react-spectrogram run lint` *(fails: numerous existing eslint errors)*
- `npx --yes eslint src/utils/usageStats.ts src/components/layout/StatisticsPanel.tsx src/utils/__tests__/usageStats.test.ts src/components/__tests__/StatisticsPanel.test.tsx`
- `npm --prefix react-spectrogram test` *(fails: loadFromStorage is not a function, multiple test failures)*

------
https://chatgpt.com/codex/tasks/task_e_68a516690eb8832baeff6c4fac2cf535