### PR TITLE
Throttle playback updates and clamp seek times

### DIFF
--- a/react-spectrogram/src/utils/__tests__/PlaybackEngine.throttle.test.ts
+++ b/react-spectrogram/src/utils/__tests__/PlaybackEngine.throttle.test.ts
@@ -1,0 +1,100 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { playbackEngine } from "../PlaybackEngine";
+
+declare global {
+  interface Window {
+    webkitAudioContext: typeof AudioContext;
+  }
+}
+
+class MockSource {
+  connect = vi.fn();
+  start = vi.fn();
+  stop = vi.fn();
+  disconnect = vi.fn();
+  onended: (() => void) | null = null;
+  buffer: AudioBuffer | null = null;
+}
+
+class MockGain {
+  gain = { value: 1 };
+  connect = vi.fn();
+}
+
+class MockAudioContext {
+  destination = {};
+  get currentTime() {
+    return performance.now() / 1000;
+  }
+  createGain() {
+    return new MockGain() as any;
+  }
+  createBufferSource() {
+    return new MockSource() as any;
+  }
+  createAnalyser() {
+    return { connect: vi.fn(), fftSize: 0 } as any;
+  }
+  resume = vi.fn();
+}
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  vi.stubGlobal("requestAnimationFrame", (cb: FrameRequestCallback) =>
+    setTimeout(() => cb(performance.now()), 10),
+  );
+  vi.stubGlobal("cancelAnimationFrame", vi.fn());
+  (global as any).AudioContext = MockAudioContext as any;
+  (global as any).webkitAudioContext = MockAudioContext as any;
+  (window as any).AudioContext = MockAudioContext as any;
+  (window as any).webkitAudioContext = MockAudioContext as any;
+  (playbackEngine as any).audioContext = new MockAudioContext() as any;
+  (playbackEngine as any).gainNode = new MockGain() as any;
+  (playbackEngine as any).currentBuffer = { duration: 5 } as any;
+});
+
+afterEach(() => {
+  playbackEngine.stop();
+  vi.useRealTimers();
+  vi.clearAllMocks();
+});
+
+describe("PlaybackEngine throttling", () => {
+  it("dispatches at most once per 20ms", () => {
+    const cb = vi.fn();
+    playbackEngine.subscribe(cb);
+    playbackEngine.play(0);
+    cb.mockClear();
+
+    vi.advanceTimersByTime(10);
+    expect(cb).toHaveBeenCalledTimes(0);
+    vi.advanceTimersByTime(10);
+    expect(cb).toHaveBeenCalledTimes(1);
+    vi.advanceTimersByTime(10);
+    expect(cb).toHaveBeenCalledTimes(1);
+  });
+
+  it("resets throttle after seek and pause", () => {
+    const cb = vi.fn();
+    playbackEngine.subscribe(cb);
+    playbackEngine.play(0);
+
+    // Seek should reset throttling
+    playbackEngine.seek(1);
+    cb.mockClear();
+    vi.advanceTimersByTime(10);
+    expect(cb).toHaveBeenCalledTimes(0);
+    vi.advanceTimersByTime(10);
+    expect(cb).toHaveBeenCalledTimes(1);
+
+    // Pause/resume should also reset
+    playbackEngine.pause();
+    playbackEngine.resume();
+    cb.mockClear();
+    vi.advanceTimersByTime(10);
+    expect(cb).toHaveBeenCalledTimes(0);
+    vi.advanceTimersByTime(10);
+    expect(cb).toHaveBeenCalledTimes(1);
+  });
+});

--- a/react-spectrogram/src/utils/__tests__/audioPlayer.throttle.test.ts
+++ b/react-spectrogram/src/utils/__tests__/audioPlayer.throttle.test.ts
@@ -1,0 +1,111 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { audioPlayer, DEFAULT_VOLUME } from "../audioPlayer";
+
+declare global {
+  interface Window {
+    webkitAudioContext: typeof AudioContext;
+  }
+}
+
+class MockSource {
+  connect = vi.fn();
+  start = vi.fn();
+  stop = vi.fn();
+  disconnect = vi.fn();
+  onended: (() => void) | null = null;
+  buffer: AudioBuffer | null = null;
+}
+
+class MockGain {
+  gain = { value: DEFAULT_VOLUME };
+  connect = vi.fn();
+}
+
+class MockAnalyser {
+  connect = vi.fn();
+  fftSize = 0;
+}
+
+class MockAudioContext {
+  destination = {};
+  get currentTime() {
+    return performance.now() / 1000;
+  }
+  createGain() {
+    return new MockGain() as any;
+  }
+  createAnalyser() {
+    return new MockAnalyser() as any;
+  }
+  createBufferSource() {
+    return new MockSource() as any;
+  }
+  decodeAudioData = vi.fn().mockResolvedValue({ duration: 5 } as any);
+  resume = vi.fn();
+  close = vi.fn();
+}
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  vi.stubGlobal("requestAnimationFrame", (cb: FrameRequestCallback) =>
+    setTimeout(() => cb(performance.now()), 10),
+  );
+  vi.stubGlobal("cancelAnimationFrame", vi.fn());
+  (global as any).AudioContext = MockAudioContext as any;
+  (global as any).webkitAudioContext = MockAudioContext as any;
+  (window as any).AudioContext = MockAudioContext as any;
+  (window as any).webkitAudioContext = MockAudioContext as any;
+});
+
+afterEach(() => {
+  audioPlayer.stopPlayback();
+  audioPlayer.cleanup();
+  vi.useRealTimers();
+  vi.clearAllMocks();
+});
+
+describe("audioPlayer throttling", () => {
+  it("dispatches at most once per 20ms", async () => {
+    const cb = vi.fn();
+    audioPlayer.subscribe(cb);
+    const track = {
+      file: { arrayBuffer: async () => new ArrayBuffer(8) },
+    } as any;
+    await audioPlayer.playTrack(track, 0);
+    cb.mockClear();
+
+    vi.advanceTimersByTime(10);
+    expect(cb).toHaveBeenCalledTimes(0);
+    vi.advanceTimersByTime(10);
+    expect(cb).toHaveBeenCalledTimes(1);
+    vi.advanceTimersByTime(10);
+    expect(cb).toHaveBeenCalledTimes(1);
+  });
+
+  it("resets throttle after seek and pause", async () => {
+    const cb = vi.fn();
+    audioPlayer.subscribe(cb);
+    const track = {
+      file: { arrayBuffer: async () => new ArrayBuffer(8) },
+    } as any;
+    await audioPlayer.playTrack(track, 0);
+
+    // Seek should reset throttling
+    audioPlayer.seekTo(1);
+    cb.mockClear();
+    vi.advanceTimersByTime(10);
+    expect(cb).toHaveBeenCalledTimes(0);
+    vi.advanceTimersByTime(10);
+    expect(cb).toHaveBeenCalledTimes(1);
+
+    // Pause/resume should also reset
+    audioPlayer.pausePlayback();
+    await audioPlayer.resumePlayback();
+    cb.mockClear();
+    vi.advanceTimersByTime(10);
+    expect(cb).toHaveBeenCalledTimes(0);
+    vi.advanceTimersByTime(10);
+    expect(cb).toHaveBeenCalledTimes(1);
+  });
+});

--- a/react-spectrogram/src/utils/audioPlayer.ts
+++ b/react-spectrogram/src/utils/audioPlayer.ts
@@ -1,43 +1,48 @@
-import type { AudioTrack } from '@/types'
+import type { AudioTrack } from "@/types";
+
+// Throttle interval for time update dispatches.
+// 20ms (~50Hz) balances responsiveness with overhead.
+const TIME_UPDATE_INTERVAL_MS = 20;
 
 /**
  * State callback signature used by subscribers listening to playback
  * updates from the player.
  */
-type AudioPlayerCallback = (state: AudioPlayerState) => void
+type AudioPlayerCallback = (state: AudioPlayerState) => void;
 
 /**
  * Default volume used when initializing the gain node. Exported for tests
  * and to avoid magic numbers sprinkled through the codebase.
  */
-export const DEFAULT_VOLUME = 0.5
+export const DEFAULT_VOLUME = 0.5;
 
 class AudioPlayerEngine {
-  private static instance: AudioPlayerEngine | null = null
-  private audioContext: AudioContext | null = null
-  private source: AudioBufferSourceNode | null = null
-  private gainNode: GainNode | null = null
-  private analyser: AnalyserNode | null = null
-  private currentBuffer: AudioBuffer | null = null
-  private startTime: number = 0
-  private pausedTime: number = 0
-  private isPaused: boolean = false
-  private animationFrameId: number | null = null
-  private callbacks: Set<AudioPlayerCallback> = new Set()
-  private currentTrack: any = null
-  private currentTime: number = 0
-  private playRequestId = 0
+  private static instance: AudioPlayerEngine | null = null;
+  private audioContext: AudioContext | null = null;
+  private source: AudioBufferSourceNode | null = null;
+  private gainNode: GainNode | null = null;
+  private analyser: AnalyserNode | null = null;
+  private currentBuffer: AudioBuffer | null = null;
+  private startTime: number = 0;
+  private pausedTime: number = 0;
+  private isPaused: boolean = false;
+  private animationFrameId: number | null = null;
+  private callbacks: Set<AudioPlayerCallback> = new Set();
+  private currentTrack: AudioTrack | null = null;
+  private currentTime: number = 0;
+  private playRequestId = 0;
+  private lastDispatch = 0;
   /**
    * Registered callbacks for when the current track finishes playback. We
    * keep a set so multiple listeners (e.g. tests or hooks) can respond
    * without overwriting each other.
    */
-  private trackEndCallbacks: Set<() => void> = new Set()
+  private trackEndCallbacks: Set<() => void> = new Set();
 
   // Microphone-related properties
-  private microphoneSource: MediaStreamAudioSourceNode | null = null
-  private microphoneStream: MediaStream | null = null
-  private microphoneActive: boolean = false
+  private microphoneSource: MediaStreamAudioSourceNode | null = null;
+  private microphoneStream: MediaStream | null = null;
+  private microphoneActive: boolean = false;
 
   private constructor() {
     // Private constructor to enforce singleton
@@ -45,17 +50,17 @@ class AudioPlayerEngine {
 
   static getInstance(): AudioPlayerEngine {
     if (!AudioPlayerEngine.instance) {
-      AudioPlayerEngine.instance = new AudioPlayerEngine()
+      AudioPlayerEngine.instance = new AudioPlayerEngine();
     }
-    return AudioPlayerEngine.instance
+    return AudioPlayerEngine.instance;
   }
 
   // Subscribe to state changes
   subscribe(callback: AudioPlayerCallback): () => void {
-    this.callbacks.add(callback)
+    this.callbacks.add(callback);
     return () => {
-      this.callbacks.delete(callback)
-    }
+      this.callbacks.delete(callback);
+    };
   }
 
   /**
@@ -64,13 +69,13 @@ class AudioPlayerEngine {
    * without directly coupling to the player internals.
    */
   onTrackEnd(callback: () => void): () => void {
-    this.trackEndCallbacks.add(callback)
-    return () => this.trackEndCallbacks.delete(callback)
+    this.trackEndCallbacks.add(callback);
+    return () => this.trackEndCallbacks.delete(callback);
   }
 
-
-  // Notify all subscribers of state changes
-  private notifySubscribers() {
+  // Notify all subscribers of state changes and record dispatch time.
+  private notifySubscribers(now: number = performance.now()) {
+    this.lastDispatch = now;
     const state: AudioPlayerState = {
       isPlaying: this.isPlaying(),
       isPaused: this.isPaused,
@@ -78,74 +83,77 @@ class AudioPlayerEngine {
       currentTime: this.getCurrentTime(),
       duration: this.getDuration(),
       volume: this.getVolume(),
-      isMuted: this.getMuted()
-    }
-    
-    this.callbacks.forEach(callback => callback(state))
+      isMuted: this.getMuted(),
+    };
+
+    this.callbacks.forEach((callback) => callback(state));
   }
 
   // Initialize audio context - this is the ONLY place where AudioContext is created
   async initAudioContext(): Promise<AudioContext> {
     if (!this.audioContext) {
-      this.audioContext = new (window.AudioContext || (window as any).webkitAudioContext)()
-      
+      const win = window as Window & {
+        webkitAudioContext?: typeof AudioContext;
+      };
+      this.audioContext = new (window.AudioContext ||
+        win.webkitAudioContext)!();
+
       // Create gain node for volume control
-      this.gainNode = this.audioContext.createGain()
-      this.gainNode.gain.value = DEFAULT_VOLUME // Initialize to sane default
-      
+      this.gainNode = this.audioContext.createGain();
+      this.gainNode.gain.value = DEFAULT_VOLUME; // Initialize to sane default
+
       // Create analyser for frequency data
-      this.analyser = this.audioContext.createAnalyser()
-      this.analyser.fftSize = 2048
-      
+      this.analyser = this.audioContext.createAnalyser();
+      this.analyser.fftSize = 2048;
+
       // Connect nodes
-      this.gainNode.connect(this.analyser)
-      this.analyser.connect(this.audioContext.destination)
+      this.gainNode.connect(this.analyser);
+      this.analyser.connect(this.audioContext.destination);
     }
 
     // Resume context if suspended
-    if (this.audioContext.state === 'suspended') {
-      await this.audioContext.resume()
+    if (this.audioContext.state === "suspended") {
+      await this.audioContext.resume();
     }
 
-    return this.audioContext
+    return this.audioContext;
   }
 
   // Get the shared audio context (for other components to use)
   getAudioContext(): AudioContext | null {
-    return this.audioContext
+    return this.audioContext;
   }
 
   // Get the shared analyser node
   getAnalyser(): AnalyserNode | null {
-    return this.analyser
+    return this.analyser;
   }
 
   // Get the shared gain node
   getGainNode(): GainNode | null {
-    return this.gainNode
+    return this.gainNode;
   }
 
   // Start microphone input using the shared audio context
   async startMicrophone(stream: MediaStream): Promise<boolean> {
     try {
-      const context = await this.initAudioContext()
-      
+      const context = await this.initAudioContext();
+
       // Stop any current playback
-      this.stopCurrentPlayback()
-      
+      this.stopCurrentPlayback();
+
       // Store the stream
-      this.microphoneStream = stream
-      
+      this.microphoneStream = stream;
+
       // Create audio source from stream
-      this.microphoneSource = context.createMediaStreamSource(stream)
-      this.microphoneSource.connect(this.gainNode!)
-      
-      this.microphoneActive = true
-      
-      return true
-      
+      this.microphoneSource = context.createMediaStreamSource(stream);
+      this.microphoneSource.connect(this.gainNode!);
+
+      this.microphoneActive = true;
+
+      return true;
     } catch (error) {
-      return false
+      return false;
     }
   }
 
@@ -154,28 +162,27 @@ class AudioPlayerEngine {
     try {
       // Stop all tracks in the stream
       if (this.microphoneStream) {
-        this.microphoneStream.getTracks().forEach(track => track.stop())
-        this.microphoneStream = null
+        this.microphoneStream.getTracks().forEach((track) => track.stop());
+        this.microphoneStream = null;
       }
 
       // Disconnect audio source
       if (this.microphoneSource) {
-        this.microphoneSource.disconnect()
-        this.microphoneSource = null
+        this.microphoneSource.disconnect();
+        this.microphoneSource = null;
       }
 
-      this.microphoneActive = false
-      
-      return true
-      
+      this.microphoneActive = false;
+
+      return true;
     } catch (error) {
-      return false
+      return false;
     }
   }
 
   // Check if microphone is active
   isMicrophoneActive(): boolean {
-    return this.microphoneActive
+    return this.microphoneActive;
   }
 
   // Stop all current playback
@@ -183,303 +190,304 @@ class AudioPlayerEngine {
     if (this.source) {
       try {
         // Prevent old onended handlers from firing after stop
-        this.source.onended = null
-        this.source.stop()
+        this.source.onended = null;
+        this.source.stop();
       } catch (e) {
         // Source might already be stopped
       }
       try {
-        this.source.disconnect()
+        this.source.disconnect();
       } catch (e) {
         // Source might already be disconnected
       }
-      this.source = null
+      this.source = null;
     }
-    
+
     if (this.animationFrameId) {
-      cancelAnimationFrame(this.animationFrameId)
-      this.animationFrameId = null
+      cancelAnimationFrame(this.animationFrameId);
+      this.animationFrameId = null;
     }
   }
 
   // Play a track
-  async playTrack(track: any, startAt = 0): Promise<void> {
-    const requestId = ++this.playRequestId
-    try {
-      const context = await this.initAudioContext()
+  async playTrack(track: AudioTrack, startAt = 0): Promise<void> {
+    const requestId = ++this.playRequestId;
+    const context = await this.initAudioContext();
 
-      // Stop any current playback and microphone
-      this.stopCurrentPlayback()
-      this.stopMicrophone()
+    // Stop any current playback and microphone
+    this.stopCurrentPlayback();
+    this.stopMicrophone();
 
-      // Reset state
-      this.isPaused = false
-      this.pausedTime = 0
-      this.currentTrack = track
+    // Reset state
+    this.isPaused = false;
+    this.pausedTime = 0;
+    this.currentTrack = track;
 
-      // Load audio buffer
-      const arrayBuffer = await track.file.arrayBuffer()
-      const decodedBuffer = await context.decodeAudioData(arrayBuffer)
-      if (requestId !== this.playRequestId) {
-        return
-      }
-      this.currentBuffer = decodedBuffer
-
-      // Create new source
-      this.source = context.createBufferSource()
-      this.source.buffer = this.currentBuffer
-      this.source.connect(this.gainNode!)
-
-      // Set up ended callback
-      this.source.onended = () => {
-        this.handleTrackEnded()
-      }
-
-      // Start playback at the requested offset
-      this.source.start(0, startAt)
-      this.startTime = context.currentTime - startAt
-
-      // Start time update loop
-      this.updateTime()
-
-      this.notifySubscribers()
-
-    } catch (error) {
-      throw error
+    // Load audio buffer
+    const arrayBuffer = await track.file.arrayBuffer();
+    const decodedBuffer = await context.decodeAudioData(arrayBuffer);
+    if (requestId !== this.playRequestId) {
+      return;
     }
+    this.currentBuffer = decodedBuffer;
+
+    // Clamp start offset to valid range before starting playback
+    const duration = this.currentBuffer.duration;
+    const safeStart = Math.max(
+      0,
+      Math.min(Number.isFinite(startAt) ? startAt : 0, duration),
+    );
+
+    // Create new source
+    this.source = context.createBufferSource();
+    this.source.buffer = this.currentBuffer;
+    this.source.connect(this.gainNode!);
+
+    // Set up ended callback
+    this.source.onended = () => {
+      this.handleTrackEnded();
+    };
+
+    // Start playback at the requested offset
+    this.source.start(0, safeStart);
+    this.startTime = context.currentTime - safeStart;
+
+    // Notify immediately then begin update loop
+    this.notifySubscribers();
+    this.updateTime();
   }
 
   // Pause playback
   pausePlayback(): void {
     if (this.source && !this.isPaused) {
       try {
-        this.source.stop()
+        this.source.stop();
       } catch (e) {
         // Source might already be stopped
       }
-      
+
       if (this.animationFrameId) {
-        cancelAnimationFrame(this.animationFrameId)
-        this.animationFrameId = null
+        cancelAnimationFrame(this.animationFrameId);
+        this.animationFrameId = null;
       }
-      
-      this.pausedTime = this.audioContext!.currentTime - this.startTime
-      this.isPaused = true
-      this.source = null
-      
-      this.notifySubscribers()
+
+      this.pausedTime = this.audioContext!.currentTime - this.startTime;
+      this.isPaused = true;
+      this.source = null;
+
+      this.notifySubscribers();
     }
   }
 
   // Resume playback
   async resumePlayback(): Promise<void> {
     if (this.isPaused && this.currentBuffer && this.audioContext) {
-      try {
-        // Create new source starting from paused position
-        this.source = this.audioContext.createBufferSource()
-        this.source.buffer = this.currentBuffer
-        this.source.connect(this.gainNode!)
-        
-        // Set up ended callback
-        this.source.onended = () => {
-          this.handleTrackEnded()
-        }
-        
-        // Start playback from paused position
-        this.source.start(0, this.pausedTime)
-        this.startTime = this.audioContext.currentTime - this.pausedTime
-        this.isPaused = false
-        
-        // Start time update loop
-        this.updateTime()
-        
-        this.notifySubscribers()
-      } catch (error) {
-        throw error
-      }
+      // Create new source starting from paused position
+      this.source = this.audioContext.createBufferSource();
+      this.source.buffer = this.currentBuffer;
+      this.source.connect(this.gainNode!);
+
+      // Set up ended callback
+      this.source.onended = () => {
+        this.handleTrackEnded();
+      };
+
+      // Start playback from paused position
+      this.source.start(0, this.pausedTime);
+      this.startTime = this.audioContext.currentTime - this.pausedTime;
+      this.isPaused = false;
+
+      // Notify immediately then restart update loop
+      this.notifySubscribers();
+      this.updateTime();
     }
   }
 
   // Stop playback
   stopPlayback(): void {
-    this.playRequestId++
-    this.stopCurrentPlayback()
-    this.stopMicrophone()
-    this.isPaused = false
-    this.pausedTime = 0
-    this.currentTime = 0
-    this.currentTrack = null
+    this.playRequestId++;
+    this.stopCurrentPlayback();
+    this.stopMicrophone();
+    this.isPaused = false;
+    this.pausedTime = 0;
+    this.currentTime = 0;
+    this.currentTrack = null;
 
-    this.notifySubscribers()
+    this.notifySubscribers();
   }
 
   // Seek to position
   seekTo(time: number): void {
-    if (!this.currentBuffer) return
+    if (!this.currentBuffer) return;
 
-    const clampedTime = Math.max(0, Math.min(time, this.currentBuffer.duration))
-    
+    const duration = this.currentBuffer.duration;
+    const clampedTime = Math.max(
+      0,
+      Math.min(Number.isFinite(time) ? time : 0, duration),
+    );
+
     if (this.isPaused) {
-      this.pausedTime = clampedTime
-      this.notifySubscribers()
+      this.pausedTime = clampedTime;
+      this.notifySubscribers();
     } else if (this.source) {
       // Stop current playback and restart from new position
-      this.stopCurrentPlayback()
-      this.startTime = this.audioContext!.currentTime - clampedTime
-      
+      this.stopCurrentPlayback();
+      this.startTime = this.audioContext!.currentTime - clampedTime;
+
       // Create new source
-      this.source = this.audioContext!.createBufferSource()
-      this.source.buffer = this.currentBuffer
-      this.source.connect(this.gainNode!)
-      
+      this.source = this.audioContext!.createBufferSource();
+      this.source.buffer = this.currentBuffer;
+      this.source.connect(this.gainNode!);
+
       this.source.onended = () => {
-        this.handleTrackEnded()
-      }
-      
-      this.source.start(0, clampedTime)
-      this.updateTime()
-      
-      this.notifySubscribers()
+        this.handleTrackEnded();
+      };
+
+      this.source.start(0, clampedTime);
+      // Notify immediately then restart update loop
+      this.notifySubscribers();
+      this.updateTime();
     }
   }
 
   // Set volume
   setVolume(volume: number): void {
     if (this.gainNode) {
-      this.gainNode.gain.value = Math.max(0, Math.min(1, volume))
-      this.notifySubscribers()
+      this.gainNode.gain.value = Math.max(0, Math.min(1, volume));
+      this.notifySubscribers();
     }
   }
 
   // Toggle mute
   toggleMute(): void {
     if (this.gainNode) {
-      const currentVolume = this.gainNode.gain.value
+      const currentVolume = this.gainNode.gain.value;
       if (currentVolume > 0) {
-        this.gainNode.gain.value = 0
+        this.gainNode.gain.value = 0;
       } else {
-        this.gainNode.gain.value = DEFAULT_VOLUME // Restore to default volume
+        this.gainNode.gain.value = DEFAULT_VOLUME; // Restore to default volume
       }
-      this.notifySubscribers()
+      this.notifySubscribers();
     }
   }
 
   // Get frequency data
   getFrequencyData(): Uint8Array | null {
-    if (!this.analyser) return null
-    
-    const bufferLength = this.analyser.frequencyBinCount
-    const dataArray = new Uint8Array(bufferLength)
-    this.analyser.getByteFrequencyData(dataArray)
-    
-    return dataArray
+    if (!this.analyser) return null;
+
+    const bufferLength = this.analyser.frequencyBinCount;
+    const dataArray = new Uint8Array(bufferLength);
+    this.analyser.getByteFrequencyData(dataArray);
+
+    return dataArray;
   }
 
   // Get time domain data
   getTimeData(): Uint8Array | null {
-    if (!this.analyser) return null
-    
-    const bufferLength = this.analyser.frequencyBinCount
-    const dataArray = new Uint8Array(bufferLength)
-    this.analyser.getByteTimeDomainData(dataArray)
-    
-    return dataArray
+    if (!this.analyser) return null;
+
+    const bufferLength = this.analyser.frequencyBinCount;
+    const dataArray = new Uint8Array(bufferLength);
+    this.analyser.getByteTimeDomainData(dataArray);
+
+    return dataArray;
   }
 
   // Update time and notify subscribers
+  // Use rAF for smoothness but throttle to TIME_UPDATE_INTERVAL_MS.
   private updateTime = () => {
     if (this.source && !this.isPaused && this.audioContext) {
-      const currentTime = this.audioContext.currentTime - this.startTime
-      this.currentTime = Math.min(currentTime, this.getDuration())
-      
-      if (currentTime < this.getDuration()) {
-        this.animationFrameId = requestAnimationFrame(this.updateTime)
+      const now = performance.now();
+      if (now - this.lastDispatch >= TIME_UPDATE_INTERVAL_MS) {
+        const currentTime = this.audioContext.currentTime - this.startTime;
+        this.currentTime = Math.min(currentTime, this.getDuration());
+        this.notifySubscribers(now);
       }
-      
-      this.notifySubscribers()
+      this.animationFrameId = requestAnimationFrame(this.updateTime);
     }
-  }
+  };
 
   // Handle track ended
   private handleTrackEnded(): void {
-    this.isPaused = false
-    this.pausedTime = 0
-    this.currentTime = 0
-    this.source = null
-    this.currentTrack = null
-    
+    this.isPaused = false;
+    this.pausedTime = 0;
+    this.currentTime = 0;
+    this.source = null;
+    this.currentTrack = null;
+
     if (this.animationFrameId) {
-      cancelAnimationFrame(this.animationFrameId)
-      this.animationFrameId = null
+      cancelAnimationFrame(this.animationFrameId);
+      this.animationFrameId = null;
     }
 
-    this.notifySubscribers()
+    this.notifySubscribers();
 
     // Inform any listeners that playback naturally reached the end. The
     // surrounding application (store, hooks) decides what to do next—play
     // another track, loop, or stop entirely.
-    this.trackEndCallbacks.forEach(cb => {
+    this.trackEndCallbacks.forEach((cb) => {
       try {
-        cb()
+        cb();
       } catch {
         /* swallow listener errors to avoid breaking player state */
       }
-    })
+    });
   }
 
   // State getters
   isPlaying(): boolean {
-    return !!this.source && !this.isPaused
+    return !!this.source && !this.isPaused;
   }
 
   isStopped(): boolean {
-    return !this.source && !this.isPaused && !this.microphoneActive
+    return !this.source && !this.isPaused && !this.microphoneActive;
   }
 
   getCurrentTime(): number {
     if (this.isPaused) {
-      return this.pausedTime
+      return this.pausedTime;
     }
     if (this.source && this.audioContext) {
-      return Math.min(this.audioContext.currentTime - this.startTime, this.getDuration())
+      return Math.min(
+        this.audioContext.currentTime - this.startTime,
+        this.getDuration(),
+      );
     }
-    return 0
+    return 0;
   }
 
   getDuration(): number {
-    return this.currentBuffer?.duration || 0
+    return this.currentBuffer?.duration || 0;
   }
 
   getVolume(): number {
-    return this.gainNode?.gain.value || 0
+    return this.gainNode?.gain.value || 0;
   }
 
   getMuted(): boolean {
-    return this.gainNode?.gain.value === 0
+    return this.gainNode?.gain.value === 0;
   }
 
   // Cleanup
   cleanup(): void {
-    this.stopCurrentPlayback()
-    this.stopMicrophone()
-    
-    if (this.audioContext) {
-      this.audioContext.close()
-      this.audioContext = null
-    }
-    
-    this.gainNode = null
-    this.analyser = null
-    this.currentBuffer = null
-    this.currentTrack = null
-    this.callbacks.clear()
-  }
+    this.stopCurrentPlayback();
+    this.stopMicrophone();
 
+    if (this.audioContext) {
+      this.audioContext.close();
+      this.audioContext = null;
+    }
+
+    this.gainNode = null;
+    this.analyser = null;
+    this.currentBuffer = null;
+    this.currentTrack = null;
+    this.callbacks.clear();
+  }
 }
 
 // Export singleton instance
-export const audioPlayer = AudioPlayerEngine.getInstance()
+export const audioPlayer = AudioPlayerEngine.getInstance();
 
 // Export types
-export type { AudioPlayerState, AudioPlayerCallback }
-
+export type { AudioPlayerState, AudioPlayerCallback };


### PR DESCRIPTION
## Summary
- throttle playback time notifications to 20ms using `requestAnimationFrame`
- clamp play and seek offsets to valid duration ranges
- add throttling tests for `PlaybackEngine` and `audioPlayer`

## Testing
- `npx eslint src/utils/PlaybackEngine.ts src/utils/audioPlayer.ts src/utils/__tests__/PlaybackEngine.throttle.test.ts src/utils/__tests__/audioPlayer.throttle.test.ts`
- `npm test` *(fails: TypeError: loadFromStorage is not a function, audioPlayer.onTrackEnd is not a function)*

------
https://chatgpt.com/codex/tasks/task_e_68a51994010c832ba8b0f91a242ec02e