### PR TITLE
feat: pill-shaped seek bar

### DIFF
--- a/web/apps/mfe-spectrogram/src/index.css
+++ b/web/apps/mfe-spectrogram/src/index.css
@@ -10,7 +10,6 @@
     114,
     128
   ); /* gray-500 - brighter for better visibility */
-  --seek-background: rgb(39, 39, 42); /* neutral-800 for gap fill */
   --seek-buffered: rgba(59, 130, 246, 0.6); /* blue-500 with more opacity */
   --seek-focus: rgb(59, 130, 246); /* blue-500 */
   --seek-disabled: rgba(156, 163, 175, 0.4); /* gray-400 with more opacity */
@@ -27,7 +26,6 @@
     114,
     128
   ); /* gray-500 - brighter for better visibility */
-  --seek-background: rgb(24, 24, 27); /* neutral-900 */
   --seek-buffered: rgba(59, 130, 246, 0.6); /* blue-500 with more opacity */
   --seek-focus: rgb(59, 130, 246); /* blue-500 */
   --seek-disabled: rgba(156, 163, 175, 0.4); /* gray-400 with more opacity */
@@ -40,7 +38,6 @@
 .light {
   --seek-played: rgb(37, 99, 235); /* blue-600 */
   --seek-unplayed: rgb(156, 163, 175); /* gray-400 */
-  --seek-background: rgb(229, 231, 235); /* gray-200 */
   --seek-buffered: rgba(37, 99, 235, 0.5); /* blue-600 with opacity */
   --seek-focus: rgb(37, 99, 235); /* blue-600 */
   --seek-disabled: rgba(156, 163, 175, 0.3); /* gray-400 with opacity */
@@ -359,16 +356,11 @@
 
   /* Seekbar container styles */
   .waveform-seekbar {
-    @apply relative bg-neutral-800/30 rounded-lg border border-neutral-700/50;
-    @apply transition-all duration-200;
-  }
-
-  .waveform-seekbar:hover {
-    @apply bg-neutral-800/50 border-neutral-600/50;
+    @apply relative rounded-lg transition-all duration-200;
   }
 
   .waveform-seekbar:focus-within {
-    @apply border-blue-400/50 ring-2 ring-blue-400/20;
+    @apply ring-2 ring-blue-400/20;
   }
 
   /* Slider styles */


### PR DESCRIPTION
## Summary
- remove seekbar borders/background colors
- render waveform bars with rounded corners
- test seekbar styling and pill geometry

## Testing
- `npx vitest run --environment jsdom src/components/__tests__/CanvasWaveformSeekbar.test.tsx` *(fails: resizeCb is not a function, HTMLCanvasElement is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68a5a27267dc832bb4e8bbeb8a6e3b8f