### PR TITLE
Ensure web input validation errors surface to users

### DIFF
--- a/web/apps/mfe-spectrogram/src/components/layout/SettingsPanel.tsx
+++ b/web/apps/mfe-spectrogram/src/components/layout/SettingsPanel.tsx
@@ -23,7 +23,7 @@ import {
 } from "@/types";
 import { THEME_COLORS } from "@/shared/theme";
 import { cn } from "@/utils/cn";
-import { directToast } from "@/utils/toast";
+import { conditionalToast, directToast } from "@/utils/toast";
 import { MetadataStorePanel } from "./MetadataStorePanel";
 import { StatisticsPanel } from "./StatisticsPanel";
 
@@ -97,6 +97,11 @@ export function SettingsPanel({
     });
   };
 
+  /**
+   * Validate a user-supplied API key.
+   * Fetches the validation function lazily from the settings store and
+   * surfaces any errors instead of failing silently.
+   */
   const validateAPIKey = async (service: "acoustid" | "musicbrainz") => {
     setValidatingKeys((prev) => ({ ...prev, [service]: true }));
 
@@ -115,7 +120,10 @@ export function SettingsPanel({
         });
       }
     } catch (error) {
-      // Silently handle API key validation error
+      console.error("API key validation failed", error);
+      conditionalToast.error(
+        "API key validation failed. Please verify the key and network connection.",
+      );
     } finally {
       setValidatingKeys((prev) => ({ ...prev, [service]: false }));
     }
@@ -321,7 +329,9 @@ export function SettingsPanel({
                 </h4>
                 {/* Mode selection */}
                 <div className="mb-3">
-                  <span className="block text-xs text-neutral-400 mb-1">Mode</span>
+                  <span className="block text-xs text-neutral-400 mb-1">
+                    Mode
+                  </span>
                   <div className="flex flex-col gap-1">
                     {[
                       { value: "live", label: "Live" },

--- a/web/apps/mfe-spectrogram/src/hooks/__tests__/useMicrophone.test.ts
+++ b/web/apps/mfe-spectrogram/src/hooks/__tests__/useMicrophone.test.ts
@@ -1,70 +1,122 @@
-import { describe, it, expect, vi, act } from 'vitest'
-import { renderHook } from '@testing-library/react'
-import { useMicrophone } from '../useMicrophone'
+import { describe, it, expect, vi, act } from "vitest";
+import { renderHook } from "@testing-library/react";
+import { useMicrophone } from "../useMicrophone";
 
-vi.mock('@/stores/audioStore', () => ({
+vi.mock("@/stores/audioStore", () => ({
   useAudioStore: () => ({
     setMicrophoneActive: vi.fn(),
     setLive: vi.fn(),
-    setCurrentTrack: vi.fn()
-  })
-}))
+    setCurrentTrack: vi.fn(),
+  }),
+}));
 
-const startMicrophoneMock = vi.fn().mockResolvedValue(true)
-const stopMicrophoneMock = vi.fn().mockReturnValue(true)
+const startMicrophoneMock = vi.fn().mockResolvedValue(true);
+const stopMicrophoneMock = vi.fn().mockReturnValue(true);
 
-vi.mock('@/utils/audioPlayer', () => ({
+vi.mock("@/utils/audioPlayer", () => ({
   audioPlayer: {
     initAudioContext: vi.fn().mockResolvedValue({}),
     startMicrophone: startMicrophoneMock,
     stopMicrophone: stopMicrophoneMock,
     getFrequencyData: vi.fn(),
     getTimeData: vi.fn(),
-    onTrackEnd: vi.fn()
-  }
-}))
+    onTrackEnd: vi.fn(),
+  },
+}));
 
-vi.mock('@/utils/toast', () => ({
+const toastSuccess = vi.fn();
+const toastError = vi.fn();
+
+vi.mock("@/utils/toast", () => ({
   conditionalToast: {
-    success: vi.fn(),
-    error: vi.fn()
-  }
-}))
+    success: toastSuccess,
+    error: toastError,
+  },
+}));
 
-describe('useMicrophone', () => {
-  it('stops tracks when stopping microphone', async () => {
-    const trackStop = vi.fn()
-    const mockStream: any = { getTracks: () => [{ stop: trackStop }] }
-    ;(global as any).navigator = {
+describe("useMicrophone", () => {
+  it("stops tracks when stopping microphone", async () => {
+    const trackStop = vi.fn();
+    const mockStream: any = { getTracks: () => [{ stop: trackStop }] };
+    (global as any).navigator = {
       mediaDevices: {
         getUserMedia: vi.fn().mockResolvedValue(mockStream),
-        enumerateDevices: vi.fn().mockResolvedValue([])
-      }
-    }
+        enumerateDevices: vi.fn().mockResolvedValue([]),
+      },
+    };
 
-    const { result } = renderHook(() => useMicrophone())
-    await act(async () => { await result.current.startMicrophone() })
-    act(() => { result.current.stopMicrophone() })
-    expect(trackStop).toHaveBeenCalled()
-  })
+    const { result } = renderHook(() => useMicrophone());
+    await act(async () => {
+      await result.current.startMicrophone();
+    });
+    act(() => {
+      result.current.stopMicrophone();
+    });
+    expect(trackStop).toHaveBeenCalled();
+  });
 
-  it('clears previous stream when starting again', async () => {
-    const trackStop1 = vi.fn()
-    const stream1: any = { getTracks: () => [{ stop: trackStop1 }] }
-    const trackStop2 = vi.fn()
-    const stream2: any = { getTracks: () => [{ stop: trackStop2 }] }
-    ;(global as any).navigator = {
+  it("clears previous stream when starting again", async () => {
+    const trackStop1 = vi.fn();
+    const stream1: any = { getTracks: () => [{ stop: trackStop1 }] };
+    const trackStop2 = vi.fn();
+    const stream2: any = { getTracks: () => [{ stop: trackStop2 }] };
+    (global as any).navigator = {
       mediaDevices: {
-        getUserMedia: vi.fn()
+        getUserMedia: vi
+          .fn()
           .mockResolvedValueOnce(stream1)
           .mockResolvedValueOnce(stream2),
-        enumerateDevices: vi.fn().mockResolvedValue([])
-      }
-    }
+        enumerateDevices: vi.fn().mockResolvedValue([]),
+      },
+    };
 
-    const { result } = renderHook(() => useMicrophone())
-    await act(async () => { await result.current.startMicrophone() })
-    await act(async () => { await result.current.startMicrophone() })
-    expect(trackStop1).toHaveBeenCalled()
-  })
-})
+    const { result } = renderHook(() => useMicrophone());
+    await act(async () => {
+      await result.current.startMicrophone();
+    });
+    await act(async () => {
+      await result.current.startMicrophone();
+    });
+    expect(trackStop1).toHaveBeenCalled();
+  });
+
+  it("reports failure when starting microphone fails", async () => {
+    const mockStream: any = { getTracks: () => [{ stop: vi.fn() }] };
+    (global as any).navigator = {
+      mediaDevices: {
+        getUserMedia: vi.fn().mockResolvedValue(mockStream),
+        enumerateDevices: vi.fn().mockResolvedValue([]),
+      },
+    };
+
+    startMicrophoneMock.mockResolvedValueOnce(false);
+
+    const { result } = renderHook(() => useMicrophone());
+    const ok = await result.current.startMicrophone();
+    expect(ok).toBe(false);
+    expect(toastError).toHaveBeenCalledWith("Failed to start microphone");
+  });
+
+  it("reports failure when stopping microphone fails", () => {
+    stopMicrophoneMock.mockReturnValueOnce(false);
+    const { result } = renderHook(() => useMicrophone());
+    const ok = result.current.stopMicrophone();
+    expect(ok).toBe(false);
+    expect(toastError).toHaveBeenCalledWith("Failed to stop microphone");
+  });
+
+  it("reports failure when enumerating devices fails", async () => {
+    (global as any).navigator = {
+      mediaDevices: {
+        enumerateDevices: vi.fn().mockRejectedValue(new Error("fail")),
+      },
+    };
+
+    const { result } = renderHook(() => useMicrophone());
+    const devices = await result.current.getInputDevices();
+    expect(devices).toEqual([]);
+    expect(toastError).toHaveBeenCalledWith(
+      "Failed to enumerate input devices",
+    );
+  });
+});

--- a/web/apps/mfe-spectrogram/src/hooks/useMicrophone.ts
+++ b/web/apps/mfe-spectrogram/src/hooks/useMicrophone.ts
@@ -101,7 +101,7 @@ export const useMicrophone = () => {
         error instanceof Error ? error.message : "Failed to start microphone";
       console.error("Microphone start failed", error);
       conditionalToast.error(message);
-      return false;
+      return handleMicrophoneError(error, "start", "Failed to start microphone");
     }
   }, [
     initAudioContext,

--- a/web/apps/mfe-spectrogram/src/hooks/useMicrophone.ts
+++ b/web/apps/mfe-spectrogram/src/hooks/useMicrophone.ts
@@ -1,38 +1,38 @@
-import { useState, useCallback, useRef, useEffect } from 'react'
-import { useAudioStore } from '@/stores/audioStore'
-import { audioPlayer } from '@/utils/audioPlayer'
-import { conditionalToast } from '@/utils/toast'
+import { useState, useCallback, useRef, useEffect } from "react";
+import { useAudioStore } from "@/stores/audioStore";
+import { audioPlayer } from "@/utils/audioPlayer";
+import { conditionalToast } from "@/utils/toast";
 
 export const useMicrophone = () => {
-  const [isInitialized, setIsInitialized] = useState(false)
-  const [isRequestingPermission, setIsRequestingPermission] = useState(false)
-  const [error, setError] = useState<string | null>(null)
-  
-  const mediaStreamRef = useRef<MediaStream | null>(null)
-  const animationFrameRef = useRef<number | null>(null)
-  
-  const { setMicrophoneActive, setLive, setCurrentTrack } = useAudioStore()
+  const [isInitialized, setIsInitialized] = useState(false);
+  const [isRequestingPermission, setIsRequestingPermission] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const mediaStreamRef = useRef<MediaStream | null>(null);
+  const animationFrameRef = useRef<number | null>(null);
+
+  const { setMicrophoneActive, setLive, setCurrentTrack } = useAudioStore();
 
   // Initialize audio context using the shared one
   const initAudioContext = useCallback(async () => {
     try {
-      const context = await audioPlayer.initAudioContext()
-      setIsInitialized(true)
-      return context
+      const context = await audioPlayer.initAudioContext();
+      setIsInitialized(true);
+      return context;
     } catch (error) {
-      throw new Error('Audio context initialization failed')
+      throw new Error("Audio context initialization failed");
     }
-  }, [])
+  }, []);
 
   // Request microphone permission
   const requestPermission = useCallback(async () => {
-    setIsRequestingPermission(true)
-    setError(null)
+    setIsRequestingPermission(true);
+    setError(null);
 
     try {
       // Check if getUserMedia is supported
       if (!navigator.mediaDevices || !navigator.mediaDevices.getUserMedia) {
-        throw new Error('Microphone access not supported in this browser')
+        throw new Error("Microphone access not supported in this browser");
       }
 
       // Request microphone access
@@ -41,203 +41,226 @@ export const useMicrophone = () => {
           echoCancellation: true,
           noiseSuppression: true,
           autoGainControl: true,
-          sampleRate: 44100
-        }
-      })
+          sampleRate: 44100,
+        },
+      });
 
-      mediaStreamRef.current = stream
-      setIsRequestingPermission(false)
-      return stream
-
+      mediaStreamRef.current = stream;
+      setIsRequestingPermission(false);
+      return stream;
     } catch (error) {
-      setIsRequestingPermission(false)
-      const errorMessage = error instanceof Error ? error.message : 'Failed to access microphone'
-      setError(errorMessage)
-      
-      if (error instanceof Error && error.name === 'NotAllowedError') {
-        conditionalToast.error('Microphone permission denied. Please allow microphone access.')
+      setIsRequestingPermission(false);
+      const errorMessage =
+        error instanceof Error ? error.message : "Failed to access microphone";
+      setError(errorMessage);
+
+      if (error instanceof Error && error.name === "NotAllowedError") {
+        conditionalToast.error(
+          "Microphone permission denied. Please allow microphone access.",
+        );
       } else {
-        conditionalToast.error(errorMessage)
+        conditionalToast.error(errorMessage);
       }
-      
-      throw error
+
+      throw error;
     }
-  }, [])
+  }, []);
 
   // Start microphone input
   const startMicrophone = useCallback(async () => {
     try {
       // Initialize audio context if needed
-      await initAudioContext()
+      await initAudioContext();
 
       // Stop any existing stream
       if (mediaStreamRef.current) {
-        mediaStreamRef.current.getTracks().forEach(t => t.stop())
-        mediaStreamRef.current = null
+        mediaStreamRef.current.getTracks().forEach((t) => t.stop());
+        mediaStreamRef.current = null;
       }
 
       // Request permission and get stream
-      const stream = await requestPermission()
+      const stream = await requestPermission();
 
       // Use the shared audio player to start microphone
-      const success = await audioPlayer.startMicrophone(stream)
-      
+      const success = await audioPlayer.startMicrophone(stream);
+
       if (success) {
         // Set up live mode
-        setMicrophoneActive(true)
-        setLive(true)
-        setCurrentTrack(null) // Clear any file track
+        setMicrophoneActive(true);
+        setLive(true);
+        setCurrentTrack(null); // Clear any file track
 
-        conditionalToast.success('Microphone activated')
-        return true
+        conditionalToast.success("Microphone activated");
+        return true;
       } else {
-        throw new Error('Failed to start microphone')
+        throw new Error("Failed to start microphone");
       }
-
     } catch (error) {
-      return false
+      // Human-readable explanation of the start failure.
+      const message =
+        error instanceof Error ? error.message : "Failed to start microphone";
+      console.error("Microphone start failed", error);
+      conditionalToast.error(message);
+      return false;
     }
-  }, [initAudioContext, requestPermission, setMicrophoneActive, setLive, setCurrentTrack])
+  }, [
+    initAudioContext,
+    requestPermission,
+    setMicrophoneActive,
+    setLive,
+    setCurrentTrack,
+  ]);
 
   // Stop microphone input
   const stopMicrophone = useCallback(() => {
     try {
       // Use the shared audio player to stop microphone
-      const success = audioPlayer.stopMicrophone()
+      const success = audioPlayer.stopMicrophone();
 
       if (success) {
-        mediaStreamRef.current?.getTracks().forEach(t => t.stop())
-        mediaStreamRef.current = null
+        mediaStreamRef.current?.getTracks().forEach((t) => t.stop());
+        mediaStreamRef.current = null;
         // Update state
-        setMicrophoneActive(false)
-        setLive(false)
+        setMicrophoneActive(false);
+        setLive(false);
 
-        conditionalToast.success('Microphone deactivated')
-        return true
+        conditionalToast.success("Microphone deactivated");
+        return true;
       } else {
-        throw new Error('Failed to stop microphone')
+        throw new Error("Failed to stop microphone");
       }
-
     } catch (error) {
-      return false
+      // Human-readable explanation of the stop failure.
+      const message =
+        error instanceof Error ? error.message : "Failed to stop microphone";
+      console.error("Microphone stop failed", error);
+      conditionalToast.error(message);
+      return false;
     }
-  }, [setMicrophoneActive, setLive])
+  }, [setMicrophoneActive, setLive]);
 
   // Toggle microphone
   const toggleMicrophone = useCallback(async () => {
-    const { isMicrophoneActive } = useAudioStore.getState()
-    
+    const { isMicrophoneActive } = useAudioStore.getState();
+
     if (isMicrophoneActive) {
-      return stopMicrophone()
+      return stopMicrophone();
     } else {
-      return startMicrophone()
+      return startMicrophone();
     }
-  }, [startMicrophone, stopMicrophone])
+  }, [startMicrophone, stopMicrophone]);
 
   // Get available input devices
   const getInputDevices = useCallback(async (): Promise<MediaDeviceInfo[]> => {
     try {
-      const devices = await navigator.mediaDevices.enumerateDevices()
-      return devices.filter(device => device.kind === 'audioinput')
+      const devices = await navigator.mediaDevices.enumerateDevices();
+      return devices.filter((device) => device.kind === "audioinput");
     } catch (error) {
-      return []
+      console.error("Failed to enumerate input devices", error);
+      conditionalToast.error("Failed to enumerate input devices");
+      return [];
     }
-  }, [])
+  }, []);
 
   // Switch to specific input device
-  const switchInputDevice = useCallback(async (deviceId: string) => {
-    try {
-      // Stop current microphone
-      await stopMicrophone()
+  const switchInputDevice = useCallback(
+    async (deviceId: string) => {
+      try {
+        // Stop current microphone
+        await stopMicrophone();
 
-      // Request new stream with specific device
-      const stream = await navigator.mediaDevices.getUserMedia({
-        audio: {
-          deviceId: { exact: deviceId },
-          echoCancellation: true,
-          noiseSuppression: true,
-          autoGainControl: true,
-          sampleRate: 44100
+        // Request new stream with specific device
+        const stream = await navigator.mediaDevices.getUserMedia({
+          audio: {
+            deviceId: { exact: deviceId },
+            echoCancellation: true,
+            noiseSuppression: true,
+            autoGainControl: true,
+            sampleRate: 44100,
+          },
+        });
+
+        // Start microphone with new stream
+        const success = await audioPlayer.startMicrophone(stream);
+
+        if (success) {
+          conditionalToast.success("Input device switched");
+          return true;
+        } else {
+          throw new Error("Failed to switch input device");
         }
-      })
-
-      // Start microphone with new stream
-      const success = await audioPlayer.startMicrophone(stream)
-      
-      if (success) {
-        conditionalToast.success('Input device switched')
-        return true
-      } else {
-        throw new Error('Failed to switch input device')
+      } catch (error) {
+        conditionalToast.error("Failed to switch input device");
+        return false;
       }
-
-    } catch (error) {
-      conditionalToast.error('Failed to switch input device')
-      return false
-    }
-  }, [stopMicrophone])
+    },
+    [stopMicrophone],
+  );
 
   // Get frequency data for spectrogram (from shared audio player)
   const getFrequencyData = useCallback(() => {
-    return audioPlayer.getFrequencyData()
-  }, [])
+    return audioPlayer.getFrequencyData();
+  }, []);
 
   // Get time domain data (from shared audio player)
   const getTimeData = useCallback(() => {
-    return audioPlayer.getTimeData()
-  }, [])
+    return audioPlayer.getTimeData();
+  }, []);
 
   // Start real-time analysis loop
-  const startAnalysis = useCallback((onData: (frequencyData: Uint8Array, timeData: Uint8Array) => void) => {
-    const analyse = () => {
-      const frequencyData = getFrequencyData()
-      const timeData = getTimeData()
-      
-      if (frequencyData && timeData) {
-        onData(frequencyData, timeData)
-      }
-      
-      animationFrameRef.current = requestAnimationFrame(analyse)
-    }
+  const startAnalysis = useCallback(
+    (onData: (frequencyData: Uint8Array, timeData: Uint8Array) => void) => {
+      const analyse = () => {
+        const frequencyData = getFrequencyData();
+        const timeData = getTimeData();
 
-    analyse()
-  }, [getFrequencyData, getTimeData])
+        if (frequencyData && timeData) {
+          onData(frequencyData, timeData);
+        }
+
+        animationFrameRef.current = requestAnimationFrame(analyse);
+      };
+
+      analyse();
+    },
+    [getFrequencyData, getTimeData],
+  );
 
   // Stop analysis loop
   const stopAnalysis = useCallback(() => {
     if (animationFrameRef.current) {
-      cancelAnimationFrame(animationFrameRef.current)
-      animationFrameRef.current = null
+      cancelAnimationFrame(animationFrameRef.current);
+      animationFrameRef.current = null;
     }
-  }, [])
+  }, []);
 
   // Get input level
   const getInputLevel = useCallback(() => {
-    const timeData = getTimeData()
-    if (!timeData) return 0
+    const timeData = getTimeData();
+    if (!timeData) return 0;
 
     // Calculate RMS (Root Mean Square) of the audio data
-    let sum = 0
+    let sum = 0;
     for (let i = 0; i < timeData.length; i++) {
-      const sample = (timeData[i] - 128) / 128 // Convert to -1 to 1 range
-      sum += sample * sample
+      const sample = (timeData[i] - 128) / 128; // Convert to -1 to 1 range
+      sum += sample * sample;
     }
-    const rms = Math.sqrt(sum / timeData.length)
-    
+    const rms = Math.sqrt(sum / timeData.length);
+
     // Convert to dB
-    const db = 20 * Math.log10(Math.max(rms, 1e-10))
-    
+    const db = 20 * Math.log10(Math.max(rms, 1e-10));
+
     // Normalize to 0-1 range (assuming -60dB to 0dB range)
-    return Math.max(0, Math.min(1, (db + 60) / 60))
-  }, [getTimeData])
+    return Math.max(0, Math.min(1, (db + 60) / 60));
+  }, [getTimeData]);
 
   // Cleanup on unmount
   useEffect(() => {
     return () => {
-      stopAnalysis()
-      stopMicrophone()
-    }
-  }, [stopMicrophone, stopAnalysis])
+      stopAnalysis();
+      stopMicrophone();
+    };
+  }, [stopMicrophone, stopAnalysis]);
 
   return {
     isInitialized,
@@ -253,6 +276,6 @@ export const useMicrophone = () => {
     startAnalysis,
     stopAnalysis,
     getInputLevel,
-    initAudioContext
-  }
-}
+    initAudioContext,
+  };
+};


### PR DESCRIPTION
## Summary
- surface API key validation errors via toast instead of failing silently
- report microphone start/stop and device enumeration failures with clear errors
- cover new error paths with additional tests

## Testing
- `npm test` *(fails: ReferenceError: requestAnimationFrame is not defined, many modules missing)*
- `npm run lint` *(fails: Missing script: "lint" )*
- `npm test` *(fails: this file contains an unclosed delimiter)*

------
https://chatgpt.com/codex/tasks/task_e_68a5c10131a4832b8dd62f958cc75013