### PR TITLE
feat: compute waveform bars based on width

### DIFF
--- a/web/apps/mfe-spectrogram/src/components/layout/Footer.tsx
+++ b/web/apps/mfe-spectrogram/src/components/layout/Footer.tsx
@@ -578,9 +578,6 @@ export const Footer: React.FC = () => {
               }
             }
           }}
-          numBars={isMobile ? 150 : 300}
-          barWidth={isMobile ? 1 : 2}
-          barGap={isMobile ? 0.5 : 1}
           maxBarHeight={isMobile ? 16 : 24}
           disabled={!currentTrack}
           bufferedTime={duration * 0.8} // Mock buffered time for demo


### PR DESCRIPTION
## Summary
- derive waveform bar count from container width using fixed bar and gap sizes
- align final bar with track end and recalc peaks on resize
- add regression tests for bar alignment and cleanup Footer usage

## Testing
- `npm test` *(fails: requestAnimationFrame is not defined, missing modules)*

------
https://chatgpt.com/codex/tasks/task_e_68a59f2b6c9c832ba52a471fef3b5cd1