### PR TITLE
refactor: share time update logic

### DIFF
--- a/react-spectrogram/src/utils/__tests__/timeUpdater.test.ts
+++ b/react-spectrogram/src/utils/__tests__/timeUpdater.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { createTimeUpdater } from "../timeUpdater";
+
+describe("createTimeUpdater", () => {
+  let rafCallbacks: Record<number, FrameRequestCallback>;
+  let rafId = 0;
+  type RafEnv = {
+    requestAnimationFrame: (cb: FrameRequestCallback) => number;
+    cancelAnimationFrame: (id: number) => void;
+  };
+  let rafEnv: RafEnv;
+
+  beforeEach(() => {
+    rafCallbacks = {};
+    rafId = 0;
+    rafEnv = globalThis as unknown as RafEnv;
+    // Mock rAF/cAF to provide deterministic control over the loop
+    rafEnv.requestAnimationFrame = vi.fn((cb: FrameRequestCallback) => {
+      const id = ++rafId;
+      rafCallbacks[id] = cb;
+      return id;
+    });
+    rafEnv.cancelAnimationFrame = vi.fn((id: number) => {
+      delete rafCallbacks[id];
+    });
+  });
+
+  it("invokes callbacks until shouldContinue returns false", () => {
+    let time = 0;
+    const onUpdate = vi.fn();
+    const updater = createTimeUpdater({
+      getTime: () => ++time,
+      onUpdate,
+      shouldContinue: (t) => t < 2,
+    });
+
+    updater.start();
+    // First frame
+    rafCallbacks[1]();
+    // Second frame; shouldContinue now false so loop stops
+    rafCallbacks[2]();
+
+    expect(onUpdate).toHaveBeenCalledTimes(2);
+    expect(onUpdate).toHaveBeenNthCalledWith(1, 1);
+    expect(onUpdate).toHaveBeenNthCalledWith(2, 2);
+    expect(rafEnv.requestAnimationFrame).toHaveBeenCalledTimes(2);
+    expect(rafEnv.cancelAnimationFrame).toHaveBeenCalledTimes(0);
+  });
+
+  it("stop cancels the scheduled frame", () => {
+    const updater = createTimeUpdater({
+      getTime: () => 0,
+      onUpdate: () => {},
+    });
+    updater.start();
+    updater.stop();
+    expect(rafEnv.cancelAnimationFrame).toHaveBeenCalledTimes(1);
+  });
+
+  it("throws on invalid time values", () => {
+    const updater = createTimeUpdater({
+      getTime: () => NaN,
+      onUpdate: () => {},
+    });
+    updater.start();
+    expect(() => rafCallbacks[1]()).toThrow("Invalid time value");
+    expect(rafEnv.cancelAnimationFrame).toHaveBeenCalledTimes(1);
+  });
+});

--- a/react-spectrogram/src/utils/audioPlayer.ts
+++ b/react-spectrogram/src/utils/audioPlayer.ts
@@ -1,43 +1,67 @@
-import type { AudioTrack } from '@/types'
+import type { AudioTrack } from "@/types";
+import { createTimeUpdater } from "./timeUpdater";
 
 /**
  * State callback signature used by subscribers listening to playback
  * updates from the player.
  */
-type AudioPlayerCallback = (state: AudioPlayerState) => void
+type AudioPlayerCallback = (state: AudioPlayerState) => void;
 
 /**
  * Default volume used when initializing the gain node. Exported for tests
  * and to avoid magic numbers sprinkled through the codebase.
  */
-export const DEFAULT_VOLUME = 0.5
+export const DEFAULT_VOLUME = 0.5;
 
 class AudioPlayerEngine {
-  private static instance: AudioPlayerEngine | null = null
-  private audioContext: AudioContext | null = null
-  private source: AudioBufferSourceNode | null = null
-  private gainNode: GainNode | null = null
-  private analyser: AnalyserNode | null = null
-  private currentBuffer: AudioBuffer | null = null
-  private startTime: number = 0
-  private pausedTime: number = 0
-  private isPaused: boolean = false
-  private animationFrameId: number | null = null
-  private callbacks: Set<AudioPlayerCallback> = new Set()
-  private currentTrack: any = null
-  private currentTime: number = 0
-  private playRequestId = 0
+  private static instance: AudioPlayerEngine | null = null;
+  private audioContext: AudioContext | null = null;
+  private source: AudioBufferSourceNode | null = null;
+  private gainNode: GainNode | null = null;
+  private analyser: AnalyserNode | null = null;
+  private currentBuffer: AudioBuffer | null = null;
+  private startTime: number = 0;
+  private pausedTime: number = 0;
+  private isPaused: boolean = false;
+  private callbacks: Set<AudioPlayerCallback> = new Set();
+  private currentTrack: AudioTrack | null = null;
+  private currentTime: number = 0;
+  private playRequestId = 0;
+
+  /**
+   * Shared frame loop handling time progression and subscriber notification.
+   * Centralising this logic avoids divergence between playback engines and
+   * makes the behaviour easy to reason about and test.
+   */
+  private timeUpdater = createTimeUpdater({
+    getTime: () => {
+      if (!this.audioContext || !this.source || this.isPaused) {
+        return this.currentTime;
+      }
+      return this.audioContext.currentTime - this.startTime;
+    },
+    onUpdate: (time) => {
+      // Clamp to duration to avoid reporting times past the end of the buffer.
+      this.currentTime = Math.min(time, this.getDuration());
+      this.notifySubscribers();
+    },
+    shouldContinue: (time) =>
+      !!this.source &&
+      !this.isPaused &&
+      !!this.audioContext &&
+      time < this.getDuration(),
+  });
   /**
    * Registered callbacks for when the current track finishes playback. We
    * keep a set so multiple listeners (e.g. tests or hooks) can respond
    * without overwriting each other.
    */
-  private trackEndCallbacks: Set<() => void> = new Set()
+  private trackEndCallbacks: Set<() => void> = new Set();
 
   // Microphone-related properties
-  private microphoneSource: MediaStreamAudioSourceNode | null = null
-  private microphoneStream: MediaStream | null = null
-  private microphoneActive: boolean = false
+  private microphoneSource: MediaStreamAudioSourceNode | null = null;
+  private microphoneStream: MediaStream | null = null;
+  private microphoneActive: boolean = false;
 
   private constructor() {
     // Private constructor to enforce singleton
@@ -45,17 +69,17 @@ class AudioPlayerEngine {
 
   static getInstance(): AudioPlayerEngine {
     if (!AudioPlayerEngine.instance) {
-      AudioPlayerEngine.instance = new AudioPlayerEngine()
+      AudioPlayerEngine.instance = new AudioPlayerEngine();
     }
-    return AudioPlayerEngine.instance
+    return AudioPlayerEngine.instance;
   }
 
   // Subscribe to state changes
   subscribe(callback: AudioPlayerCallback): () => void {
-    this.callbacks.add(callback)
+    this.callbacks.add(callback);
     return () => {
-      this.callbacks.delete(callback)
-    }
+      this.callbacks.delete(callback);
+    };
   }
 
   /**
@@ -64,10 +88,9 @@ class AudioPlayerEngine {
    * without directly coupling to the player internals.
    */
   onTrackEnd(callback: () => void): () => void {
-    this.trackEndCallbacks.add(callback)
-    return () => this.trackEndCallbacks.delete(callback)
+    this.trackEndCallbacks.add(callback);
+    return () => this.trackEndCallbacks.delete(callback);
   }
-
 
   // Notify all subscribers of state changes
   private notifySubscribers() {
@@ -78,74 +101,77 @@ class AudioPlayerEngine {
       currentTime: this.getCurrentTime(),
       duration: this.getDuration(),
       volume: this.getVolume(),
-      isMuted: this.getMuted()
-    }
-    
-    this.callbacks.forEach(callback => callback(state))
+      isMuted: this.getMuted(),
+    };
+
+    this.callbacks.forEach((callback) => callback(state));
   }
 
   // Initialize audio context - this is the ONLY place where AudioContext is created
   async initAudioContext(): Promise<AudioContext> {
     if (!this.audioContext) {
-      this.audioContext = new (window.AudioContext || (window as any).webkitAudioContext)()
-      
+      const AudioCtx =
+        window.AudioContext ||
+        (window as unknown as { webkitAudioContext: typeof AudioContext })
+          .webkitAudioContext;
+      this.audioContext = new AudioCtx();
+
       // Create gain node for volume control
-      this.gainNode = this.audioContext.createGain()
-      this.gainNode.gain.value = DEFAULT_VOLUME // Initialize to sane default
-      
+      this.gainNode = this.audioContext.createGain();
+      this.gainNode.gain.value = DEFAULT_VOLUME; // Initialize to sane default
+
       // Create analyser for frequency data
-      this.analyser = this.audioContext.createAnalyser()
-      this.analyser.fftSize = 2048
-      
+      this.analyser = this.audioContext.createAnalyser();
+      this.analyser.fftSize = 2048;
+
       // Connect nodes
-      this.gainNode.connect(this.analyser)
-      this.analyser.connect(this.audioContext.destination)
+      this.gainNode.connect(this.analyser);
+      this.analyser.connect(this.audioContext.destination);
     }
 
     // Resume context if suspended
-    if (this.audioContext.state === 'suspended') {
-      await this.audioContext.resume()
+    if (this.audioContext.state === "suspended") {
+      await this.audioContext.resume();
     }
 
-    return this.audioContext
+    return this.audioContext;
   }
 
   // Get the shared audio context (for other components to use)
   getAudioContext(): AudioContext | null {
-    return this.audioContext
+    return this.audioContext;
   }
 
   // Get the shared analyser node
   getAnalyser(): AnalyserNode | null {
-    return this.analyser
+    return this.analyser;
   }
 
   // Get the shared gain node
   getGainNode(): GainNode | null {
-    return this.gainNode
+    return this.gainNode;
   }
 
   // Start microphone input using the shared audio context
   async startMicrophone(stream: MediaStream): Promise<boolean> {
     try {
-      const context = await this.initAudioContext()
-      
+      const context = await this.initAudioContext();
+
       // Stop any current playback
-      this.stopCurrentPlayback()
-      
+      this.stopCurrentPlayback();
+
       // Store the stream
-      this.microphoneStream = stream
-      
+      this.microphoneStream = stream;
+
       // Create audio source from stream
-      this.microphoneSource = context.createMediaStreamSource(stream)
-      this.microphoneSource.connect(this.gainNode!)
-      
-      this.microphoneActive = true
-      
-      return true
-      
+      this.microphoneSource = context.createMediaStreamSource(stream);
+      this.microphoneSource.connect(this.gainNode!);
+
+      this.microphoneActive = true;
+
+      return true;
     } catch (error) {
-      return false
+      return false;
     }
   }
 
@@ -154,28 +180,27 @@ class AudioPlayerEngine {
     try {
       // Stop all tracks in the stream
       if (this.microphoneStream) {
-        this.microphoneStream.getTracks().forEach(track => track.stop())
-        this.microphoneStream = null
+        this.microphoneStream.getTracks().forEach((track) => track.stop());
+        this.microphoneStream = null;
       }
 
       // Disconnect audio source
       if (this.microphoneSource) {
-        this.microphoneSource.disconnect()
-        this.microphoneSource = null
+        this.microphoneSource.disconnect();
+        this.microphoneSource = null;
       }
 
-      this.microphoneActive = false
-      
-      return true
-      
+      this.microphoneActive = false;
+
+      return true;
     } catch (error) {
-      return false
+      return false;
     }
   }
 
   // Check if microphone is active
   isMicrophoneActive(): boolean {
-    return this.microphoneActive
+    return this.microphoneActive;
   }
 
   // Stop all current playback
@@ -183,303 +208,277 @@ class AudioPlayerEngine {
     if (this.source) {
       try {
         // Prevent old onended handlers from firing after stop
-        this.source.onended = null
-        this.source.stop()
+        this.source.onended = null;
+        this.source.stop();
       } catch (e) {
         // Source might already be stopped
       }
       try {
-        this.source.disconnect()
+        this.source.disconnect();
       } catch (e) {
         // Source might already be disconnected
       }
-      this.source = null
+      this.source = null;
     }
-    
-    if (this.animationFrameId) {
-      cancelAnimationFrame(this.animationFrameId)
-      this.animationFrameId = null
-    }
+
+    // Ensure no stray animation frames remain.
+    this.timeUpdater.stop();
   }
 
   // Play a track
-  async playTrack(track: any, startAt = 0): Promise<void> {
-    const requestId = ++this.playRequestId
-    try {
-      const context = await this.initAudioContext()
+  async playTrack(track: AudioTrack, startAt = 0): Promise<void> {
+    const requestId = ++this.playRequestId;
+    const context = await this.initAudioContext();
 
-      // Stop any current playback and microphone
-      this.stopCurrentPlayback()
-      this.stopMicrophone()
+    // Stop any current playback and microphone
+    this.stopCurrentPlayback();
+    this.stopMicrophone();
 
-      // Reset state
-      this.isPaused = false
-      this.pausedTime = 0
-      this.currentTrack = track
+    // Reset state
+    this.isPaused = false;
+    this.pausedTime = 0;
+    this.currentTrack = track;
 
-      // Load audio buffer
-      const arrayBuffer = await track.file.arrayBuffer()
-      const decodedBuffer = await context.decodeAudioData(arrayBuffer)
-      if (requestId !== this.playRequestId) {
-        return
-      }
-      this.currentBuffer = decodedBuffer
-
-      // Create new source
-      this.source = context.createBufferSource()
-      this.source.buffer = this.currentBuffer
-      this.source.connect(this.gainNode!)
-
-      // Set up ended callback
-      this.source.onended = () => {
-        this.handleTrackEnded()
-      }
-
-      // Start playback at the requested offset
-      this.source.start(0, startAt)
-      this.startTime = context.currentTime - startAt
-
-      // Start time update loop
-      this.updateTime()
-
-      this.notifySubscribers()
-
-    } catch (error) {
-      throw error
+    // Load audio buffer
+    const arrayBuffer = await track.file.arrayBuffer();
+    const decodedBuffer = await context.decodeAudioData(arrayBuffer);
+    if (requestId !== this.playRequestId) {
+      return;
     }
+    this.currentBuffer = decodedBuffer;
+
+    // Create new source
+    this.source = context.createBufferSource();
+    this.source.buffer = this.currentBuffer;
+    this.source.connect(this.gainNode!);
+
+    // Set up ended callback
+    this.source.onended = () => {
+      this.handleTrackEnded();
+    };
+
+    // Start playback at the requested offset
+    this.source.start(0, startAt);
+    this.startTime = context.currentTime - startAt;
+
+    // Start time update loop
+    this.timeUpdater.start();
+
+    this.notifySubscribers();
   }
 
   // Pause playback
   pausePlayback(): void {
     if (this.source && !this.isPaused) {
       try {
-        this.source.stop()
+        this.source.stop();
       } catch (e) {
         // Source might already be stopped
       }
-      
-      if (this.animationFrameId) {
-        cancelAnimationFrame(this.animationFrameId)
-        this.animationFrameId = null
-      }
-      
-      this.pausedTime = this.audioContext!.currentTime - this.startTime
-      this.isPaused = true
-      this.source = null
-      
-      this.notifySubscribers()
+      // Stop the update loop while paused to save resources.
+      this.timeUpdater.stop();
+
+      this.pausedTime = this.audioContext!.currentTime - this.startTime;
+      this.isPaused = true;
+      this.source = null;
+
+      this.notifySubscribers();
     }
   }
 
   // Resume playback
   async resumePlayback(): Promise<void> {
     if (this.isPaused && this.currentBuffer && this.audioContext) {
-      try {
-        // Create new source starting from paused position
-        this.source = this.audioContext.createBufferSource()
-        this.source.buffer = this.currentBuffer
-        this.source.connect(this.gainNode!)
-        
-        // Set up ended callback
-        this.source.onended = () => {
-          this.handleTrackEnded()
-        }
-        
-        // Start playback from paused position
-        this.source.start(0, this.pausedTime)
-        this.startTime = this.audioContext.currentTime - this.pausedTime
-        this.isPaused = false
-        
-        // Start time update loop
-        this.updateTime()
-        
-        this.notifySubscribers()
-      } catch (error) {
-        throw error
-      }
+      // Create new source starting from paused position
+      this.source = this.audioContext.createBufferSource();
+      this.source.buffer = this.currentBuffer;
+      this.source.connect(this.gainNode!);
+
+      // Set up ended callback
+      this.source.onended = () => {
+        this.handleTrackEnded();
+      };
+
+      // Start playback from paused position
+      this.source.start(0, this.pausedTime);
+      this.startTime = this.audioContext.currentTime - this.pausedTime;
+      this.isPaused = false;
+
+      // Start time update loop
+      this.timeUpdater.start();
+
+      this.notifySubscribers();
     }
   }
 
   // Stop playback
   stopPlayback(): void {
-    this.playRequestId++
-    this.stopCurrentPlayback()
-    this.stopMicrophone()
-    this.isPaused = false
-    this.pausedTime = 0
-    this.currentTime = 0
-    this.currentTrack = null
+    this.playRequestId++;
+    this.stopCurrentPlayback();
+    this.stopMicrophone();
+    this.isPaused = false;
+    this.pausedTime = 0;
+    this.currentTime = 0;
+    this.currentTrack = null;
 
-    this.notifySubscribers()
+    this.notifySubscribers();
   }
 
   // Seek to position
   seekTo(time: number): void {
-    if (!this.currentBuffer) return
+    if (!this.currentBuffer) return;
 
-    const clampedTime = Math.max(0, Math.min(time, this.currentBuffer.duration))
-    
+    const clampedTime = Math.max(
+      0,
+      Math.min(time, this.currentBuffer.duration),
+    );
+
     if (this.isPaused) {
-      this.pausedTime = clampedTime
-      this.notifySubscribers()
+      this.pausedTime = clampedTime;
+      this.notifySubscribers();
     } else if (this.source) {
       // Stop current playback and restart from new position
-      this.stopCurrentPlayback()
-      this.startTime = this.audioContext!.currentTime - clampedTime
-      
+      this.stopCurrentPlayback();
+      this.startTime = this.audioContext!.currentTime - clampedTime;
+
       // Create new source
-      this.source = this.audioContext!.createBufferSource()
-      this.source.buffer = this.currentBuffer
-      this.source.connect(this.gainNode!)
-      
+      this.source = this.audioContext!.createBufferSource();
+      this.source.buffer = this.currentBuffer;
+      this.source.connect(this.gainNode!);
+
       this.source.onended = () => {
-        this.handleTrackEnded()
-      }
-      
-      this.source.start(0, clampedTime)
-      this.updateTime()
-      
-      this.notifySubscribers()
+        this.handleTrackEnded();
+      };
+
+      this.source.start(0, clampedTime);
+      this.timeUpdater.start();
+
+      this.notifySubscribers();
     }
   }
 
   // Set volume
   setVolume(volume: number): void {
     if (this.gainNode) {
-      this.gainNode.gain.value = Math.max(0, Math.min(1, volume))
-      this.notifySubscribers()
+      this.gainNode.gain.value = Math.max(0, Math.min(1, volume));
+      this.notifySubscribers();
     }
   }
 
   // Toggle mute
   toggleMute(): void {
     if (this.gainNode) {
-      const currentVolume = this.gainNode.gain.value
+      const currentVolume = this.gainNode.gain.value;
       if (currentVolume > 0) {
-        this.gainNode.gain.value = 0
+        this.gainNode.gain.value = 0;
       } else {
-        this.gainNode.gain.value = DEFAULT_VOLUME // Restore to default volume
+        this.gainNode.gain.value = DEFAULT_VOLUME; // Restore to default volume
       }
-      this.notifySubscribers()
+      this.notifySubscribers();
     }
   }
 
   // Get frequency data
   getFrequencyData(): Uint8Array | null {
-    if (!this.analyser) return null
-    
-    const bufferLength = this.analyser.frequencyBinCount
-    const dataArray = new Uint8Array(bufferLength)
-    this.analyser.getByteFrequencyData(dataArray)
-    
-    return dataArray
+    if (!this.analyser) return null;
+
+    const bufferLength = this.analyser.frequencyBinCount;
+    const dataArray = new Uint8Array(bufferLength);
+    this.analyser.getByteFrequencyData(dataArray);
+
+    return dataArray;
   }
 
   // Get time domain data
   getTimeData(): Uint8Array | null {
-    if (!this.analyser) return null
-    
-    const bufferLength = this.analyser.frequencyBinCount
-    const dataArray = new Uint8Array(bufferLength)
-    this.analyser.getByteTimeDomainData(dataArray)
-    
-    return dataArray
-  }
+    if (!this.analyser) return null;
 
-  // Update time and notify subscribers
-  private updateTime = () => {
-    if (this.source && !this.isPaused && this.audioContext) {
-      const currentTime = this.audioContext.currentTime - this.startTime
-      this.currentTime = Math.min(currentTime, this.getDuration())
-      
-      if (currentTime < this.getDuration()) {
-        this.animationFrameId = requestAnimationFrame(this.updateTime)
-      }
-      
-      this.notifySubscribers()
-    }
+    const bufferLength = this.analyser.frequencyBinCount;
+    const dataArray = new Uint8Array(bufferLength);
+    this.analyser.getByteTimeDomainData(dataArray);
+
+    return dataArray;
   }
 
   // Handle track ended
   private handleTrackEnded(): void {
-    this.isPaused = false
-    this.pausedTime = 0
-    this.currentTime = 0
-    this.source = null
-    this.currentTrack = null
-    
-    if (this.animationFrameId) {
-      cancelAnimationFrame(this.animationFrameId)
-      this.animationFrameId = null
-    }
+    this.isPaused = false;
+    this.pausedTime = 0;
+    this.currentTime = 0;
+    this.source = null;
+    this.currentTrack = null;
 
-    this.notifySubscribers()
+    // Stop any pending time updates now that playback concluded.
+    this.timeUpdater.stop();
+
+    this.notifySubscribers();
 
     // Inform any listeners that playback naturally reached the end. The
     // surrounding application (store, hooks) decides what to do next—play
     // another track, loop, or stop entirely.
-    this.trackEndCallbacks.forEach(cb => {
+    this.trackEndCallbacks.forEach((cb) => {
       try {
-        cb()
+        cb();
       } catch {
         /* swallow listener errors to avoid breaking player state */
       }
-    })
+    });
   }
 
   // State getters
   isPlaying(): boolean {
-    return !!this.source && !this.isPaused
+    return !!this.source && !this.isPaused;
   }
 
   isStopped(): boolean {
-    return !this.source && !this.isPaused && !this.microphoneActive
+    return !this.source && !this.isPaused && !this.microphoneActive;
   }
 
   getCurrentTime(): number {
     if (this.isPaused) {
-      return this.pausedTime
+      return this.pausedTime;
     }
     if (this.source && this.audioContext) {
-      return Math.min(this.audioContext.currentTime - this.startTime, this.getDuration())
+      return Math.min(
+        this.audioContext.currentTime - this.startTime,
+        this.getDuration(),
+      );
     }
-    return 0
+    return 0;
   }
 
   getDuration(): number {
-    return this.currentBuffer?.duration || 0
+    return this.currentBuffer?.duration || 0;
   }
 
   getVolume(): number {
-    return this.gainNode?.gain.value || 0
+    return this.gainNode?.gain.value || 0;
   }
 
   getMuted(): boolean {
-    return this.gainNode?.gain.value === 0
+    return this.gainNode?.gain.value === 0;
   }
 
   // Cleanup
   cleanup(): void {
-    this.stopCurrentPlayback()
-    this.stopMicrophone()
-    
-    if (this.audioContext) {
-      this.audioContext.close()
-      this.audioContext = null
-    }
-    
-    this.gainNode = null
-    this.analyser = null
-    this.currentBuffer = null
-    this.currentTrack = null
-    this.callbacks.clear()
-  }
+    this.stopCurrentPlayback();
+    this.stopMicrophone();
 
+    if (this.audioContext) {
+      this.audioContext.close();
+      this.audioContext = null;
+    }
+
+    this.gainNode = null;
+    this.analyser = null;
+    this.currentBuffer = null;
+    this.currentTrack = null;
+    this.callbacks.clear();
+  }
 }
 
 // Export singleton instance
-export const audioPlayer = AudioPlayerEngine.getInstance()
+export const audioPlayer = AudioPlayerEngine.getInstance();
 
 // Export types
-export type { AudioPlayerState, AudioPlayerCallback }
-
+export type { AudioPlayerState, AudioPlayerCallback };

--- a/react-spectrogram/src/utils/timeUpdater.ts
+++ b/react-spectrogram/src/utils/timeUpdater.ts
@@ -1,0 +1,93 @@
+/**
+ * Utility to create a time updater loop driven by `requestAnimationFrame`.
+ *
+ * The engines in this project often need to dispatch playback time updates
+ * while audio is playing. Previously each engine implemented its own loop,
+ * which led to subtle differences and duplicated logic.  This helper
+ * centralises the logic, guaranteeing consistent behaviour and making it
+ * trivial to test.
+ *
+ * The updater is intentionally minimal and allocation‑free: it only works
+ * with numbers and avoids creating new objects on every frame to keep the
+ * garbage collector at bay.
+ */
+export interface TimeUpdaterOptions {
+  /**
+   * Returns the current playback time in seconds.  The function **must**
+   * return a finite, non‑negative number.  It is evaluated on every frame so
+   * it should be cheap and side‑effect free.
+   */
+  getTime: () => number;
+
+  /**
+   * Invoked after `getTime` with the freshly obtained time value. Consumers
+   * typically store the value and notify listeners of the change.
+   */
+  onUpdate: (time: number) => void;
+
+  /**
+   * Optional predicate invoked after `onUpdate`. When it returns `true` the
+   * updater schedules the next animation frame; returning `false` stops the
+   * loop.  If omitted the updater will continue indefinitely.
+   */
+  shouldContinue?: (time: number) => boolean;
+}
+
+export interface TimeUpdater {
+  /** Start the update loop. Calling multiple times has no effect. */
+  start(): void;
+  /** Stop the loop if running. */
+  stop(): void;
+}
+
+/**
+ * Create a `TimeUpdater` instance.  It exposes `start` and `stop` methods used
+ * by the engines to control the update loop.  The function validates all
+ * inputs, failing fast when it encounters an invalid time value to prevent
+ * infinite loops or NaN propagation.
+ */
+export function createTimeUpdater(options: TimeUpdaterOptions): TimeUpdater {
+  let frameId: number | null = null;
+
+  // Cancel the scheduled frame and reset the identifier.
+  const stop = () => {
+    if (frameId !== null) {
+      cancelAnimationFrame(frameId);
+      frameId = null;
+    }
+  };
+
+  const update = () => {
+    const time = options.getTime();
+
+    // Validate time to catch programming errors early.
+    if (!Number.isFinite(time) || time < 0) {
+      stop();
+      throw new Error(`Invalid time value: ${time}`);
+    }
+
+    options.onUpdate(time);
+
+    const shouldContinue = options.shouldContinue
+      ? options.shouldContinue(time)
+      : true;
+
+    if (shouldContinue) {
+      frameId = requestAnimationFrame(update);
+    } else {
+      frameId = null;
+    }
+  };
+
+  return {
+    start() {
+      // Guard against double scheduling; start is idempotent.
+      if (frameId === null) {
+        frameId = requestAnimationFrame(update);
+      }
+    },
+    stop,
+  };
+}
+
+export default createTimeUpdater;


### PR DESCRIPTION
## Summary
- extract generic `createTimeUpdater` utility with validation
- refactor audio engines to use shared time updater
- add targeted tests for the new time updater helper

## Testing
- `npx eslint src/utils/timeUpdater.ts src/utils/PlaybackEngine.ts src/utils/audioPlayer.ts src/utils/__tests__/timeUpdater.test.ts`
- `npm run test:coverage` *(fails: TypeError: __vite_ssr_import_2__.audioPlayer.onTrackEnd is not a function)*

------
https://chatgpt.com/codex/tasks/task_e_68a52af73540832bbb92a77ef84004da