### PR TITLE
feat: sync seekbar colors with theme

### DIFF
--- a/web/apps/mfe-spectrogram/src/components/__tests__/SettingsPanel.test.tsx
+++ b/web/apps/mfe-spectrogram/src/components/__tests__/SettingsPanel.test.tsx
@@ -1,153 +1,193 @@
-import { render, screen, fireEvent, within } from '@testing-library/react'
-import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { SettingsPanel } from '../layout/SettingsPanel'
+import { render, screen, fireEvent, within } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { SettingsPanel } from "../layout/SettingsPanel";
 
 const mockSettings = {
-  theme: 'dark' as const,
-  amplitudeScale: 'db' as const,
-  frequencyScale: 'logarithmic' as const,
-  resolution: 'medium' as const,
+  theme: "dark" as const,
+  amplitudeScale: "db" as const,
+  frequencyScale: "logarithmic" as const,
+  resolution: "medium" as const,
   refreshRate: 60 as const,
-  colormap: 'viridis',
+  colormap: "viridis",
   showLegend: true,
-}
+  seekPlayedColor: "",
+  seekUnplayedColor: "",
+};
 
-const mockOnSettingsChange = vi.fn()
-const mockOnClose = vi.fn()
+const mockOnSettingsChange = vi.fn();
+const mockOnClose = vi.fn();
 
-describe('SettingsPanel', () => {
+describe("SettingsPanel", () => {
   beforeEach(() => {
-    vi.clearAllMocks()
-  })
+    vi.clearAllMocks();
+  });
 
-  it('renders when open', () => {
+  it("renders when open", () => {
     render(
       <SettingsPanel
         settings={mockSettings}
         isOpen={true}
         onClose={mockOnClose}
         onSettingsChange={mockOnSettingsChange}
-      />
-    )
-    
-    expect(screen.getByText('Settings')).toBeInTheDocument()
-  })
+      />,
+    );
 
-  it('does not render when closed', () => {
+    expect(screen.getByText("Settings")).toBeInTheDocument();
+  });
+
+  it("does not render when closed", () => {
     render(
       <SettingsPanel
         settings={mockSettings}
         isOpen={false}
         onClose={mockOnClose}
         onSettingsChange={mockOnSettingsChange}
-      />
-    )
-    
-    expect(screen.queryByText('Settings')).not.toBeInTheDocument()
-  })
+      />,
+    );
 
-  it('renders all theme options', () => {
+    expect(screen.queryByText("Settings")).not.toBeInTheDocument();
+  });
+
+  it("renders all theme options", () => {
     render(
       <SettingsPanel
         settings={mockSettings}
         isOpen={true}
         onClose={mockOnClose}
         onSettingsChange={mockOnSettingsChange}
-      />
-    )
-    
-    expect(screen.getByText('Dark')).toBeInTheDocument()
-    expect(screen.getByText('Light')).toBeInTheDocument()
-    expect(screen.getByText('Neon')).toBeInTheDocument()
-    expect(screen.getByText('High Contrast')).toBeInTheDocument()
-  })
+      />,
+    );
 
-  it('handles theme selection', () => {
+    expect(screen.getByText("Dark")).toBeInTheDocument();
+    expect(screen.getByText("Light")).toBeInTheDocument();
+    expect(screen.getByText("Neon")).toBeInTheDocument();
+    expect(screen.getByText("High Contrast")).toBeInTheDocument();
+  });
+
+  it("handles theme selection", () => {
     render(
       <SettingsPanel
         settings={mockSettings}
         isOpen={true}
         onClose={mockOnClose}
         onSettingsChange={mockOnSettingsChange}
-      />
-    )
-    
-    const lightThemeButton = screen.getByText('Light')
-    fireEvent.click(lightThemeButton)
-    
-    expect(mockOnSettingsChange).toHaveBeenCalledWith({ theme: 'light' })
-  })
+      />,
+    );
 
-  it('handles amplitude scale change', () => {
+    const lightThemeButton = screen.getByText("Light");
+    fireEvent.click(lightThemeButton);
+
+    expect(mockOnSettingsChange).toHaveBeenCalledWith({ theme: "light" });
+  });
+
+  it("handles amplitude scale change", () => {
     render(
       <SettingsPanel
         settings={mockSettings}
         isOpen={true}
         onClose={mockOnClose}
         onSettingsChange={mockOnSettingsChange}
-      />
-    )
-    
-    const amplitudeScaleSection = screen.getByText('Amplitude Scale').closest('div')
-    const linearRadio = within(amplitudeScaleSection!).getByDisplayValue('linear')
-    fireEvent.click(linearRadio)
-    
-    expect(mockOnSettingsChange).toHaveBeenCalledWith({ amplitudeScale: 'linear' })
-  })
+      />,
+    );
 
-  it('handles legend toggle', () => {
-    render(
-      <SettingsPanel
-        settings={mockSettings}
-        isOpen={true}
-        onClose={mockOnClose}
-        onSettingsChange={mockOnSettingsChange}
-      />
-    )
-    
-    const legendCheckbox = screen.getByRole('checkbox')
-    fireEvent.click(legendCheckbox)
-    
-    expect(mockOnSettingsChange).toHaveBeenCalledWith({ showLegend: false })
-  })
+    const amplitudeScaleSection = screen
+      .getByText("Amplitude Scale")
+      .closest("div");
+    const linearRadio = within(amplitudeScaleSection!).getByDisplayValue(
+      "linear",
+    );
+    fireEvent.click(linearRadio);
 
-  it('handles close button', () => {
-    render(
-      <SettingsPanel
-        settings={mockSettings}
-        isOpen={true}
-        onClose={mockOnClose}
-        onSettingsChange={mockOnSettingsChange}
-      />
-    )
-    
-    const closeButton = screen.getByTitle('Close (Esc)')
-    fireEvent.click(closeButton)
-    
-    expect(mockOnClose).toHaveBeenCalled()
-  })
-
-  it('handles reset to defaults', () => {
-    render(
-      <SettingsPanel
-        settings={mockSettings}
-        isOpen={true}
-        onClose={mockOnClose}
-        onSettingsChange={mockOnSettingsChange}
-      />
-    )
-    
-    const resetButton = screen.getByText('Reset to Defaults')
-    fireEvent.click(resetButton)
-    
     expect(mockOnSettingsChange).toHaveBeenCalledWith({
-      theme: 'dark',
-      amplitudeScale: 'db',
-      frequencyScale: 'logarithmic',
-      resolution: 'medium',
+      amplitudeScale: "linear",
+    });
+  });
+
+  it("handles legend toggle", () => {
+    render(
+      <SettingsPanel
+        settings={mockSettings}
+        isOpen={true}
+        onClose={mockOnClose}
+        onSettingsChange={mockOnSettingsChange}
+      />,
+    );
+
+    const legendCheckbox = screen.getByRole("checkbox");
+    fireEvent.click(legendCheckbox);
+
+    expect(mockOnSettingsChange).toHaveBeenCalledWith({ showLegend: false });
+  });
+
+  it("handles close button", () => {
+    render(
+      <SettingsPanel
+        settings={mockSettings}
+        isOpen={true}
+        onClose={mockOnClose}
+        onSettingsChange={mockOnSettingsChange}
+      />,
+    );
+
+    const closeButton = screen.getByTitle("Close (Esc)");
+    fireEvent.click(closeButton);
+
+    expect(mockOnClose).toHaveBeenCalled();
+  });
+
+  it("handles reset to defaults", () => {
+    render(
+      <SettingsPanel
+        settings={mockSettings}
+        isOpen={true}
+        onClose={mockOnClose}
+        onSettingsChange={mockOnSettingsChange}
+      />,
+    );
+
+    const resetButton = screen.getByText("Reset to Defaults");
+    fireEvent.click(resetButton);
+
+    expect(mockOnSettingsChange).toHaveBeenCalledWith({
+      theme: "dark",
+      amplitudeScale: "db",
+      frequencyScale: "logarithmic",
+      resolution: "medium",
       refreshRate: 60,
-      colormap: 'viridis',
+      colormap: "viridis",
       showLegend: true,
-    })
-  })
-})
+      seekPlayedColor: "",
+      seekUnplayedColor: "",
+    });
+  });
+
+  it("allows overriding and resetting seekbar colours", () => {
+    render(
+      <SettingsPanel
+        settings={mockSettings}
+        isOpen={true}
+        onClose={mockOnClose}
+        onSettingsChange={mockOnSettingsChange}
+      />,
+    );
+
+    const playedInput = screen.getByLabelText("Played") as HTMLInputElement;
+    fireEvent.input(playedInput, { target: { value: "#123456" } });
+    expect(mockOnSettingsChange).toHaveBeenCalledWith({
+      seekPlayedColor: "#123456",
+    });
+
+    const unplayedInput = screen.getByLabelText("Unplayed") as HTMLInputElement;
+    fireEvent.input(unplayedInput, { target: { value: "#654321" } });
+    expect(mockOnSettingsChange).toHaveBeenCalledWith({
+      seekUnplayedColor: "#654321",
+    });
+
+    const resetButton = screen.getByText("Reset");
+    fireEvent.click(resetButton);
+    expect(mockOnSettingsChange).toHaveBeenCalledWith({
+      seekPlayedColor: "",
+      seekUnplayedColor: "",
+    });
+  });
+});

--- a/web/apps/mfe-spectrogram/src/components/layout/SettingsPanel.tsx
+++ b/web/apps/mfe-spectrogram/src/components/layout/SettingsPanel.tsx
@@ -1,16 +1,37 @@
-import React, { useState } from 'react'
-import { X, Palette, Sliders, Monitor, Zap, Key, Image, Check, AlertCircle, Loader2, Database, BarChart } from 'lucide-react'
-import { SpectrogramSettings, Theme, AmplitudeScale, FrequencyScale, Resolution, RefreshRate } from '@/types'
-import { cn } from '@/utils/cn'
-import { directToast } from '@/utils/toast'
-import { MetadataStorePanel } from './MetadataStorePanel'
-import { StatisticsPanel } from './StatisticsPanel'
+import React, { useState } from "react";
+import {
+  X,
+  Palette,
+  Sliders,
+  Monitor,
+  Zap,
+  Key,
+  Image,
+  Check,
+  AlertCircle,
+  Loader2,
+  Database,
+  BarChart,
+} from "lucide-react";
+import {
+  SpectrogramSettings,
+  Theme,
+  AmplitudeScale,
+  FrequencyScale,
+  Resolution,
+  RefreshRate,
+} from "@/types";
+import { THEME_COLORS } from "@/shared/theme";
+import { cn } from "@/utils/cn";
+import { directToast } from "@/utils/toast";
+import { MetadataStorePanel } from "./MetadataStorePanel";
+import { StatisticsPanel } from "./StatisticsPanel";
 
 interface SettingsPanelProps {
-  settings: SpectrogramSettings
-  isOpen: boolean
-  onClose: () => void
-  onSettingsChange: (settings: Partial<SpectrogramSettings>) => void
+  settings: SpectrogramSettings;
+  isOpen: boolean;
+  onClose: () => void;
+  onSettingsChange: (settings: Partial<SpectrogramSettings>) => void;
 }
 
 export function SettingsPanel({
@@ -19,125 +40,142 @@ export function SettingsPanel({
   onClose,
   onSettingsChange,
 }: SettingsPanelProps) {
-  const [validatingKeys, setValidatingKeys] = useState<{ [key: string]: boolean }>({})
-  const [activeTab, setActiveTab] = useState<'general' | 'artwork' | 'api' | 'database' | 'stats'>('general')
+  const [validatingKeys, setValidatingKeys] = useState<{
+    [key: string]: boolean;
+  }>({});
+  const [activeTab, setActiveTab] = useState<
+    "general" | "artwork" | "api" | "database" | "stats"
+  >("general");
 
-  if (!isOpen) return null
+  if (!isOpen) return null;
 
   const themes: { value: Theme; label: string; icon: React.ReactNode }[] = [
-    { value: 'dark', label: 'Dark', icon: <Palette size={16} /> },
-    { value: 'light', label: 'Light', icon: <Monitor size={16} /> },
-    { value: 'neon', label: 'Neon', icon: <Zap size={16} /> },
-    { value: 'high-contrast', label: 'High Contrast', icon: <Sliders size={16} /> },
-  ]
+    { value: "dark", label: "Dark", icon: <Palette size={16} /> },
+    { value: "light", label: "Light", icon: <Monitor size={16} /> },
+    { value: "neon", label: "Neon", icon: <Zap size={16} /> },
+    {
+      value: "high-contrast",
+      label: "High Contrast",
+      icon: <Sliders size={16} />,
+    },
+  ];
 
   const amplitudeScales: { value: AmplitudeScale; label: string }[] = [
-    { value: 'linear', label: 'Linear' },
-    { value: 'logarithmic', label: 'Logarithmic' },
-    { value: 'db', label: 'Decibels (dB)' },
-  ]
+    { value: "linear", label: "Linear" },
+    { value: "logarithmic", label: "Logarithmic" },
+    { value: "db", label: "Decibels (dB)" },
+  ];
 
   const frequencyScales: { value: FrequencyScale; label: string }[] = [
-    { value: 'linear', label: 'Linear' },
-    { value: 'logarithmic', label: 'Logarithmic' },
-  ]
+    { value: "linear", label: "Linear" },
+    { value: "logarithmic", label: "Logarithmic" },
+  ];
 
   const resolutions: { value: Resolution; label: string }[] = [
-    { value: 'low', label: 'Low (Fast)' },
-    { value: 'medium', label: 'Medium' },
-    { value: 'high', label: 'High (Detailed)' },
-  ]
+    { value: "low", label: "Low (Fast)" },
+    { value: "medium", label: "Medium" },
+    { value: "high", label: "High (Detailed)" },
+  ];
 
   const refreshRates: { value: RefreshRate; label: string }[] = [
-    { value: 30, label: '30 FPS' },
-    { value: 60, label: '60 FPS' },
-  ]
+    { value: 30, label: "30 FPS" },
+    { value: 60, label: "60 FPS" },
+  ];
 
-  const handleAPIKeyChange = (service: 'acoustid' | 'musicbrainz', key: string) => {
+  // Theme-aware seekbar colour values. Using local variables avoids repeated
+  // lookups when rendering inputs.
+  const themeColours = THEME_COLORS[settings.theme];
+  const playedColour = settings.seekPlayedColor || themeColours.accent;
+  const unplayedColour = settings.seekUnplayedColor || themeColours.primary;
+
+  const handleAPIKeyChange = (
+    service: "acoustid" | "musicbrainz",
+    key: string,
+  ) => {
     onSettingsChange({
-      apiKeys: { ...settings.apiKeys, [service]: key }
-    })
-  }
+      apiKeys: { ...settings.apiKeys, [service]: key },
+    });
+  };
 
-  const validateAPIKey = async (service: 'acoustid' | 'musicbrainz') => {
-    setValidatingKeys(prev => ({ ...prev, [service]: true }))
-    
+  const validateAPIKey = async (service: "acoustid" | "musicbrainz") => {
+    setValidatingKeys((prev) => ({ ...prev, [service]: true }));
+
     try {
-      const isValid = await import('@/stores/settingsStore').then(module => 
-        module.useSettingsStore.getState().validateAPIKey(service)
-      )
-      
+      const isValid = await import("@/stores/settingsStore").then((module) =>
+        module.useSettingsStore.getState().validateAPIKey(service),
+      );
+
       if (isValid) {
         // Update the status in settings
         onSettingsChange({
           apiKeyStatus: {
             ...settings.apiKeyStatus,
-            [service]: { valid: true, lastChecked: new Date() }
-          }
-        })
+            [service]: { valid: true, lastChecked: new Date() },
+          },
+        });
       }
     } catch (error) {
       // Silently handle API key validation error
     } finally {
-      setValidatingKeys(prev => ({ ...prev, [service]: false }))
+      setValidatingKeys((prev) => ({ ...prev, [service]: false }));
     }
-  }
+  };
 
-  const getAPIKeyStatusIcon = (service: 'acoustid' | 'musicbrainz') => {
-    const status = settings.apiKeyStatus[service]
-    
-    if (validatingKeys[service]) {
-      return <Loader2 size={16} className="animate-spin text-blue-500" />
-    }
-    
-    if (status.valid) {
-      return <Check size={16} className="text-green-500" />
-    }
-    
-    if (settings.apiKeys[service]) {
-      return <AlertCircle size={16} className="text-red-500" />
-    }
-    
-    return <AlertCircle size={16} className="text-gray-400" />
-  }
+  const getAPIKeyStatusIcon = (service: "acoustid" | "musicbrainz") => {
+    const status = settings.apiKeyStatus[service];
 
-  const getAPIKeyStatusText = (service: 'acoustid' | 'musicbrainz') => {
-    const status = settings.apiKeyStatus[service]
-    
     if (validatingKeys[service]) {
-      return 'Validating...'
+      return <Loader2 size={16} className="animate-spin text-blue-500" />;
     }
-    
+
     if (status.valid) {
-      return 'Valid'
+      return <Check size={16} className="text-green-500" />;
     }
-    
+
     if (settings.apiKeys[service]) {
-      return 'Invalid'
+      return <AlertCircle size={16} className="text-red-500" />;
     }
-    
-    return 'Not set'
-  }
+
+    return <AlertCircle size={16} className="text-gray-400" />;
+  };
+
+  const getAPIKeyStatusText = (service: "acoustid" | "musicbrainz") => {
+    const status = settings.apiKeyStatus[service];
+
+    if (validatingKeys[service]) {
+      return "Validating...";
+    }
+
+    if (status.valid) {
+      return "Valid";
+    }
+
+    if (settings.apiKeys[service]) {
+      return "Invalid";
+    }
+
+    return "Not set";
+  };
 
   return (
-    <div className={cn(
-      'fixed inset-0 z-50',
-      'flex items-center justify-center',
-      'bg-black/50 backdrop-blur-sm'
-    )}>
-      <div className={cn(
-        'panel w-full max-w-2xl max-h-[90vh]',
-        'flex flex-col',
-        'animate-scale-in'
-      )}>
+    <div
+      className={cn(
+        "fixed inset-0 z-50",
+        "flex items-center justify-center",
+        "bg-black/50 backdrop-blur-sm",
+      )}
+    >
+      <div
+        className={cn(
+          "panel w-full max-w-2xl max-h-[90vh]",
+          "flex flex-col",
+          "animate-scale-in",
+        )}
+      >
         {/* Header */}
         <div className="flex items-center justify-between p-4 border-b border-neutral-800">
           <h3 className="text-lg font-semibold text-neutral-100">Settings</h3>
-          <button
-            onClick={onClose}
-            className="icon-btn"
-            title="Close (Esc)"
-          >
+          <button onClick={onClose} className="icon-btn" title="Close (Esc)">
             <X size={20} />
           </button>
         </div>
@@ -145,59 +183,59 @@ export function SettingsPanel({
         {/* Tabs */}
         <div className="flex border-b border-neutral-800">
           <button
-            onClick={() => setActiveTab('general')}
+            onClick={() => setActiveTab("general")}
             className={cn(
-              'flex-1 px-4 py-3 text-sm font-medium transition-colors',
-              activeTab === 'general'
-                ? 'text-accent-blue border-b-2 border-accent-blue'
-                : 'text-neutral-400 hover:text-neutral-200'
+              "flex-1 px-4 py-3 text-sm font-medium transition-colors",
+              activeTab === "general"
+                ? "text-accent-blue border-b-2 border-accent-blue"
+                : "text-neutral-400 hover:text-neutral-200",
             )}
           >
             General
           </button>
           <button
-            onClick={() => setActiveTab('artwork')}
+            onClick={() => setActiveTab("artwork")}
             className={cn(
-              'flex-1 px-4 py-3 text-sm font-medium transition-colors',
-              activeTab === 'artwork'
-                ? 'text-accent-blue border-b-2 border-accent-blue'
-                : 'text-neutral-400 hover:text-neutral-200'
+              "flex-1 px-4 py-3 text-sm font-medium transition-colors",
+              activeTab === "artwork"
+                ? "text-accent-blue border-b-2 border-accent-blue"
+                : "text-neutral-400 hover:text-neutral-200",
             )}
           >
             <Image size={16} className="inline mr-2" />
             Artwork
           </button>
           <button
-            onClick={() => setActiveTab('api')}
+            onClick={() => setActiveTab("api")}
             className={cn(
-              'flex-1 px-4 py-3 text-sm font-medium transition-colors',
-              activeTab === 'api'
-                ? 'text-accent-blue border-b-2 border-accent-blue'
-                : 'text-neutral-400 hover:text-neutral-200'
+              "flex-1 px-4 py-3 text-sm font-medium transition-colors",
+              activeTab === "api"
+                ? "text-accent-blue border-b-2 border-accent-blue"
+                : "text-neutral-400 hover:text-neutral-200",
             )}
           >
             <Key size={16} className="inline mr-2" />
             API Keys
           </button>
           <button
-            onClick={() => setActiveTab('stats')}
+            onClick={() => setActiveTab("stats")}
             className={cn(
-              'flex-1 px-4 py-3 text-sm font-medium transition-colors',
-              activeTab === 'stats'
-                ? 'text-accent-blue border-b-2 border-accent-blue'
-                : 'text-neutral-400 hover:text-neutral-200'
+              "flex-1 px-4 py-3 text-sm font-medium transition-colors",
+              activeTab === "stats"
+                ? "text-accent-blue border-b-2 border-accent-blue"
+                : "text-neutral-400 hover:text-neutral-200",
             )}
           >
             <BarChart size={16} className="inline mr-2" />
             Statistics
           </button>
           <button
-            onClick={() => setActiveTab('database')}
+            onClick={() => setActiveTab("database")}
             className={cn(
-              'flex-1 px-4 py-3 text-sm font-medium transition-colors',
-              activeTab === 'database'
-                ? 'text-accent-blue border-b-2 border-accent-blue'
-                : 'text-neutral-400 hover:text-neutral-200'
+              "flex-1 px-4 py-3 text-sm font-medium transition-colors",
+              activeTab === "database"
+                ? "text-accent-blue border-b-2 border-accent-blue"
+                : "text-neutral-400 hover:text-neutral-200",
             )}
           >
             <Database size={16} className="inline mr-2" />
@@ -207,22 +245,24 @@ export function SettingsPanel({
 
         {/* Content */}
         <div className="flex-1 p-4 overflow-y-auto scrollbar-thin">
-          {activeTab === 'general' && (
+          {activeTab === "general" && (
             <div className="space-y-6">
               {/* Theme Selection */}
               <div>
-                <h4 className="text-sm font-medium text-neutral-100 mb-3">Theme</h4>
+                <h4 className="text-sm font-medium text-neutral-100 mb-3">
+                  Theme
+                </h4>
                 <div className="grid grid-cols-2 gap-2">
                   {themes.map((theme) => (
                     <button
                       key={theme.value}
                       onClick={() => onSettingsChange({ theme: theme.value })}
                       className={cn(
-                        'flex items-center gap-2 p-3 rounded border',
-                        'transition-colors',
+                        "flex items-center gap-2 p-3 rounded border",
+                        "transition-colors",
                         settings.theme === theme.value
-                          ? 'border-accent-blue bg-accent-blue/10 text-accent-blue'
-                          : 'border-neutral-700 hover:border-neutral-600 text-neutral-300'
+                          ? "border-accent-blue bg-accent-blue/10 text-accent-blue"
+                          : "border-neutral-700 hover:border-neutral-600 text-neutral-300",
                       )}
                     >
                       {theme.icon}
@@ -232,9 +272,53 @@ export function SettingsPanel({
                 </div>
               </div>
 
+              {/* Seekbar Colour Overrides */}
+              <div className="mt-4">
+                <h4 className="text-sm font-medium text-neutral-100 mb-3">
+                  Seekbar Colours
+                </h4>
+                <div className="flex items-center gap-4">
+                  <label className="flex items-center gap-2 text-sm text-neutral-300">
+                    Played
+                    <input
+                      type="color"
+                      value={playedColour}
+                      onChange={(e) =>
+                        onSettingsChange({ seekPlayedColor: e.target.value })
+                      }
+                      className="w-8 h-8 p-0 border-none bg-transparent cursor-pointer"
+                    />
+                  </label>
+                  <label className="flex items-center gap-2 text-sm text-neutral-300">
+                    Unplayed
+                    <input
+                      type="color"
+                      value={unplayedColour}
+                      onChange={(e) =>
+                        onSettingsChange({ seekUnplayedColor: e.target.value })
+                      }
+                      className="w-8 h-8 p-0 border-none bg-transparent cursor-pointer"
+                    />
+                  </label>
+                  <button
+                    onClick={() =>
+                      onSettingsChange({
+                        seekPlayedColor: "",
+                        seekUnplayedColor: "",
+                      })
+                    }
+                    className="px-2 py-1 text-xs text-accent-blue border border-accent-blue rounded hover:bg-accent-blue/10"
+                  >
+                    Reset
+                  </button>
+                </div>
+              </div>
+
               {/* Amplitude Scale */}
               <div>
-                <h4 className="text-sm font-medium text-neutral-100 mb-3">Amplitude Scale</h4>
+                <h4 className="text-sm font-medium text-neutral-100 mb-3">
+                  Amplitude Scale
+                </h4>
                 <div className="space-y-2">
                   {amplitudeScales.map((scale) => (
                     <label
@@ -246,10 +330,16 @@ export function SettingsPanel({
                         name="amplitudeScale"
                         value={scale.value}
                         checked={settings.amplitudeScale === scale.value}
-                        onChange={(e) => onSettingsChange({ amplitudeScale: e.target.value as AmplitudeScale })}
+                        onChange={(e) =>
+                          onSettingsChange({
+                            amplitudeScale: e.target.value as AmplitudeScale,
+                          })
+                        }
                         className="text-accent-blue"
                       />
-                      <span className="text-sm text-neutral-300">{scale.label}</span>
+                      <span className="text-sm text-neutral-300">
+                        {scale.label}
+                      </span>
                     </label>
                   ))}
                 </div>
@@ -257,7 +347,9 @@ export function SettingsPanel({
 
               {/* Frequency Scale */}
               <div>
-                <h4 className="text-sm font-medium text-neutral-100 mb-3">Frequency Scale</h4>
+                <h4 className="text-sm font-medium text-neutral-100 mb-3">
+                  Frequency Scale
+                </h4>
                 <div className="space-y-2">
                   {frequencyScales.map((scale) => (
                     <label
@@ -269,10 +361,16 @@ export function SettingsPanel({
                         name="frequencyScale"
                         value={scale.value}
                         checked={settings.frequencyScale === scale.value}
-                        onChange={(e) => onSettingsChange({ frequencyScale: e.target.value as FrequencyScale })}
+                        onChange={(e) =>
+                          onSettingsChange({
+                            frequencyScale: e.target.value as FrequencyScale,
+                          })
+                        }
                         className="text-accent-blue"
                       />
-                      <span className="text-sm text-neutral-300">{scale.label}</span>
+                      <span className="text-sm text-neutral-300">
+                        {scale.label}
+                      </span>
                     </label>
                   ))}
                 </div>
@@ -280,7 +378,9 @@ export function SettingsPanel({
 
               {/* Resolution */}
               <div>
-                <h4 className="text-sm font-medium text-neutral-100 mb-3">Resolution</h4>
+                <h4 className="text-sm font-medium text-neutral-100 mb-3">
+                  Resolution
+                </h4>
                 <div className="space-y-2">
                   {resolutions.map((resolution) => (
                     <label
@@ -292,10 +392,16 @@ export function SettingsPanel({
                         name="resolution"
                         value={resolution.value}
                         checked={settings.resolution === resolution.value}
-                        onChange={(e) => onSettingsChange({ resolution: e.target.value as Resolution })}
+                        onChange={(e) =>
+                          onSettingsChange({
+                            resolution: e.target.value as Resolution,
+                          })
+                        }
                         className="text-accent-blue"
                       />
-                      <span className="text-sm text-neutral-300">{resolution.label}</span>
+                      <span className="text-sm text-neutral-300">
+                        {resolution.label}
+                      </span>
                     </label>
                   ))}
                 </div>
@@ -303,7 +409,9 @@ export function SettingsPanel({
 
               {/* Refresh Rate */}
               <div>
-                <h4 className="text-sm font-medium text-neutral-100 mb-3">Refresh Rate</h4>
+                <h4 className="text-sm font-medium text-neutral-100 mb-3">
+                  Refresh Rate
+                </h4>
                 <div className="space-y-2">
                   {refreshRates.map((rate) => (
                     <label
@@ -315,10 +423,18 @@ export function SettingsPanel({
                         name="refreshRate"
                         value={rate.value}
                         checked={settings.refreshRate === rate.value}
-                        onChange={(e) => onSettingsChange({ refreshRate: parseInt(e.target.value) as RefreshRate })}
+                        onChange={(e) =>
+                          onSettingsChange({
+                            refreshRate: parseInt(
+                              e.target.value,
+                            ) as RefreshRate,
+                          })
+                        }
                         className="text-accent-blue"
                       />
-                      <span className="text-sm text-neutral-300">{rate.label}</span>
+                      <span className="text-sm text-neutral-300">
+                        {rate.label}
+                      </span>
                     </label>
                   ))}
                 </div>
@@ -330,7 +446,9 @@ export function SettingsPanel({
                   <input
                     type="checkbox"
                     checked={settings.showLegend}
-                    onChange={(e) => onSettingsChange({ showLegend: e.target.checked })}
+                    onChange={(e) =>
+                      onSettingsChange({ showLegend: e.target.checked })
+                    }
                     className="text-accent-blue"
                   />
                   <span className="text-sm text-neutral-300">Show Legend</span>
@@ -344,42 +462,57 @@ export function SettingsPanel({
                     type="checkbox"
                     checked={settings.enableToastNotifications}
                     onChange={(e) => {
-                      const enabled = e.target.checked
-                      onSettingsChange({ enableToastNotifications: enabled })
+                      const enabled = e.target.checked;
+                      onSettingsChange({ enableToastNotifications: enabled });
                       if (enabled) {
-                        directToast.success('Toast notifications enabled')
+                        directToast.success("Toast notifications enabled");
                       }
                     }}
                     className="text-accent-blue"
                   />
                   <div>
-                    <span className="text-sm text-neutral-300">Toast Notifications</span>
-                    <p className="text-xs text-neutral-500">Show success and error notifications</p>
+                    <span className="text-sm text-neutral-300">
+                      Toast Notifications
+                    </span>
+                    <p className="text-xs text-neutral-500">
+                      Show success and error notifications
+                    </p>
                   </div>
                 </label>
               </div>
             </div>
           )}
 
-          {activeTab === 'artwork' && (
+          {activeTab === "artwork" && (
             <div className="space-y-6">
               <div className="bg-neutral-800/50 rounded-lg p-4">
-                <h4 className="text-sm font-medium text-neutral-100 mb-2">Artwork Sources</h4>
+                <h4 className="text-sm font-medium text-neutral-100 mb-2">
+                  Artwork Sources
+                </h4>
                 <p className="text-xs text-neutral-400 mb-4">
-                  Configure how album artwork is retrieved. Sources are tried in order of priority.
+                  Configure how album artwork is retrieved. Sources are tried in
+                  order of priority.
                 </p>
-                
+
                 <div className="space-y-3">
                   <label className="flex items-center gap-3 p-2 rounded hover:bg-neutral-800 cursor-pointer">
                     <input
                       type="checkbox"
                       checked={settings.enableExternalArtwork}
-                      onChange={(e) => onSettingsChange({ enableExternalArtwork: e.target.checked })}
+                      onChange={(e) =>
+                        onSettingsChange({
+                          enableExternalArtwork: e.target.checked,
+                        })
+                      }
                       className="text-accent-blue"
                     />
                     <div>
-                      <span className="text-sm text-neutral-300">Enable External Artwork</span>
-                      <p className="text-xs text-neutral-500">Allow fetching artwork from online sources</p>
+                      <span className="text-sm text-neutral-300">
+                        Enable External Artwork
+                      </span>
+                      <p className="text-xs text-neutral-500">
+                        Allow fetching artwork from online sources
+                      </p>
                     </div>
                   </label>
 
@@ -387,13 +520,21 @@ export function SettingsPanel({
                     <input
                       type="checkbox"
                       checked={settings.enableMusicBrainz}
-                      onChange={(e) => onSettingsChange({ enableMusicBrainz: e.target.checked })}
+                      onChange={(e) =>
+                        onSettingsChange({
+                          enableMusicBrainz: e.target.checked,
+                        })
+                      }
                       disabled={!settings.enableExternalArtwork}
                       className="text-accent-blue"
                     />
                     <div>
-                      <span className="text-sm text-neutral-300">MusicBrainz Lookup</span>
-                      <p className="text-xs text-neutral-500">Search MusicBrainz database for album artwork</p>
+                      <span className="text-sm text-neutral-300">
+                        MusicBrainz Lookup
+                      </span>
+                      <p className="text-xs text-neutral-500">
+                        Search MusicBrainz database for album artwork
+                      </p>
                     </div>
                   </label>
 
@@ -401,13 +542,20 @@ export function SettingsPanel({
                     <input
                       type="checkbox"
                       checked={settings.enableAcoustID}
-                      onChange={(e) => onSettingsChange({ enableAcoustID: e.target.checked })}
+                      onChange={(e) =>
+                        onSettingsChange({ enableAcoustID: e.target.checked })
+                      }
                       disabled={!settings.enableExternalArtwork}
                       className="text-accent-blue"
                     />
                     <div>
-                      <span className="text-sm text-neutral-300">AcoustID Fingerprinting</span>
-                      <p className="text-xs text-neutral-500">Use audio fingerprinting for identification (requires API key)</p>
+                      <span className="text-sm text-neutral-300">
+                        AcoustID Fingerprinting
+                      </span>
+                      <p className="text-xs text-neutral-500">
+                        Use audio fingerprinting for identification (requires
+                        API key)
+                      </p>
                     </div>
                   </label>
 
@@ -415,12 +563,21 @@ export function SettingsPanel({
                     <input
                       type="checkbox"
                       checked={settings.enablePlaceholderArtwork}
-                      onChange={(e) => onSettingsChange({ enablePlaceholderArtwork: e.target.checked })}
+                      onChange={(e) =>
+                        onSettingsChange({
+                          enablePlaceholderArtwork: e.target.checked,
+                        })
+                      }
                       className="text-accent-blue"
                     />
                     <div>
-                      <span className="text-sm text-neutral-300">Generate Placeholder Artwork</span>
-                      <p className="text-xs text-neutral-500">Create unique placeholder images when no artwork is found</p>
+                      <span className="text-sm text-neutral-300">
+                        Generate Placeholder Artwork
+                      </span>
+                      <p className="text-xs text-neutral-500">
+                        Create unique placeholder images when no artwork is
+                        found
+                      </p>
                     </div>
                   </label>
                 </div>
@@ -428,72 +585,102 @@ export function SettingsPanel({
             </div>
           )}
 
-          {activeTab === 'api' && (
+          {activeTab === "api" && (
             <div className="space-y-6">
               <div className="bg-neutral-800/50 rounded-lg p-4">
-                <h4 className="text-sm font-medium text-neutral-100 mb-2">API Keys</h4>
+                <h4 className="text-sm font-medium text-neutral-100 mb-2">
+                  API Keys
+                </h4>
                 <p className="text-xs text-neutral-400 mb-4">
-                  Configure API keys for external services. Keys are stored locally and never shared.
+                  Configure API keys for external services. Keys are stored
+                  locally and never shared.
                 </p>
-                
+
                 <div className="space-y-4">
                   {/* AcoustID API Key */}
                   <div>
                     <div className="flex items-center gap-2 mb-2">
-                      <label className="text-sm font-medium text-neutral-300">AcoustID API Key</label>
-                      {getAPIKeyStatusIcon('acoustid')}
+                      <label className="text-sm font-medium text-neutral-300">
+                        AcoustID API Key
+                      </label>
+                      {getAPIKeyStatusIcon("acoustid")}
                       <span className="text-xs text-neutral-500">
-                        {getAPIKeyStatusText('acoustid')}
+                        {getAPIKeyStatusText("acoustid")}
                       </span>
                     </div>
                     <div className="flex gap-2">
                       <input
                         type="password"
-                        value={settings.apiKeys.acoustid || ''}
-                        onChange={(e) => handleAPIKeyChange('acoustid', e.target.value)}
+                        value={settings.apiKeys.acoustid || ""}
+                        onChange={(e) =>
+                          handleAPIKeyChange("acoustid", e.target.value)
+                        }
                         placeholder="Enter your AcoustID API key"
                         className="flex-1 px-3 py-2 bg-neutral-700 border border-neutral-600 rounded text-sm text-neutral-100 placeholder-neutral-400 focus:outline-none focus:border-accent-blue"
                       />
                       <button
-                        onClick={() => validateAPIKey('acoustid')}
-                        disabled={!settings.apiKeys.acoustid || validatingKeys.acoustid}
+                        onClick={() => validateAPIKey("acoustid")}
+                        disabled={
+                          !settings.apiKeys.acoustid || validatingKeys.acoustid
+                        }
                         className="px-3 py-2 bg-accent-blue text-white rounded text-sm hover:bg-accent-blue/80 disabled:opacity-50 disabled:cursor-not-allowed"
                       >
-                        {validatingKeys.acoustid ? <Loader2 size={16} className="animate-spin" /> : 'Test'}
+                        {validatingKeys.acoustid ? (
+                          <Loader2 size={16} className="animate-spin" />
+                        ) : (
+                          "Test"
+                        )}
                       </button>
                     </div>
                     <p className="text-xs text-neutral-500 mt-1">
-                      Get a free API key from <a href="https://acoustid.org/" target="_blank" rel="noopener noreferrer" className="text-accent-blue hover:underline">acoustid.org</a>
+                      Get a free API key from{" "}
+                      <a
+                        href="https://acoustid.org/"
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="text-accent-blue hover:underline"
+                      >
+                        acoustid.org
+                      </a>
                     </p>
                   </div>
 
                   {/* MusicBrainz API Key */}
                   <div>
                     <div className="flex items-center gap-2 mb-2">
-                      <label className="text-sm font-medium text-neutral-300">MusicBrainz API Key</label>
-                      {getAPIKeyStatusIcon('musicbrainz')}
+                      <label className="text-sm font-medium text-neutral-300">
+                        MusicBrainz API Key
+                      </label>
+                      {getAPIKeyStatusIcon("musicbrainz")}
                       <span className="text-xs text-neutral-500">
-                        {getAPIKeyStatusText('musicbrainz')}
+                        {getAPIKeyStatusText("musicbrainz")}
                       </span>
                     </div>
                     <div className="flex gap-2">
                       <input
                         type="password"
-                        value={settings.apiKeys.musicbrainz || ''}
-                        onChange={(e) => handleAPIKeyChange('musicbrainz', e.target.value)}
+                        value={settings.apiKeys.musicbrainz || ""}
+                        onChange={(e) =>
+                          handleAPIKeyChange("musicbrainz", e.target.value)
+                        }
                         placeholder="Optional - MusicBrainz works without API key"
                         className="flex-1 px-3 py-2 bg-neutral-700 border border-neutral-600 rounded text-sm text-neutral-100 placeholder-neutral-400 focus:outline-none focus:border-accent-blue"
                       />
                       <button
-                        onClick={() => validateAPIKey('musicbrainz')}
+                        onClick={() => validateAPIKey("musicbrainz")}
                         disabled={validatingKeys.musicbrainz}
                         className="px-3 py-2 bg-accent-blue text-white rounded text-sm hover:bg-accent-blue/80 disabled:opacity-50 disabled:cursor-not-allowed"
                       >
-                        {validatingKeys.musicbrainz ? <Loader2 size={16} className="animate-spin" /> : 'Test'}
+                        {validatingKeys.musicbrainz ? (
+                          <Loader2 size={16} className="animate-spin" />
+                        ) : (
+                          "Test"
+                        )}
                       </button>
                     </div>
                     <p className="text-xs text-neutral-500 mt-1">
-                      MusicBrainz is free and works without an API key, but you can register for higher rate limits
+                      MusicBrainz is free and works without an API key, but you
+                      can register for higher rate limits
                     </p>
                   </div>
                 </div>
@@ -501,13 +688,9 @@ export function SettingsPanel({
             </div>
           )}
 
-          {activeTab === 'stats' && (
-            <StatisticsPanel />
-          )}
+          {activeTab === "stats" && <StatisticsPanel />}
 
-          {activeTab === 'database' && (
-            <MetadataStorePanel />
-          )}
+          {activeTab === "database" && <MetadataStorePanel />}
         </div>
 
         {/* Footer */}
@@ -516,13 +699,15 @@ export function SettingsPanel({
             onClick={() => {
               // Reset to defaults
               onSettingsChange({
-                theme: 'dark',
-                amplitudeScale: 'db',
-                frequencyScale: 'logarithmic',
-                resolution: 'medium',
+                theme: "dark",
+                amplitudeScale: "db",
+                frequencyScale: "logarithmic",
+                resolution: "medium",
                 refreshRate: 60,
-                colormap: 'viridis',
+                colormap: "viridis",
                 showLegend: true,
+                seekPlayedColor: "",
+                seekUnplayedColor: "",
                 enableExternalArtwork: true,
                 enableAcoustID: true,
                 enableMusicBrainz: true,
@@ -530,9 +715,9 @@ export function SettingsPanel({
                 apiKeys: {},
                 apiKeyStatus: {
                   acoustid: { valid: false },
-                  musicbrainz: { valid: false }
-                }
-              })
+                  musicbrainz: { valid: false },
+                },
+              });
             }}
             className="btn-secondary w-full"
           >
@@ -541,5 +726,5 @@ export function SettingsPanel({
         </div>
       </div>
     </div>
-  )
+  );
 }

--- a/web/apps/mfe-spectrogram/src/hooks/useSeekbarColors.ts
+++ b/web/apps/mfe-spectrogram/src/hooks/useSeekbarColors.ts
@@ -1,0 +1,30 @@
+import { useEffect } from "react";
+import { useSettingsStore } from "@/shared/stores/settingsStore";
+import { THEME_COLORS } from "@/shared/theme";
+
+/**
+ * React hook that synchronises CSS variables controlling the seekbar colours
+ * with the current theme and any user overrides stored in settings.
+ * Running this hook ensures that components reading --seek-played and
+ * --seek-unplayed always receive up-to-date values without hard-coded fallbacks.
+ */
+export function useSeekbarColors(): void {
+  const { theme, seekPlayedColor, seekUnplayedColor } = useSettingsStore(
+    (state) => ({
+      theme: state.theme,
+      seekPlayedColor: state.seekPlayedColor,
+      seekUnplayedColor: state.seekUnplayedColor,
+    }),
+  );
+
+  useEffect(() => {
+    const root = document.documentElement;
+    const { accent, primary } = THEME_COLORS[theme];
+    // Apply overrides if present; otherwise fall back to theme colours.
+    root.style.setProperty("--seek-played", (seekPlayedColor || accent).trim());
+    root.style.setProperty(
+      "--seek-unplayed",
+      (seekUnplayedColor || primary).trim(),
+    );
+  }, [theme, seekPlayedColor, seekUnplayedColor]);
+}

--- a/web/apps/mfe-spectrogram/src/index.css
+++ b/web/apps/mfe-spectrogram/src/index.css
@@ -2,48 +2,47 @@
 @tailwind components;
 @tailwind utilities;
 
+/*
+  Theme colour variables
+  ----------------------
+  --accent-color and --primary-color are the canonical theme colours. The
+  seekbar variables reference these to ensure consistency across themes and
+  user customisation. Values are overridden by theme-specific classes and can
+  be further overridden via settings.
+*/
 :root {
+  --accent-color: #3b82f6;
+  --primary-color: #6b7280;
   /* Seekbar theme variables */
-  --seek-played: rgb(59, 130, 246); /* blue-500 */
-  --seek-unplayed: rgb(
-    107,
-    114,
-    128
-  ); /* gray-500 - brighter for better visibility */
+  --seek-played: var(--accent-color);
+  --seek-unplayed: var(--primary-color);
   --seek-buffered: rgba(59, 130, 246, 0.6); /* blue-500 with more opacity */
-  --seek-focus: rgb(59, 130, 246); /* blue-500 */
+  --seek-focus: var(--accent-color);
   --seek-disabled: rgba(156, 163, 175, 0.4); /* gray-400 with more opacity */
   --seek-hover-played: rgb(96, 165, 250); /* blue-400 */
   --seek-hover-unplayed: rgb(156, 163, 175); /* gray-400 - brighter on hover */
   --seek-time-label: rgb(156, 163, 175); /* gray-400 */
 }
 
-/* Dark theme overrides */
-.dark {
-  --seek-played: rgb(59, 130, 246); /* blue-500 */
-  --seek-unplayed: rgb(
-    107,
-    114,
-    128
-  ); /* gray-500 - brighter for better visibility */
-  --seek-buffered: rgba(59, 130, 246, 0.6); /* blue-500 with more opacity */
-  --seek-focus: rgb(59, 130, 246); /* blue-500 */
-  --seek-disabled: rgba(156, 163, 175, 0.4); /* gray-400 with more opacity */
-  --seek-hover-played: rgb(96, 165, 250); /* blue-400 */
-  --seek-hover-unplayed: rgb(156, 163, 175); /* gray-400 - brighter on hover */
-  --seek-time-label: rgb(156, 163, 175); /* gray-400 */
+/* Theme overrides matching the body class applied by the app */
+.theme-dark {
+  --accent-color: #3b82f6;
+  --primary-color: #6b7280;
 }
 
-/* Light theme overrides */
-.light {
-  --seek-played: rgb(37, 99, 235); /* blue-600 */
-  --seek-unplayed: rgb(156, 163, 175); /* gray-400 */
-  --seek-buffered: rgba(37, 99, 235, 0.5); /* blue-600 with opacity */
-  --seek-focus: rgb(37, 99, 235); /* blue-600 */
-  --seek-disabled: rgba(156, 163, 175, 0.3); /* gray-400 with opacity */
-  --seek-hover-played: rgb(59, 130, 246); /* blue-500 */
-  --seek-hover-unplayed: rgb(107, 114, 128); /* gray-500 */
-  --seek-time-label: rgb(107, 114, 128); /* gray-500 */
+.theme-light {
+  --accent-color: #2563eb;
+  --primary-color: #9ca3af;
+}
+
+.theme-neon {
+  --accent-color: #14b8a6;
+  --primary-color: #a3a3a3;
+}
+
+.theme-high-contrast {
+  --accent-color: #ffffff;
+  --primary-color: #000000;
 }
 
 /* Custom scrollbar styles */

--- a/web/apps/mfe-spectrogram/src/shared/stores/settingsStore.ts
+++ b/web/apps/mfe-spectrogram/src/shared/stores/settingsStore.ts
@@ -1,57 +1,75 @@
-import { create } from 'zustand'
-import { subscribeWithSelector } from 'zustand/middleware'
-import { SpectrogramSettings, Theme, AmplitudeScale, FrequencyScale, Resolution, RefreshRate, APIKeys, APIKeyStatus } from '@/types'
+import { create } from "zustand";
+import { subscribeWithSelector } from "zustand/middleware";
+import {
+  SpectrogramSettings,
+  Theme,
+  AmplitudeScale,
+  FrequencyScale,
+  Resolution,
+  RefreshRate,
+  APIKeys,
+  APIKeyStatus,
+} from "@/types";
 
 interface SettingsStore extends SpectrogramSettings {
   // Actions
-  setTheme: (theme: Theme) => void
-  setAmplitudeScale: (scale: AmplitudeScale) => void
-  setFrequencyScale: (scale: FrequencyScale) => void
-  setResolution: (resolution: Resolution) => void
-  setRefreshRate: (rate: RefreshRate) => void
-  setColormap: (colormap: string) => void
-  setShowLegend: (show: boolean) => void
-  setEnableToastNotifications: (enable: boolean) => void
-  updateSettings: (settings: Partial<SpectrogramSettings>) => void
-  resetToDefaults: () => void
-  loadFromStorage: () => void
-  saveToStorage: () => void
-  
+  setTheme: (theme: Theme) => void;
+  setAmplitudeScale: (scale: AmplitudeScale) => void;
+  setFrequencyScale: (scale: FrequencyScale) => void;
+  setResolution: (resolution: Resolution) => void;
+  setRefreshRate: (rate: RefreshRate) => void;
+  setColormap: (colormap: string) => void;
+  setShowLegend: (show: boolean) => void;
+  setEnableToastNotifications: (enable: boolean) => void;
+  /** User-defined override for the played portion colour. */
+  setSeekPlayedColor: (color: string) => void;
+  /** User-defined override for the unplayed portion colour. */
+  setSeekUnplayedColor: (color: string) => void;
+  /** Clears both colour overrides, reverting to theme defaults. */
+  resetSeekbarColors: () => void;
+  updateSettings: (settings: Partial<SpectrogramSettings>) => void;
+  resetToDefaults: () => void;
+  loadFromStorage: () => void;
+  saveToStorage: () => void;
+
   // API Key actions
-  setAPIKey: (service: keyof APIKeys, key: string) => void
-  validateAPIKey: (service: keyof APIKeys) => Promise<boolean>
-  getAPIKeyStatus: () => APIKeyStatus
-  
+  setAPIKey: (service: keyof APIKeys, key: string) => void;
+  validateAPIKey: (service: keyof APIKeys) => Promise<boolean>;
+  getAPIKeyStatus: () => APIKeyStatus;
+
   // Artwork settings actions
-  setEnableExternalArtwork: (enable: boolean) => void
-  setEnableAcoustID: (enable: boolean) => void
-  setEnableMusicBrainz: (enable: boolean) => void
-  setEnablePlaceholderArtwork: (enable: boolean) => void
+  setEnableExternalArtwork: (enable: boolean) => void;
+  setEnableAcoustID: (enable: boolean) => void;
+  setEnableMusicBrainz: (enable: boolean) => void;
+  setEnablePlaceholderArtwork: (enable: boolean) => void;
 }
 
 const defaultSettings: SpectrogramSettings = {
-  theme: 'dark',
-  amplitudeScale: 'db',
-  frequencyScale: 'logarithmic',
-  resolution: 'medium',
+  theme: "dark",
+  amplitudeScale: "db",
+  frequencyScale: "logarithmic",
+  resolution: "medium",
   refreshRate: 60,
-  colormap: 'viridis',
+  colormap: "viridis",
   showLegend: true,
   enableToastNotifications: false, // Disabled by default
+  // Seekbar color overrides: empty strings mean use theme defaults.
+  seekPlayedColor: "",
+  seekUnplayedColor: "",
   // API Keys
   apiKeys: {},
   apiKeyStatus: {
     acoustid: { valid: false },
-    musicbrainz: { valid: false }
+    musicbrainz: { valid: false },
   },
   // Artwork settings
   enableExternalArtwork: true,
   enableAcoustID: true,
   enableMusicBrainz: true,
   enablePlaceholderArtwork: true,
-}
+};
 
-const STORAGE_KEY = 'spectrogram-settings'
+const STORAGE_KEY = "spectrogram-settings";
 
 export const useSettingsStore = create<SettingsStore>()(
   subscribeWithSelector((set, get) => ({
@@ -64,37 +82,44 @@ export const useSettingsStore = create<SettingsStore>()(
     setRefreshRate: (refreshRate) => set({ refreshRate }),
     setColormap: (colormap) => set({ colormap }),
     setShowLegend: (showLegend) => set({ showLegend }),
-    setEnableToastNotifications: (enableToastNotifications) => set({ enableToastNotifications }),
+    setEnableToastNotifications: (enableToastNotifications) =>
+      set({ enableToastNotifications }),
+    // Store colour overrides individually to avoid unnecessary object copies.
+    setSeekPlayedColor: (seekPlayedColor) => set({ seekPlayedColor }),
+    setSeekUnplayedColor: (seekUnplayedColor) => set({ seekUnplayedColor }),
+    // Reset both colours back to theme-driven defaults in one cheap update.
+    resetSeekbarColors: () =>
+      set({ seekPlayedColor: "", seekUnplayedColor: "" }),
 
     updateSettings: (settings) => {
-      set((state) => ({ ...state, ...settings }))
+      set((state) => ({ ...state, ...settings }));
     },
 
     resetToDefaults: () => {
-      set(defaultSettings)
+      set(defaultSettings);
     },
 
     loadFromStorage: () => {
       try {
-        const stored = localStorage.getItem(STORAGE_KEY)
+        const stored = localStorage.getItem(STORAGE_KEY);
         if (stored) {
-          const settings = JSON.parse(stored)
+          const settings = JSON.parse(stored);
           // Ensure all required fields are present
-          const mergedSettings = { ...defaultSettings, ...settings }
-          set((state) => ({ ...state, ...mergedSettings }))
+          const mergedSettings = { ...defaultSettings, ...settings };
+          set((state) => ({ ...state, ...mergedSettings }));
         }
-          } catch (error) {
-      // Failed to load settings from storage
-    }
+      } catch (error) {
+        // Failed to load settings from storage
+      }
     },
 
     saveToStorage: () => {
       try {
-        const settings = get()
-        localStorage.setItem(STORAGE_KEY, JSON.stringify(settings))
-          } catch (error) {
-      // Failed to save settings to storage
-    }
+        const settings = get();
+        localStorage.setItem(STORAGE_KEY, JSON.stringify(settings));
+      } catch (error) {
+        // Failed to save settings to storage
+      }
     },
 
     // API Key actions
@@ -103,75 +128,81 @@ export const useSettingsStore = create<SettingsStore>()(
         apiKeys: { ...state.apiKeys, [service]: key },
         apiKeyStatus: {
           ...state.apiKeyStatus,
-          [service]: { valid: false, lastChecked: undefined }
-        }
-      }))
+          [service]: { valid: false, lastChecked: undefined },
+        },
+      }));
     },
 
     validateAPIKey: async (service) => {
-      const state = get()
-      const apiKey = state.apiKeys[service]
-      
+      const state = get();
+      const apiKey = state.apiKeys[service];
+
       if (!apiKey) {
         set((state) => ({
           apiKeyStatus: {
             ...state.apiKeyStatus,
-            [service]: { valid: false, lastChecked: new Date() }
-          }
-        }))
-        return false
+            [service]: { valid: false, lastChecked: new Date() },
+          },
+        }));
+        return false;
       }
 
       try {
-        let isValid = false
-        
-        if (service === 'acoustid') {
+        let isValid = false;
+
+        if (service === "acoustid") {
           // Test AcoustID API
-          const response = await fetch(`https://api.acoustid.org/v2/lookup?client=${apiKey}&meta=recordings+releasegroups&fingerprint=test&duration=1`)
-          isValid = response.ok
-        } else if (service === 'musicbrainz') {
+          const response = await fetch(
+            `https://api.acoustid.org/v2/lookup?client=${apiKey}&meta=recordings+releasegroups&fingerprint=test&duration=1`,
+          );
+          isValid = response.ok;
+        } else if (service === "musicbrainz") {
           // Test MusicBrainz API (no API key required, but we can test the endpoint)
-          const response = await fetch('https://musicbrainz.org/ws/2/release/?query=artist:"test"&fmt=json&limit=1')
-          isValid = response.ok
+          const response = await fetch(
+            'https://musicbrainz.org/ws/2/release/?query=artist:"test"&fmt=json&limit=1',
+          );
+          isValid = response.ok;
         }
 
         set((state) => ({
           apiKeyStatus: {
             ...state.apiKeyStatus,
-            [service]: { valid: isValid, lastChecked: new Date() }
-          }
-        }))
+            [service]: { valid: isValid, lastChecked: new Date() },
+          },
+        }));
 
-        return isValid
+        return isValid;
       } catch (error) {
         set((state) => ({
           apiKeyStatus: {
             ...state.apiKeyStatus,
-            [service]: { valid: false, lastChecked: new Date() }
-          }
-        }))
-        return false
+            [service]: { valid: false, lastChecked: new Date() },
+          },
+        }));
+        return false;
       }
     },
 
     getAPIKeyStatus: () => {
-      return get().apiKeyStatus
+      return get().apiKeyStatus;
     },
 
     // Artwork settings actions
-    setEnableExternalArtwork: (enable) => set({ enableExternalArtwork: enable }),
+    setEnableExternalArtwork: (enable) =>
+      set({ enableExternalArtwork: enable }),
     setEnableAcoustID: (enable) => set({ enableAcoustID: enable }),
     setEnableMusicBrainz: (enable) => set({ enableMusicBrainz: enable }),
-    setEnablePlaceholderArtwork: (enable) => set({ enablePlaceholderArtwork: enable }),
-  }))
-)
+    setEnablePlaceholderArtwork: (enable) =>
+      set({ enablePlaceholderArtwork: enable }),
+  })),
+);
 
 // Auto-save settings when they change
 useSettingsStore.subscribe((state) => {
-  state.saveToStorage()
-})
+  state.saveToStorage();
+});
 
 // Load settings on initialization
-if (typeof window !== 'undefined') {
-  useSettingsStore.getState().loadFromStorage()
+if (typeof window !== "undefined") {
+  useSettingsStore.getState().loadFromStorage();
 }

--- a/web/apps/mfe-spectrogram/src/shared/theme.ts
+++ b/web/apps/mfe-spectrogram/src/shared/theme.ts
@@ -1,0 +1,24 @@
+/**
+ * Mapping of themes to their accent and primary colors.
+ * Centralizes color definitions to avoid scattering hex literals and
+ * allows components to derive consistent styling from the active theme.
+ */
+import { Theme } from "@/types";
+
+/**
+ * Hard-coded color palette for each supported theme.
+ * Both accent and primary colors are hex strings and intentionally kept
+ * minimal to reduce memory and avoid runtime color computation.
+ */
+export const THEME_COLORS: Record<Theme, { accent: string; primary: string }> =
+  {
+    // Classic dark theme: blue accents with neutral grays.
+    dark: { accent: "#3b82f6", primary: "#6b7280" },
+    // Light theme uses slightly darker blues and lighter grays for contrast.
+    light: { accent: "#2563eb", primary: "#9ca3af" },
+    // Neon theme favours a vivid teal accent; primary remains neutral to
+    // prevent eye strain despite the bright palette.
+    neon: { accent: "#14b8a6", primary: "#a3a3a3" },
+    // High contrast aims for maximal legibility: white accent on black primary.
+    "high-contrast": { accent: "#ffffff", primary: "#000000" },
+  } as const;

--- a/web/apps/mfe-spectrogram/src/shared/types/index.ts
+++ b/web/apps/mfe-spectrogram/src/shared/types/index.ts
@@ -128,6 +128,16 @@ export interface SpectrogramSettings {
   colormap: string;
   showLegend: boolean;
   enableToastNotifications: boolean;
+  /**
+   * Optional override for the played portion of the seekbar.
+   * When empty, the active theme's accent color is used.
+   */
+  seekPlayedColor?: string;
+  /**
+   * Optional override for the unplayed portion of the seekbar.
+   * Falls back to the theme's primary color when unset.
+   */
+  seekUnplayedColor?: string;
   // API Keys
   apiKeys: APIKeys;
   apiKeyStatus: APIKeyStatus;

--- a/web/apps/mfe-spectrogram/src/stores/settingsStore.ts
+++ b/web/apps/mfe-spectrogram/src/stores/settingsStore.ts
@@ -1,57 +1,75 @@
-import { create } from 'zustand'
-import { subscribeWithSelector } from 'zustand/middleware'
-import { SpectrogramSettings, Theme, AmplitudeScale, FrequencyScale, Resolution, RefreshRate, APIKeys, APIKeyStatus } from '@/types'
+import { create } from "zustand";
+import { subscribeWithSelector } from "zustand/middleware";
+import {
+  SpectrogramSettings,
+  Theme,
+  AmplitudeScale,
+  FrequencyScale,
+  Resolution,
+  RefreshRate,
+  APIKeys,
+  APIKeyStatus,
+} from "@/types";
 
 interface SettingsStore extends SpectrogramSettings {
   // Actions
-  setTheme: (theme: Theme) => void
-  setAmplitudeScale: (scale: AmplitudeScale) => void
-  setFrequencyScale: (scale: FrequencyScale) => void
-  setResolution: (resolution: Resolution) => void
-  setRefreshRate: (rate: RefreshRate) => void
-  setColormap: (colormap: string) => void
-  setShowLegend: (show: boolean) => void
-  setEnableToastNotifications: (enable: boolean) => void
-  updateSettings: (settings: Partial<SpectrogramSettings>) => void
-  resetToDefaults: () => void
-  loadFromStorage: () => void
-  saveToStorage: () => void
-  
+  setTheme: (theme: Theme) => void;
+  setAmplitudeScale: (scale: AmplitudeScale) => void;
+  setFrequencyScale: (scale: FrequencyScale) => void;
+  setResolution: (resolution: Resolution) => void;
+  setRefreshRate: (rate: RefreshRate) => void;
+  setColormap: (colormap: string) => void;
+  setShowLegend: (show: boolean) => void;
+  setEnableToastNotifications: (enable: boolean) => void;
+  /** User-defined override for the played portion colour. */
+  setSeekPlayedColor: (color: string) => void;
+  /** User-defined override for the unplayed portion colour. */
+  setSeekUnplayedColor: (color: string) => void;
+  /** Clears both colour overrides, reverting to theme defaults. */
+  resetSeekbarColors: () => void;
+  updateSettings: (settings: Partial<SpectrogramSettings>) => void;
+  resetToDefaults: () => void;
+  loadFromStorage: () => void;
+  saveToStorage: () => void;
+
   // API Key actions
-  setAPIKey: (service: keyof APIKeys, key: string) => void
-  validateAPIKey: (service: keyof APIKeys) => Promise<boolean>
-  getAPIKeyStatus: () => APIKeyStatus
-  
+  setAPIKey: (service: keyof APIKeys, key: string) => void;
+  validateAPIKey: (service: keyof APIKeys) => Promise<boolean>;
+  getAPIKeyStatus: () => APIKeyStatus;
+
   // Artwork settings actions
-  setEnableExternalArtwork: (enable: boolean) => void
-  setEnableAcoustID: (enable: boolean) => void
-  setEnableMusicBrainz: (enable: boolean) => void
-  setEnablePlaceholderArtwork: (enable: boolean) => void
+  setEnableExternalArtwork: (enable: boolean) => void;
+  setEnableAcoustID: (enable: boolean) => void;
+  setEnableMusicBrainz: (enable: boolean) => void;
+  setEnablePlaceholderArtwork: (enable: boolean) => void;
 }
 
 const defaultSettings: SpectrogramSettings = {
-  theme: 'dark',
-  amplitudeScale: 'db',
-  frequencyScale: 'logarithmic',
-  resolution: 'medium',
+  theme: "dark",
+  amplitudeScale: "db",
+  frequencyScale: "logarithmic",
+  resolution: "medium",
   refreshRate: 60,
-  colormap: 'viridis',
+  colormap: "viridis",
   showLegend: true,
   enableToastNotifications: false, // Disabled by default
+  // Seekbar color overrides: empty strings mean use theme defaults.
+  seekPlayedColor: "",
+  seekUnplayedColor: "",
   // API Keys
   apiKeys: {},
   apiKeyStatus: {
     acoustid: { valid: false },
-    musicbrainz: { valid: false }
+    musicbrainz: { valid: false },
   },
   // Artwork settings
   enableExternalArtwork: true,
   enableAcoustID: true,
   enableMusicBrainz: true,
   enablePlaceholderArtwork: true,
-}
+};
 
-const STORAGE_KEY = 'spectrogram-settings'
+const STORAGE_KEY = "spectrogram-settings";
 
 export const useSettingsStore = create<SettingsStore>()(
   subscribeWithSelector((set, get) => ({
@@ -64,37 +82,44 @@ export const useSettingsStore = create<SettingsStore>()(
     setRefreshRate: (refreshRate) => set({ refreshRate }),
     setColormap: (colormap) => set({ colormap }),
     setShowLegend: (showLegend) => set({ showLegend }),
-    setEnableToastNotifications: (enableToastNotifications) => set({ enableToastNotifications }),
+    setEnableToastNotifications: (enableToastNotifications) =>
+      set({ enableToastNotifications }),
+    // Store colour overrides individually to avoid unnecessary object copies.
+    setSeekPlayedColor: (seekPlayedColor) => set({ seekPlayedColor }),
+    setSeekUnplayedColor: (seekUnplayedColor) => set({ seekUnplayedColor }),
+    // Reset both colours back to theme-driven defaults in one cheap update.
+    resetSeekbarColors: () =>
+      set({ seekPlayedColor: "", seekUnplayedColor: "" }),
 
     updateSettings: (settings) => {
-      set((state) => ({ ...state, ...settings }))
+      set((state) => ({ ...state, ...settings }));
     },
 
     resetToDefaults: () => {
-      set(defaultSettings)
+      set(defaultSettings);
     },
 
     loadFromStorage: () => {
       try {
-        const stored = localStorage.getItem(STORAGE_KEY)
+        const stored = localStorage.getItem(STORAGE_KEY);
         if (stored) {
-          const settings = JSON.parse(stored)
+          const settings = JSON.parse(stored);
           // Ensure all required fields are present
-          const mergedSettings = { ...defaultSettings, ...settings }
-          set((state) => ({ ...state, ...mergedSettings }))
+          const mergedSettings = { ...defaultSettings, ...settings };
+          set((state) => ({ ...state, ...mergedSettings }));
         }
-          } catch (error) {
-      // Failed to load settings from storage
-    }
+      } catch (error) {
+        // Failed to load settings from storage
+      }
     },
 
     saveToStorage: () => {
       try {
-        const settings = get()
-        localStorage.setItem(STORAGE_KEY, JSON.stringify(settings))
-          } catch (error) {
-      // Failed to save settings to storage
-    }
+        const settings = get();
+        localStorage.setItem(STORAGE_KEY, JSON.stringify(settings));
+      } catch (error) {
+        // Failed to save settings to storage
+      }
     },
 
     // API Key actions
@@ -103,75 +128,81 @@ export const useSettingsStore = create<SettingsStore>()(
         apiKeys: { ...state.apiKeys, [service]: key },
         apiKeyStatus: {
           ...state.apiKeyStatus,
-          [service]: { valid: false, lastChecked: undefined }
-        }
-      }))
+          [service]: { valid: false, lastChecked: undefined },
+        },
+      }));
     },
 
     validateAPIKey: async (service) => {
-      const state = get()
-      const apiKey = state.apiKeys[service]
-      
+      const state = get();
+      const apiKey = state.apiKeys[service];
+
       if (!apiKey) {
         set((state) => ({
           apiKeyStatus: {
             ...state.apiKeyStatus,
-            [service]: { valid: false, lastChecked: new Date() }
-          }
-        }))
-        return false
+            [service]: { valid: false, lastChecked: new Date() },
+          },
+        }));
+        return false;
       }
 
       try {
-        let isValid = false
-        
-        if (service === 'acoustid') {
+        let isValid = false;
+
+        if (service === "acoustid") {
           // Test AcoustID API
-          const response = await fetch(`https://api.acoustid.org/v2/lookup?client=${apiKey}&meta=recordings+releasegroups&fingerprint=test&duration=1`)
-          isValid = response.ok
-        } else if (service === 'musicbrainz') {
+          const response = await fetch(
+            `https://api.acoustid.org/v2/lookup?client=${apiKey}&meta=recordings+releasegroups&fingerprint=test&duration=1`,
+          );
+          isValid = response.ok;
+        } else if (service === "musicbrainz") {
           // Test MusicBrainz API (no API key required, but we can test the endpoint)
-          const response = await fetch('https://musicbrainz.org/ws/2/release/?query=artist:"test"&fmt=json&limit=1')
-          isValid = response.ok
+          const response = await fetch(
+            'https://musicbrainz.org/ws/2/release/?query=artist:"test"&fmt=json&limit=1',
+          );
+          isValid = response.ok;
         }
 
         set((state) => ({
           apiKeyStatus: {
             ...state.apiKeyStatus,
-            [service]: { valid: isValid, lastChecked: new Date() }
-          }
-        }))
+            [service]: { valid: isValid, lastChecked: new Date() },
+          },
+        }));
 
-        return isValid
+        return isValid;
       } catch (error) {
         set((state) => ({
           apiKeyStatus: {
             ...state.apiKeyStatus,
-            [service]: { valid: false, lastChecked: new Date() }
-          }
-        }))
-        return false
+            [service]: { valid: false, lastChecked: new Date() },
+          },
+        }));
+        return false;
       }
     },
 
     getAPIKeyStatus: () => {
-      return get().apiKeyStatus
+      return get().apiKeyStatus;
     },
 
     // Artwork settings actions
-    setEnableExternalArtwork: (enable) => set({ enableExternalArtwork: enable }),
+    setEnableExternalArtwork: (enable) =>
+      set({ enableExternalArtwork: enable }),
     setEnableAcoustID: (enable) => set({ enableAcoustID: enable }),
     setEnableMusicBrainz: (enable) => set({ enableMusicBrainz: enable }),
-    setEnablePlaceholderArtwork: (enable) => set({ enablePlaceholderArtwork: enable }),
-  }))
-)
+    setEnablePlaceholderArtwork: (enable) =>
+      set({ enablePlaceholderArtwork: enable }),
+  })),
+);
 
 // Auto-save settings when they change
 useSettingsStore.subscribe((state) => {
-  state.saveToStorage()
-})
+  state.saveToStorage();
+});
 
 // Load settings on initialization
-if (typeof window !== 'undefined') {
-  useSettingsStore.getState().loadFromStorage()
+if (typeof window !== "undefined") {
+  useSettingsStore.getState().loadFromStorage();
 }

--- a/web/apps/mfe-spectrogram/src/types/index.ts
+++ b/web/apps/mfe-spectrogram/src/types/index.ts
@@ -128,6 +128,16 @@ export interface SpectrogramSettings {
   colormap: string;
   showLegend: boolean;
   enableToastNotifications: boolean;
+  /**
+   * Optional override for the played portion of the seekbar.
+   * When empty, the active theme's accent color is used.
+   */
+  seekPlayedColor?: string;
+  /**
+   * Optional override for the unplayed portion of the seekbar.
+   * Falls back to the theme's primary color when unset.
+   */
+  seekUnplayedColor?: string;
   // API Keys
   apiKeys: APIKeys;
   apiKeyStatus: APIKeyStatus;


### PR DESCRIPTION
## Summary
- derive seekbar colors from theme and expose overrides in settings
- propagate theme/override updates via CSS vars
- validate seekbar color changes with new tests

## Testing
- `npm test` *(fails: unclosed delimiter in `tests/inverse_parallel.rs`)*
- `cd web/apps/mfe-spectrogram && npm test` *(fails: missing browser globals and modules)*

------
https://chatgpt.com/codex/tasks/task_e_68a5a6580d9c832b989aa6aa14c24ac3