### PR TITLE
Add WebAssembly seek bar computation and renderer

### DIFF
--- a/web-spectrogram/app.mjs
+++ b/web-spectrogram/app.mjs
@@ -1,3 +1,5 @@
+import { drawSeekBar } from "./seek_bar.mjs";
+
 export function ensureBuffer() {
   if (typeof globalThis.Buffer === "undefined") {
     globalThis.Buffer = class Buffer extends Uint8Array {
@@ -196,3 +198,5 @@ if (typeof window !== "undefined") {
   initApp();
 }
 /* c8 ignore stop */
+
+export { drawSeekBar };

--- a/web-spectrogram/seek_bar.mjs
+++ b/web-spectrogram/seek_bar.mjs
@@ -1,0 +1,92 @@
+// Render a seek bar using WebGL when available, falling back to Canvas2D.
+// Bars are 5px wide with 4px gaps and fully rounded ends.
+export function drawSeekBar(canvas, bars, progress, theme) {
+  const BAR_WIDTH = 5;
+  const GAP = 4;
+  const count = bars.length;
+  const gl = canvas.getContext('webgl2') || canvas.getContext('webgl');
+  const width = count * BAR_WIDTH + (count ? (count - 1) * GAP : 0);
+  canvas.width = width;
+  const height = canvas.height;
+
+  if (gl) {
+    gl.viewport(0, 0, width, height);
+    gl.clearColor(0, 0, 0, 0);
+    gl.clear(gl.COLOR_BUFFER_BIT);
+    const vs = gl.createShader(gl.VERTEX_SHADER);
+    gl.shaderSource(vs, `attribute vec2 p; void main(){gl_Position=vec4(p,0.0,1.0);}`);
+    gl.compileShader(vs);
+    const fs = gl.createShader(gl.FRAGMENT_SHADER);
+    gl.shaderSource(fs, `precision mediump float; uniform vec4 color; void main(){gl_FragColor=color;}`);
+    gl.compileShader(fs);
+    const program = gl.createProgram();
+    gl.attachShader(program, vs);
+    gl.attachShader(program, fs);
+    gl.linkProgram(program);
+    gl.useProgram(program);
+    const pos = gl.createBuffer();
+    gl.bindBuffer(gl.ARRAY_BUFFER, pos);
+    const loc = gl.getAttribLocation(program, 'p');
+    gl.enableVertexAttribArray(loc);
+    gl.vertexAttribPointer(loc, 2, gl.FLOAT, false, 0, 0);
+    const colorLoc = gl.getUniformLocation(program, 'color');
+
+    for (let i = 0; i < count; i++) {
+      const x = -1 + (2 * i * (BAR_WIDTH + GAP)) / width;
+      const w = (2 * BAR_WIDTH) / width;
+      const h = (2 * bars[i] * height) / height;
+      const y = -1 + (2 * (height - bars[i] * height)) / height;
+      const vertices = new Float32Array([
+        x, y + h,
+        x + w, y + h,
+        x, y,
+        x + w, y,
+      ]);
+      gl.bufferData(gl.ARRAY_BUFFER, vertices, gl.STREAM_DRAW);
+      const color = i < progress * count ? theme.accent : theme.primary;
+      const rgba = parseColor(color);
+      gl.uniform4f(colorLoc, rgba[0], rgba[1], rgba[2], rgba[3]);
+      gl.drawArrays(gl.TRIANGLE_STRIP, 0, 4);
+    }
+    return;
+  }
+
+  const ctx = canvas.getContext('2d');
+  ctx.clearRect(0, 0, width, height);
+  for (let i = 0; i < count; i++) {
+    const x = i * (BAR_WIDTH + GAP);
+    const h = bars[i] * height;
+    const y = height - h;
+    const color = i < progress * count ? theme.accent : theme.primary;
+    ctx.fillStyle = color;
+    drawRoundedRect(ctx, x, y, BAR_WIDTH, h, BAR_WIDTH / 2);
+  }
+}
+
+function drawRoundedRect(ctx, x, y, w, h, r) {
+  ctx.beginPath();
+  ctx.moveTo(x + r, y);
+  ctx.arcTo(x + w, y, x + w, y + h, r);
+  ctx.arcTo(x + w, y + h, x, y + h, r);
+  ctx.arcTo(x, y + h, x, y, r);
+  ctx.arcTo(x, y, x + w, y, r);
+  ctx.closePath();
+  ctx.fill();
+}
+
+function parseColor(css) {
+  const canvas = document.createElement('canvas');
+  const ctx = canvas.getContext('2d');
+  ctx.fillStyle = css;
+  const rgb = ctx.fillStyle.match(/^#(?:[0-9a-fA-F]{3}){1,2}$/) ? hexToRgb(ctx.fillStyle) : [0, 0, 0];
+  return [rgb[0] / 255, rgb[1] / 255, rgb[2] / 255, 1];
+}
+
+function hexToRgb(hex) {
+  let c = hex.substring(1);
+  if (c.length === 3) {
+    c = c.split('').map((x) => x + x).join('');
+  }
+  const num = parseInt(c, 16);
+  return [(num >> 16) & 255, (num >> 8) & 255, num & 255];
+}

--- a/web-spectrogram/src/lib.rs
+++ b/web-spectrogram/src/lib.rs
@@ -6,6 +6,9 @@ use kofft::window::hann;
 use kofft::{dct, wavelet};
 use wasm_bindgen::prelude::*;
 
+pub mod seek_bar;
+pub use seek_bar::{compute_seek_bar, SeekBar};
+
 const WIN_LEN: usize = 1024;
 const HOP: usize = WIN_LEN / 2;
 const FLOOR_DB: f32 = -80.0;
@@ -120,13 +123,7 @@ impl FftResult {
 
     #[wasm_bindgen(getter)]
     pub fn im(&self) -> Vec<f32> {
-    pub fn re(&self) -> Float32Array {
-        Float32Array::from(self.re.as_slice())
-    }
-
-    #[wasm_bindgen(getter)]
-    pub fn im(&self) -> Float32Array {
-        Float32Array::from(self.im.as_slice())
+        self.im.clone()
     }
 }
 
@@ -164,13 +161,7 @@ impl HaarResult {
 
     #[wasm_bindgen(getter)]
     pub fn diff(&self) -> Vec<f32> {
-    pub fn avg(&self) -> Array {
-        self.avg.iter().map(|&x| JsValue::from_f64(x as f64)).collect()
-    }
-
-    #[wasm_bindgen(getter)]
-    pub fn diff(&self) -> Array {
-        self.diff.iter().map(|&x| JsValue::from_f64(x as f64)).collect()
+        self.diff.clone()
     }
 }
 

--- a/web-spectrogram/src/seek_bar.rs
+++ b/web-spectrogram/src/seek_bar.rs
@@ -1,0 +1,117 @@
+use kofft::fft;
+use wasm_bindgen::prelude::*;
+
+/// Width of each bar in pixels.
+const BAR_WIDTH_PX: usize = 5;
+/// Gap between bars in pixels.
+const BAR_GAP_PX: usize = 4;
+
+/// Holds the normalized height of each seek bar.
+#[wasm_bindgen]
+#[derive(Clone)]
+pub struct SeekBar {
+    bars: Vec<f32>,
+}
+
+#[wasm_bindgen]
+impl SeekBar {
+    /// Returns the normalized heights (0.0 - 1.0) of all bars.
+    #[wasm_bindgen(getter)]
+    pub fn bars(&self) -> Vec<f32> {
+        self.bars.clone()
+    }
+
+    /// Number of bars in the seek bar.
+    #[wasm_bindgen(getter)]
+    pub fn count(&self) -> usize {
+        self.bars.len()
+    }
+}
+
+/// Compute number of bars that fit in the provided width.
+fn bar_count(width_px: f32) -> usize {
+    ((width_px as usize) + BAR_GAP_PX) / (BAR_WIDTH_PX + BAR_GAP_PX)
+}
+
+/// Compute the maximum FFT magnitude for the given sample segment.
+fn segment_amplitude(segment: &[f32]) -> f32 {
+    let mut re = segment.to_vec();
+    let mut im = vec![0.0; re.len()];
+    if fft::fft_split(&mut re, &mut im).is_err() {
+        return 0.0;
+    }
+    re.iter()
+        .zip(&im)
+        .map(|(r, i)| (r * r + i * i).sqrt())
+        .fold(0.0, f32::max)
+}
+
+/// Compute normalized bar heights for the seek bar.
+#[wasm_bindgen]
+pub fn compute_seek_bar(samples: &[f32], width_px: f32, scale: f32) -> SeekBar {
+    let count = bar_count(width_px);
+    if count == 0 {
+        return SeekBar { bars: Vec::new() };
+    }
+    let seg_len = (samples.len() + count - 1) / count;
+    let mut bars = Vec::with_capacity(count);
+    for i in 0..count {
+        let start = i * seg_len;
+        let end = usize::min(start + seg_len, samples.len());
+        let amp = if start < end {
+            segment_amplitude(&samples[start..end])
+        } else {
+            0.0
+        };
+        bars.push(amp);
+    }
+    if let Some(max) = bars
+        .iter()
+        .cloned()
+        .fold(None::<f32>, |a, b| Some(a.map_or(b, |m| m.max(b))))
+    {
+        if max > 0.0 {
+            for b in &mut bars {
+                *b = (*b / max).powf(scale);
+            }
+        }
+    }
+    SeekBar { bars }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    // Verify bar count formula and gap handling.
+    fn count_matches_width() {
+        assert_eq!(bar_count(0.0), 0);
+        assert_eq!(bar_count(13.0), 1); // width too small for two bars
+        assert_eq!(bar_count(14.0), 2); // exact fit for two bars
+    }
+
+    #[test]
+    // Ensure amplitude calculation spans entire sample slice and normalization.
+    fn amplitudes_cover_entire_track() {
+        let mut samples = vec![0.0f32; 8];
+        samples.extend(vec![1.0f32; 8]);
+        let res = compute_seek_bar(&samples, 14.0, 1.0);
+        let bars = res.bars();
+        assert_eq!(bars.len(), 2);
+        assert!(bars[0] < 1e-6);
+        assert!((bars[1] - 1.0).abs() < 1e-6);
+    }
+
+    #[test]
+    // Scaling parameter should exponentiate normalized values.
+    fn scaling_is_applied() {
+        let mut samples = vec![0.5f32; 8];
+        samples.extend(vec![1.0f32; 8]);
+        let res = compute_seek_bar(&samples, 14.0, 2.0);
+        let bars = res.bars();
+        assert_eq!(bars.len(), 2);
+        assert!((bars[0] - 0.25).abs() < 1e-6);
+        assert!((bars[1] - 1.0).abs() < 1e-6);
+    }
+}


### PR DESCRIPTION
## Summary
- expose new `compute_seek_bar` function backed by `kofft` FFT to derive normalized bar amplitudes
- re-export seek bar API and integrate draw helper in web example
- add WebGL/Canvas renderer for fixed-width seek bars

## Testing
- `cargo test`
- `cargo test -p web-spectrogram`
- `node --test web-spectrogram/tests/app.test.mjs` *(fails: Unexpected token 'const' in app.mjs)*

------
https://chatgpt.com/codex/tasks/task_e_68a5af0aabdc832b8ad2475ba1dea63f

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added a visual seek bar with rounded bars and progress-aware coloring.
  - Automatic rendering via WebGL with graceful Canvas fallback for broader compatibility.

- Refactor
  - Simplified WebAssembly bindings to return native arrays, reducing overhead and potentially changing integration expectations.

- Chores
  - Exposed the seek bar renderer through the public API for easier use in apps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->