### PR TITLE
refactor: share time updater

### DIFF
--- a/react-spectrogram/src/utils/__tests__/timeUpdater.test.ts
+++ b/react-spectrogram/src/utils/__tests__/timeUpdater.test.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { createTimeUpdater, TIME_UPDATE_INTERVAL_MS } from "../timeUpdater";
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  vi.stubGlobal("requestAnimationFrame", (cb: FrameRequestCallback) =>
+    setTimeout(() => cb(performance.now()), 10),
+  );
+  vi.stubGlobal("cancelAnimationFrame", vi.fn());
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+  vi.unstubAllGlobals();
+  vi.clearAllMocks();
+});
+
+describe("createTimeUpdater", () => {
+  it("throttles callbacks to the configured interval", () => {
+    const onUpdate = vi.fn();
+    const updater = createTimeUpdater({
+      onUpdate: (now) => {
+        onUpdate(now);
+        updater.record(now);
+      },
+      shouldUpdate: () => true,
+    });
+    updater.record();
+    updater.start();
+    vi.advanceTimersByTime(10);
+    expect(onUpdate).toHaveBeenCalledTimes(0);
+    vi.advanceTimersByTime(10);
+    expect(onUpdate).toHaveBeenCalledTimes(1);
+    vi.advanceTimersByTime(10);
+    expect(onUpdate).toHaveBeenCalledTimes(1);
+  });
+
+  it("respects manual record() calls", () => {
+    const onUpdate = vi.fn();
+    const updater = createTimeUpdater({
+      onUpdate: (now) => {
+        onUpdate(now);
+        updater.record(now);
+      },
+      shouldUpdate: () => true,
+    });
+    updater.record();
+    updater.start();
+    vi.advanceTimersByTime(TIME_UPDATE_INTERVAL_MS);
+    expect(onUpdate).toHaveBeenCalledTimes(1);
+    updater.record();
+    vi.advanceTimersByTime(10);
+    expect(onUpdate).toHaveBeenCalledTimes(1);
+    vi.advanceTimersByTime(10);
+    expect(onUpdate).toHaveBeenCalledTimes(2);
+  });
+
+  it("stops when stop() is called", () => {
+    const onUpdate = vi.fn();
+    const updater = createTimeUpdater({
+      onUpdate: (now) => {
+        onUpdate(now);
+        updater.record(now);
+      },
+      shouldUpdate: () => true,
+    });
+    updater.record();
+    updater.start();
+    updater.stop();
+    vi.advanceTimersByTime(TIME_UPDATE_INTERVAL_MS * 2);
+    expect(onUpdate).toHaveBeenCalledTimes(0);
+    expect(global.cancelAnimationFrame).toHaveBeenCalled();
+  });
+
+  it("throws on invalid configuration", () => {
+    // @ts-expect-error deliberate misconfiguration
+    expect(() => createTimeUpdater({})).toThrow();
+  });
+});

--- a/react-spectrogram/src/utils/timeUpdater.ts
+++ b/react-spectrogram/src/utils/timeUpdater.ts
@@ -1,0 +1,101 @@
+/**
+ * Utility for dispatching time-based updates with requestAnimationFrame while
+ * throttling calls to avoid overwhelming subscribers.
+ *
+ * The updater keeps internal state for the last dispatch time and exposes
+ * methods to start/stop the loop and to record manual dispatches. Consumers
+ * must call `record()` whenever they notify outside the rAF loop to keep the
+ * throttle consistent.
+ */
+
+// Shared interval used by audio engines. 20ms (~50Hz) balances UI responsiveness
+// with computational cost.
+export const TIME_UPDATE_INTERVAL_MS = 20;
+
+/** Options for {@link createTimeUpdater}. */
+export interface TimeUpdaterOptions {
+  /** Called whenever an update should be dispatched. */
+  onUpdate: (now: number) => void;
+  /** Determines whether the update loop should continue. */
+  shouldUpdate: () => boolean;
+  /** Optional throttle interval override. */
+  intervalMs?: number;
+  /** requestAnimationFrame override for tests. */
+  requestFrame?: (cb: FrameRequestCallback) => number;
+  /** cancelAnimationFrame override for tests. */
+  cancelFrame?: (id: number) => void;
+}
+
+/** Control interface returned by {@link createTimeUpdater}. */
+export interface TimeUpdater {
+  /** Begin the update loop if not already running. */
+  start(): void;
+  /** Stop the update loop. Safe to call multiple times. */
+  stop(): void;
+  /** Record a manual dispatch time (e.g. after seek/pause events). */
+  record(now?: number): void;
+}
+
+/**
+ * Create a new time updater with the provided options. The updater uses
+ * `requestAnimationFrame` for smooth updates but throttles calls to the
+ * specified interval. Consumers are responsible for invoking `record()` after
+ * manual dispatches to keep throttling consistent.
+ */
+export function createTimeUpdater(options: TimeUpdaterOptions): TimeUpdater {
+  const {
+    onUpdate,
+    shouldUpdate,
+    intervalMs = TIME_UPDATE_INTERVAL_MS,
+    requestFrame = requestAnimationFrame,
+    cancelFrame = cancelAnimationFrame,
+  } = options;
+
+  if (typeof onUpdate !== "function") {
+    throw new Error("onUpdate must be a function");
+  }
+  if (typeof shouldUpdate !== "function") {
+    throw new Error("shouldUpdate must be a function");
+  }
+
+  const interval =
+    Number.isFinite(intervalMs) && intervalMs >= 0
+      ? intervalMs
+      : TIME_UPDATE_INTERVAL_MS;
+
+  let frameId: number | null = null;
+  let lastDispatch = 0;
+
+  const frame = () => {
+    if (!shouldUpdate()) {
+      frameId = null;
+      return;
+    }
+    const now = performance.now();
+    if (now - lastDispatch >= interval) {
+      onUpdate(now);
+      // `onUpdate` should call `record()`; guard here just in case.
+      lastDispatch = now;
+    }
+    frameId = requestFrame(frame);
+  };
+
+  return {
+    start() {
+      if (frameId !== null) return;
+      frame();
+    },
+    stop() {
+      if (frameId !== null) {
+        cancelFrame(frameId);
+        frameId = null;
+      }
+    },
+    record(now: number = performance.now()) {
+      if (!Number.isFinite(now)) {
+        throw new Error("Invalid time passed to record()");
+      }
+      lastDispatch = now;
+    },
+  };
+}


### PR DESCRIPTION
## Summary
- add `createTimeUpdater` utility for throttled rAF updates
- refactor playback engines to use shared time updater
- test new time updater behaviors

## Testing
- `npm test` *(fails: loadFromStorage is not a function)*
- `npx vitest run src/utils/__tests__` *(fails: this.audioContext.createAnalyser is not a function)*
- `npm run lint` *(fails: 138 problems)*
- `npm run type-check` *(fails: numerous TS errors)*

------
https://chatgpt.com/codex/tasks/task_e_68a5498253f4832b85cecca97d2686ae