### PR TITLE
fix: distinguish meta and control shortcuts

### DIFF
--- a/web/apps/mfe-spectrogram/src/utils/__tests__/keyboard.test.ts
+++ b/web/apps/mfe-spectrogram/src/utils/__tests__/keyboard.test.ts
@@ -1,9 +1,12 @@
 import { describe, it, expect } from 'vitest'
-import { 
-  parseKeyCombo, 
-  isKeyComboPressed, 
+import {
+  parseKeyCombo,
+  isKeyComboPressed,
   getShortcutDisplay,
-  DEFAULT_SHORTCUTS 
+  DEFAULT_SHORTCUTS,
+  saveShortcuts,
+  loadShortcuts,
+  SHORTCUTS_STORAGE_KEY,
 } from '../keyboard'
 
 describe('Keyboard Utils', () => {
@@ -20,6 +23,11 @@ describe('Keyboard Utils', () => {
 
     it('handles whitespace', () => {
       expect(parseKeyCombo(' Control + Shift + S ')).toEqual(['control', 'shift', 's'])
+    })
+
+    it('normalizes meta key aliases', () => {
+      expect(parseKeyCombo('Cmd+S')).toEqual(['meta', 's'])
+      expect(parseKeyCombo('Command+S')).toEqual(['meta', 's'])
     })
   })
 
@@ -46,6 +54,12 @@ describe('Keyboard Utils', () => {
       const event = new KeyboardEvent('keydown', { key: 'S' })
       expect(isKeyComboPressed(event, 's')).toBe(true)
       expect(isKeyComboPressed(event, 'S')).toBe(true)
+    })
+
+    it('distinguishes control and meta keys', () => {
+      const metaEvent = new KeyboardEvent('keydown', { key: 's', metaKey: true })
+      expect(isKeyComboPressed(metaEvent, 'meta+s')).toBe(true)
+      expect(isKeyComboPressed(metaEvent, 'control+s')).toBe(false)
     })
   })
 
@@ -78,6 +92,17 @@ describe('Keyboard Utils', () => {
       expect(DEFAULT_SHORTCUTS.volumeDown).toBe('ArrowDown')
       expect(DEFAULT_SHORTCUTS.mute).toBe('m')
       expect(DEFAULT_SHORTCUTS.help).toBe('?')
+    })
+  })
+
+  describe('storage helpers', () => {
+    it('saves and loads shortcuts using a constant key', () => {
+      const custom = { ...DEFAULT_SHORTCUTS, playPause: 'k' }
+      saveShortcuts(custom)
+      const stored = localStorage.getItem(SHORTCUTS_STORAGE_KEY)
+      expect(stored).not.toBeNull()
+      const loaded = loadShortcuts()
+      expect(loaded.playPause).toBe('k')
     })
   })
 })

--- a/web/apps/mfe-spectrogram/src/utils/keyboard.ts
+++ b/web/apps/mfe-spectrogram/src/utils/keyboard.ts
@@ -107,7 +107,22 @@ export function getShortcutDisplay(combo: string): string {
   return combo
     .split('+')
     .map(key => key.charAt(0).toUpperCase() + key.slice(1))
-    .join(' + ')
+  // Map normalized key names to display names
+  const isMac = typeof navigator !== 'undefined' && /Mac|iPod|iPhone|iPad/.test(navigator.platform);
+  const keyDisplayMap: Record<string, string> = {
+    meta: isMac ? 'Cmd' : 'Meta',
+    control: 'Ctrl',
+    shift: 'Shift',
+    alt: isMac ? 'Option' : 'Alt',
+    // Add more mappings as needed
+  };
+  return combo
+    .split('+')
+    .map(key => {
+      const lower = key.trim().toLowerCase();
+      return keyDisplayMap[lower] || (key.charAt(0).toUpperCase() + key.slice(1));
+    })
+    .join(' + ');
 }
 
 /**

--- a/web/apps/mfe-spectrogram/src/utils/keyboard.ts
+++ b/web/apps/mfe-spectrogram/src/utils/keyboard.ts
@@ -1,5 +1,14 @@
 import { KeyboardShortcuts } from '@/types'
 
+/**
+ * LocalStorage key for persisting user-defined keyboard shortcuts.
+ */
+export const SHORTCUTS_STORAGE_KEY = 'spectrogram-shortcuts'
+
+/**
+ * Default key bindings for the spectrogram application.
+ * Each property maps an action to the key combination that triggers it.
+ */
 export const DEFAULT_SHORTCUTS: KeyboardShortcuts = {
   playPause: ' ',
   seekBackward: 'ArrowLeft',
@@ -18,35 +27,65 @@ export const DEFAULT_SHORTCUTS: KeyboardShortcuts = {
   help: '?',
 }
 
+/**
+ * Breaks a combination string like "Control+S" into normalized key names.
+ * Common aliases for the meta key (Cmd, Command) are converted to "meta".
+ * @param combo Combination string to parse.
+ * @returns Array of normalized key names.
+ */
 export function parseKeyCombo(combo: string): string[] {
-  return combo.toLowerCase().split('+').map(key => key.trim())
+  return combo
+    .toLowerCase()
+    .split('+')
+    .map(key => {
+      const trimmed = key.trim()
+      return trimmed === 'cmd' || trimmed === 'command' ? 'meta' : trimmed
+    })
 }
 
+/**
+ * Determines whether a keyboard event matches the provided key combination.
+ * Additional modifier keys beyond those specified in the combo are ignored.
+ * @param event Keyboard event to inspect.
+ * @param combo Key combination such as "Control+S".
+ */
 export function isKeyComboPressed(event: KeyboardEvent, combo: string): boolean {
   const keys = parseKeyCombo(combo)
   const pressedKeys = new Set<string>()
-  
+
   // Add modifier keys
-  if (event.ctrlKey || event.metaKey) pressedKeys.add('control')
+  if (event.ctrlKey) pressedKeys.add('control')
+  if (event.metaKey) pressedKeys.add('meta')
   if (event.shiftKey) pressedKeys.add('shift')
   if (event.altKey) pressedKeys.add('alt')
-  
+
   // Add the main key
   pressedKeys.add(event.key.toLowerCase())
-  
+
   // Check if all required keys are pressed
   return keys.every(key => pressedKeys.has(key))
 }
 
-export function createKeyboardHandler(shortcuts: KeyboardShortcuts, handlers: Record<string, () => void>) {
+/**
+ * Creates a handler that invokes callbacks when configured shortcuts are pressed.
+ * Events originating from text input elements are ignored to avoid interference.
+ * @param shortcuts Mapping of actions to key combinations.
+ * @param handlers Mapping of actions to functions that handle the shortcut.
+ */
+export function createKeyboardHandler(
+  shortcuts: KeyboardShortcuts,
+  handlers: Record<string, () => void>
+) {
   return (event: KeyboardEvent) => {
     // Don't handle shortcuts when typing in input fields
-    if (event.target instanceof HTMLInputElement || 
-        event.target instanceof HTMLTextAreaElement ||
-        event.target instanceof HTMLSelectElement) {
+    if (
+      event.target instanceof HTMLInputElement ||
+      event.target instanceof HTMLTextAreaElement ||
+      event.target instanceof HTMLSelectElement
+    ) {
       return
     }
-    
+
     // Check each shortcut
     Object.entries(shortcuts).forEach(([action, combo]) => {
       if (isKeyComboPressed(event, combo)) {
@@ -60,6 +99,10 @@ export function createKeyboardHandler(shortcuts: KeyboardShortcuts, handlers: Re
   }
 }
 
+/**
+ * Formats a key combination for display by capitalizing each key name.
+ * @param combo Combination string to format.
+ */
 export function getShortcutDisplay(combo: string): string {
   return combo
     .split('+')
@@ -67,22 +110,32 @@ export function getShortcutDisplay(combo: string): string {
     .join(' + ')
 }
 
+/**
+ * Persists keyboard shortcut mappings to LocalStorage.
+ * Logs failures for easier debugging.
+ * @param shortcuts Shortcut mapping to store.
+ */
 export function saveShortcuts(shortcuts: KeyboardShortcuts): void {
   try {
-    localStorage.setItem('spectrogram-shortcuts', JSON.stringify(shortcuts))
-      } catch (error) {
-      // Failed to save shortcuts
-    }
+    localStorage.setItem(SHORTCUTS_STORAGE_KEY, JSON.stringify(shortcuts))
+  } catch (error) {
+    console.error('Failed to save shortcuts', error)
+  }
 }
 
+/**
+ * Retrieves shortcut mappings from LocalStorage, falling back to defaults.
+ * Logs failures for diagnostic purposes.
+ * @returns Merged shortcut mapping.
+ */
 export function loadShortcuts(): KeyboardShortcuts {
   try {
-    const stored = localStorage.getItem('spectrogram-shortcuts')
+    const stored = localStorage.getItem(SHORTCUTS_STORAGE_KEY)
     if (stored) {
       return { ...DEFAULT_SHORTCUTS, ...JSON.parse(stored) }
     }
   } catch (error) {
-    // Failed to load shortcuts
+    console.error('Failed to load shortcuts', error)
   }
   return DEFAULT_SHORTCUTS
 }


### PR DESCRIPTION
## Summary
- ensure meta key no longer triggers control shortcuts
- normalize Cmd/Command aliases to meta and centralize localStorage key
- document keyboard utils and expand tests for persistence and meta handling

## Testing
- `npx vitest run src/utils/__tests__/keyboard.test.ts --environment jsdom --coverage`
- `cargo test` *(fails: unclosed delimiter in tests/inverse_parallel.rs:141:31)*

------
https://chatgpt.com/codex/tasks/task_e_68a5d1154240832b9ec3974926ea4e9c