### PR TITLE
feat: add themed palettes and centralize color usage

### DIFF
--- a/web/apps/mfe-spectrogram/src/app/App.tsx
+++ b/web/apps/mfe-spectrogram/src/app/App.tsx
@@ -1,18 +1,19 @@
-import React, { useEffect } from 'react'
-import { Header } from '../layout/Header'
-import { Footer } from '../layout/Footer'
-import { SpectrogramView } from '../features/spectrogram/SpectrogramView'
-import { MetadataPanel } from '../features/metadata/MetadataPanel'
-import { PlaylistPanel } from '../features/playlist/PlaylistPanel'
-import { SettingsPanel } from '../features/settings/SettingsPanel'
-import { ShortcutsModal } from '../features/shortcuts/ShortcutsModal'
-import { useUIStore } from '../shared/stores/uiStore'
-import { useSettingsStore } from '../shared/stores/settingsStore'
-import { useAudioStore } from '../shared/stores/audioStore'
-import { Toaster } from 'react-hot-toast'
+import React, { useEffect } from "react";
+import { Header } from "../layout/Header";
+import { Footer } from "../layout/Footer";
+import { SpectrogramView } from "../features/spectrogram/SpectrogramView";
+import { MetadataPanel } from "../features/metadata/MetadataPanel";
+import { PlaylistPanel } from "../features/playlist/PlaylistPanel";
+import { SettingsPanel } from "../features/settings/SettingsPanel";
+import { ShortcutsModal } from "../features/shortcuts/ShortcutsModal";
+import { useUIStore } from "../shared/stores/uiStore";
+import { useSettingsStore } from "../shared/stores/settingsStore";
+import { useAudioStore } from "../shared/stores/audioStore";
+import { THEME_COLORS } from "@/shared/theme";
+import { Toaster } from "react-hot-toast";
 
 export function App() {
-  const { theme, updateSettings, loadFromStorage } = useSettingsStore()
+  const { theme, updateSettings, loadFromStorage } = useSettingsStore();
   const {
     isMobile,
     isTablet,
@@ -24,7 +25,7 @@ export function App() {
     setSettingsPanelOpen,
     shortcutsHelpOpen,
     setShortcutsHelpOpen,
-  } = useUIStore()
+  } = useUIStore();
 
   const {
     currentTrack,
@@ -33,32 +34,38 @@ export function App() {
     playTrack,
     removeFromPlaylist,
     reorderPlaylist,
-  } = useAudioStore()
+  } = useAudioStore();
 
   useEffect(() => {
-    loadFromStorage()
-  }, [loadFromStorage])
+    loadFromStorage();
+  }, [loadFromStorage]);
 
   useEffect(() => {
-    const className = `theme-${theme}`
-    const bodyClassList = document.body.classList
-    bodyClassList.remove('theme-dark', 'theme-light')
-    bodyClassList.add(className)
-    const metaThemeColor = document.querySelector('meta[name="theme-color"]')
+    const className = `theme-${theme}`;
+    const bodyClassList = document.body.classList;
+    // Remove any previously applied theme- classes to avoid clashes when
+    // switching themes at runtime.
+    bodyClassList.remove(...Object.keys(THEME_COLORS).map((t) => `theme-${t}`));
+    bodyClassList.add(className);
+    // Keep the browser's address bar and surrounding UI in sync with the
+    // active theme background colour for a polished look on mobile.
+    const metaThemeColor = document.querySelector('meta[name="theme-color"]');
     if (metaThemeColor) {
-      metaThemeColor.setAttribute('content', theme === 'dark' ? '#0a0a0a' : '#ffffff')
+      metaThemeColor.setAttribute("content", THEME_COLORS[theme].background);
     }
     return () => {
-      bodyClassList.remove(className)
-    }
-  }, [theme])
+      bodyClassList.remove(className);
+    };
+  }, [theme]);
 
   return (
     <div className="app-layout bg-neutral-950 text-neutral-100 min-h-screen">
       <Header />
       <div className="main-content flex-1 flex relative overflow-hidden">
         {!isMobile && (
-          <div className={`sidebar-left ${metadataPanelOpen ? 'w-80 opacity-100' : 'w-0 opacity-0 overflow-hidden'} ${isTablet ? 'absolute left-0 top-0 h-full z-20 shadow-2xl' : 'relative'}`}>
+          <div
+            className={`sidebar-left ${metadataPanelOpen ? "w-80 opacity-100" : "w-0 opacity-0 overflow-hidden"} ${isTablet ? "absolute left-0 top-0 h-full z-20 shadow-2xl" : "relative"}`}
+          >
             <MetadataPanel
               track={currentTrack}
               isOpen={metadataPanelOpen}
@@ -73,7 +80,9 @@ export function App() {
         </div>
 
         {!isMobile && (
-          <div className={`sidebar-right ${playlistPanelOpen ? 'w-80 opacity-100' : 'w-0 opacity-0 overflow-hidden'} ${isTablet ? 'absolute right-0 top-0 h-full z-20 shadow-2xl' : 'relative'}`}>
+          <div
+            className={`sidebar-right ${playlistPanelOpen ? "w-80 opacity-100" : "w-0 opacity-0 overflow-hidden"} ${isTablet ? "absolute right-0 top-0 h-full z-20 shadow-2xl" : "relative"}`}
+          >
             <PlaylistPanel
               tracks={playlist}
               currentTrackIndex={currentTrackIndex}
@@ -125,11 +134,12 @@ export function App() {
         onSettingsChange={updateSettings}
       />
 
-      <ShortcutsModal isOpen={shortcutsHelpOpen} onClose={() => setShortcutsHelpOpen(false)} />
+      <ShortcutsModal
+        isOpen={shortcutsHelpOpen}
+        onClose={() => setShortcutsHelpOpen(false)}
+      />
 
-      <Toaster position={isMobile ? 'top-center' : 'top-right'} />
+      <Toaster position={isMobile ? "top-center" : "top-right"} />
     </div>
-  )
+  );
 }
-
-

--- a/web/apps/mfe-spectrogram/src/components/layout/PlaylistPanel.tsx
+++ b/web/apps/mfe-spectrogram/src/components/layout/PlaylistPanel.tsx
@@ -1,188 +1,233 @@
-import React, { useState, useRef, useCallback, useMemo, useEffect } from 'react'
-import { X, Play, Trash2, FileAudio, Pause, Loader2 } from 'lucide-react'
-import { AudioTrack } from '@/shared/types'
-import { cn } from '@/shared/utils/cn'
-import { formatDuration } from '@/shared/utils/audio'
-import { useAudioFile } from '@/shared/hooks/useAudioFile'
-import { getFilesFromDataTransfer } from '@/shared/utils/file'
-import { fuzzyMatch, fuzzyScore } from '@/shared/utils/fuzzy'
-import { usePlaylistSearchStore } from '@/shared/stores/playlistSearchStore'
+import React, {
+  useState,
+  useRef,
+  useCallback,
+  useMemo,
+  useEffect,
+} from "react";
+import { X, Play, Trash2, FileAudio, Pause, Loader2 } from "lucide-react";
+import { AudioTrack } from "@/shared/types";
+import { cn } from "@/shared/utils/cn";
+import { formatDuration } from "@/shared/utils/audio";
+import { useAudioFile } from "@/shared/hooks/useAudioFile";
+import { getFilesFromDataTransfer } from "@/shared/utils/file";
+import { fuzzyMatch, fuzzyScore } from "@/shared/utils/fuzzy";
+import { usePlaylistSearchStore } from "@/shared/stores/playlistSearchStore";
+import { useSettingsStore } from "@/shared/stores/settingsStore";
+import { THEME_COLORS } from "@/shared/theme";
 
 interface PlaylistPanelProps {
-  tracks: AudioTrack[]
-  currentTrackIndex: number
-  isOpen: boolean
-  onClose: () => void
-  onTrackSelect: (index: number) => void
-  onTrackRemove: (index: number) => void
-  onTrackReorder: (fromIndex: number, toIndex: number) => void
+  tracks: AudioTrack[];
+  currentTrackIndex: number;
+  isOpen: boolean;
+  onClose: () => void;
+  onTrackSelect: (index: number) => void;
+  onTrackRemove: (index: number) => void;
+  onTrackReorder: (fromIndex: number, toIndex: number) => void;
 }
 
 interface CircularProgressControlProps {
-  track: AudioTrack
-  size?: number
-  progress?: number
-  buffered?: number
-  isPlaying?: boolean
-  onPlayPause?: () => void
-  onSeek?: (progress: number) => void
+  track: AudioTrack;
+  size?: number;
+  progress?: number;
+  buffered?: number;
+  isPlaying?: boolean;
+  onPlayPause?: () => void;
+  onSeek?: (progress: number) => void;
 }
 
 interface LazyAlbumArtProps {
-  data: Uint8Array
-  mimeType: string
-  className?: string
-  onClick?: () => void
+  data: Uint8Array;
+  mimeType: string;
+  className?: string;
+  onClick?: () => void;
 }
 
-function LazyAlbumArt({ data, mimeType, className, onClick }: LazyAlbumArtProps) {
-  const imgRef = useRef<HTMLImageElement>(null)
+function LazyAlbumArt({
+  data,
+  mimeType,
+  className,
+  onClick,
+}: LazyAlbumArtProps) {
+  const imgRef = useRef<HTMLImageElement>(null);
 
   useEffect(() => {
-    const img = imgRef.current
-    if (!img) return
+    const img = imgRef.current;
+    if (!img) return;
 
-    let url: string | null = null
+    let url: string | null = null;
 
     const load = () => {
-      if (url || !data || data.length === 0) return
-      const blob = new Blob([data], { type: mimeType })
-      url = URL.createObjectURL(blob)
-      img.src = url
-    }
+      if (url || !data || data.length === 0) return;
+      const blob = new Blob([data], { type: mimeType });
+      url = URL.createObjectURL(blob);
+      img.src = url;
+    };
 
     const unload = () => {
       if (url) {
-        URL.revokeObjectURL(url)
-        url = null
+        URL.revokeObjectURL(url);
+        url = null;
       }
-      img.src = ''
-    }
+      img.src = "";
+    };
 
     const observer = new IntersectionObserver((entries) => {
       entries.forEach((entry) => {
         if (entry.isIntersecting) {
-          load()
+          load();
         } else {
-          unload()
+          unload();
         }
-      })
-    })
+      });
+    });
 
-    observer.observe(img)
+    observer.observe(img);
 
     return () => {
-      observer.disconnect()
-      unload()
-    }
-  }, [data, mimeType])
-
-  return <img ref={imgRef} alt="Album Art" className={className} onClick={onClick} />
-}
-
-function CircularProgressControl({ 
-  track, 
-  size = 64, 
-  progress = 0, 
-  buffered = 0, 
-  isPlaying = false, 
-  onPlayPause,
-  onSeek 
-}: CircularProgressControlProps) {
-  const [isHovered, setIsHovered] = useState(false)
-  const [isScrubbing, setIsScrubbing] = useState(false)
-  const containerRef = useRef<HTMLDivElement>(null)
-  
-  // Calculate dimensions
-  const strokeWidth = 3
-  const radius = (size - strokeWidth) / 2
-  const circumference = 2 * Math.PI * radius
-  
-  // Calculate stroke dasharray for progress
-  const progressDasharray = `${progress * circumference} ${circumference}`
-  const bufferedDasharray = `${buffered * circumference} ${circumference}`
-  
-  // Handle play/pause click
-  const handlePlayPause = useCallback((e: React.MouseEvent) => {
-    e.stopPropagation()
-    onPlayPause?.()
-  }, [onPlayPause])
-  
-  // Calculate progress from mouse position
-  const getProgressFromMouse = useCallback((clientX: number, clientY: number): number => {
-    if (!containerRef.current) return 0
-    
-    const rect = containerRef.current.getBoundingClientRect()
-    const centerX = rect.left + rect.width / 2
-    const centerY = rect.top + rect.height / 2
-    
-    // Calculate angle from center
-    const deltaX = clientX - centerX
-    const deltaY = clientY - centerY
-    const angle = Math.atan2(deltaY, deltaX) * (180 / Math.PI)
-    
-    // Convert to 0-1 progress (starting from top, clockwise)
-    let progress = (angle + 90) / 360
-    if (progress < 0) progress += 1
-    
-    return Math.max(0, Math.min(1, progress))
-  }, [])
-  
-  // Handle ring click for seeking
-  const handleRingClick = useCallback((e: React.MouseEvent) => {
-    if (isScrubbing) return
-    
-    const newProgress = getProgressFromMouse(e.clientX, e.clientY)
-    onSeek?.(newProgress)
-  }, [isScrubbing, getProgressFromMouse, onSeek])
-  
-  // Handle mouse down for scrubbing
-  const handleMouseDown = useCallback((e: React.MouseEvent) => {
-    e.preventDefault()
-    setIsScrubbing(true)
-    
-    const handleMouseMove = (moveEvent: MouseEvent) => {
-      if (!isScrubbing) return
-      
-      const newProgress = getProgressFromMouse(moveEvent.clientX, moveEvent.clientY)
-      onSeek?.(newProgress)
-    }
-    
-    const handleMouseUp = () => {
-      setIsScrubbing(false)
-      document.removeEventListener('mousemove', handleMouseMove)
-      document.removeEventListener('mouseup', handleMouseUp)
-    }
-    
-    document.addEventListener('mousemove', handleMouseMove)
-    document.addEventListener('mouseup', handleMouseUp)
-  }, [isScrubbing, getProgressFromMouse, onSeek])
-  
-  // Handle keyboard controls
-  const handleKeyDown = useCallback((e: React.KeyboardEvent) => {
-    switch (e.key) {
-      case ' ':
-      case 'Enter':
-        e.preventDefault()
-        onPlayPause?.()
-        break
-      case 'ArrowLeft':
-        e.preventDefault()
-        const seekBack = e.shiftKey ? 10 : 5
-        const newProgressBack = Math.max(0, progress - seekBack / track.duration)
-        onSeek?.(newProgressBack)
-        break
-      case 'ArrowRight':
-        e.preventDefault()
-        const seekForward = e.shiftKey ? 10 : 5
-        const newProgressForward = Math.min(1, progress + seekForward / track.duration)
-        onSeek?.(newProgressForward)
-        break
-    }
-  }, [progress, track.duration, onPlayPause, onSeek])
+      observer.disconnect();
+      unload();
+    };
+  }, [data, mimeType]);
 
   return (
-    <div 
+    <img ref={imgRef} alt="Album Art" className={className} onClick={onClick} />
+  );
+}
+
+/**
+ * Renders a circular progress/seek control for playlist items. Colours are
+ * derived from the active theme, removing hard-coded hex codes.
+ */
+function CircularProgressControl({
+  track,
+  size = 64,
+  progress = 0,
+  buffered = 0,
+  isPlaying = false,
+  onPlayPause,
+  onSeek,
+}: CircularProgressControlProps) {
+  const [isHovered, setIsHovered] = useState(false);
+  const [isScrubbing, setIsScrubbing] = useState(false);
+  const containerRef = useRef<HTMLDivElement>(null);
+  const theme = useSettingsStore((s) => s.theme);
+  const { accent, primary } = THEME_COLORS[theme];
+
+  // Calculate dimensions
+  const strokeWidth = 3;
+  const radius = (size - strokeWidth) / 2;
+  const circumference = 2 * Math.PI * radius;
+
+  // Calculate stroke dasharray for progress
+  const progressDasharray = `${progress * circumference} ${circumference}`;
+  const bufferedDasharray = `${buffered * circumference} ${circumference}`;
+
+  // Handle play/pause click
+  const handlePlayPause = useCallback(
+    (e: React.MouseEvent) => {
+      e.stopPropagation();
+      onPlayPause?.();
+    },
+    [onPlayPause],
+  );
+
+  // Calculate progress from mouse position
+  const getProgressFromMouse = useCallback(
+    (clientX: number, clientY: number): number => {
+      if (!containerRef.current) return 0;
+
+      const rect = containerRef.current.getBoundingClientRect();
+      const centerX = rect.left + rect.width / 2;
+      const centerY = rect.top + rect.height / 2;
+
+      // Calculate angle from center
+      const deltaX = clientX - centerX;
+      const deltaY = clientY - centerY;
+      const angle = Math.atan2(deltaY, deltaX) * (180 / Math.PI);
+
+      // Convert to 0-1 progress (starting from top, clockwise)
+      let progress = (angle + 90) / 360;
+      if (progress < 0) progress += 1;
+
+      return Math.max(0, Math.min(1, progress));
+    },
+    [],
+  );
+
+  // Handle ring click for seeking
+  const handleRingClick = useCallback(
+    (e: React.MouseEvent) => {
+      if (isScrubbing) return;
+
+      const newProgress = getProgressFromMouse(e.clientX, e.clientY);
+      onSeek?.(newProgress);
+    },
+    [isScrubbing, getProgressFromMouse, onSeek],
+  );
+
+  // Handle mouse down for scrubbing
+  const handleMouseDown = useCallback(
+    (e: React.MouseEvent) => {
+      e.preventDefault();
+      setIsScrubbing(true);
+
+      const handleMouseMove = (moveEvent: MouseEvent) => {
+        if (!isScrubbing) return;
+
+        const newProgress = getProgressFromMouse(
+          moveEvent.clientX,
+          moveEvent.clientY,
+        );
+        onSeek?.(newProgress);
+      };
+
+      const handleMouseUp = () => {
+        setIsScrubbing(false);
+        document.removeEventListener("mousemove", handleMouseMove);
+        document.removeEventListener("mouseup", handleMouseUp);
+      };
+
+      document.addEventListener("mousemove", handleMouseMove);
+      document.addEventListener("mouseup", handleMouseUp);
+    },
+    [isScrubbing, getProgressFromMouse, onSeek],
+  );
+
+  // Handle keyboard controls
+  const handleKeyDown = useCallback(
+    (e: React.KeyboardEvent) => {
+      switch (e.key) {
+        case " ":
+        case "Enter":
+          e.preventDefault();
+          onPlayPause?.();
+          break;
+        case "ArrowLeft":
+          e.preventDefault();
+          const seekBack = e.shiftKey ? 10 : 5;
+          const newProgressBack = Math.max(
+            0,
+            progress - seekBack / track.duration,
+          );
+          onSeek?.(newProgressBack);
+          break;
+        case "ArrowRight":
+          e.preventDefault();
+          const seekForward = e.shiftKey ? 10 : 5;
+          const newProgressForward = Math.min(
+            1,
+            progress + seekForward / track.duration,
+          );
+          onSeek?.(newProgressForward);
+          break;
+      }
+    },
+    [progress, track.duration, onPlayPause, onSeek],
+  );
+
+  return (
+    <div
       ref={containerRef}
       className="relative flex-shrink-0"
       onMouseEnter={() => setIsHovered(true)}
@@ -192,12 +237,16 @@ function CircularProgressControl({
       <div className="relative">
         {(() => {
           try {
-            if (track.artwork && track.artwork.data && track.artwork.data.length > 0) {
+            if (
+              track.artwork &&
+              track.artwork.data &&
+              track.artwork.data.length > 0
+            ) {
               const artworkData =
                 track.artwork.data instanceof Uint8Array
                   ? track.artwork.data
-                  : new Uint8Array(track.artwork.data)
-              const mimeType = track.artwork.mimeType || 'image/jpeg'
+                  : new Uint8Array(track.artwork.data);
+              const mimeType = track.artwork.mimeType || "image/jpeg";
 
               return (
                 <LazyAlbumArt
@@ -205,12 +254,15 @@ function CircularProgressControl({
                   mimeType={mimeType}
                   className="w-16 h-16 object-cover rounded-md transition-transform hover:scale-105"
                 />
-              )
+              );
             }
 
-            if (track.metadata.album_art && track.metadata.album_art.length > 0) {
-              const albumArtData = track.metadata.album_art
-              const mimeType = track.metadata.album_art_mime || 'image/jpeg'
+            if (
+              track.metadata.album_art &&
+              track.metadata.album_art.length > 0
+            ) {
+              const albumArtData = track.metadata.album_art;
+              const mimeType = track.metadata.album_art_mime || "image/jpeg";
 
               return (
                 <LazyAlbumArt
@@ -218,20 +270,20 @@ function CircularProgressControl({
                   mimeType={mimeType}
                   className="w-16 h-16 object-cover rounded-md transition-transform hover:scale-105"
                 />
-              )
+              );
             }
 
             return (
               <div className="w-16 h-16 bg-neutral-800 rounded-md flex items-center justify-center">
                 <FileAudio size={20} className="text-neutral-500" />
               </div>
-            )
+            );
           } catch (error) {
             return (
               <div className="w-16 h-16 bg-neutral-800 rounded-md flex items-center justify-center">
                 <FileAudio size={20} className="text-neutral-500" />
               </div>
-            )
+            );
           }
         })()}
       </div>
@@ -242,7 +294,7 @@ function CircularProgressControl({
           width={size}
           height={size}
           className="absolute inset-0"
-          style={{ transform: 'rotate(-90deg)' }}
+          style={{ transform: "rotate(-90deg)" }}
         >
           {/* Background track */}
           <circle
@@ -250,11 +302,11 @@ function CircularProgressControl({
             cy={size / 2}
             r={radius}
             fill="none"
-            stroke="#374151"
+            stroke={primary}
             strokeWidth={strokeWidth}
             opacity={0.3}
           />
-          
+
           {/* Buffered progress */}
           {buffered > 0 && (
             <circle
@@ -262,36 +314,36 @@ function CircularProgressControl({
               cy={size / 2}
               r={radius}
               fill="none"
-              stroke="#6b7280"
+              stroke={primary}
               strokeWidth={strokeWidth}
               strokeDasharray={bufferedDasharray}
               opacity={0.6}
             />
           )}
-          
+
           {/* Progress arc */}
           <circle
             cx={size / 2}
             cy={size / 2}
             r={radius}
             fill="none"
-            stroke="#3b82f6"
+            stroke={accent}
             strokeWidth={strokeWidth}
             strokeDasharray={progressDasharray}
             strokeLinecap="round"
             className="transition-all duration-300 ease-out"
           />
         </svg>
-        
+
         {/* Clickable ring area for seeking */}
         <div
           className="absolute inset-0 cursor-pointer"
           onClick={handleRingClick}
           onMouseDown={handleMouseDown}
-          style={{ transform: 'rotate(-90deg)' }}
+          style={{ transform: "rotate(-90deg)" }}
         />
       </div>
-      
+
       {/* Play/Pause Button */}
       <button
         className={cn(
@@ -299,29 +351,29 @@ function CircularProgressControl({
           "transition-all duration-300 ease-out",
           "bg-black/60 backdrop-blur-sm",
           isHovered && "bg-black/80 scale-105",
-          isScrubbing && "scale-110"
+          isScrubbing && "scale-110",
         )}
         onClick={handlePlayPause}
         onKeyDown={handleKeyDown}
         role="button"
         aria-pressed={isPlaying}
-        aria-label={`${isPlaying ? 'Pause' : 'Play'} ${track.metadata.title || track.file.name}`}
+        aria-label={`${isPlaying ? "Pause" : "Play"} ${track.metadata.title || track.file.name}`}
         tabIndex={0}
       >
         {isPlaying ? (
-          <Pause 
-            size={16} 
+          <Pause
+            size={16}
             className="text-white fill-white transition-transform duration-200"
           />
         ) : (
-          <Play 
-            size={16} 
+          <Play
+            size={16}
             className="text-white fill-white transition-transform duration-200 ml-0.5"
           />
         )}
       </button>
     </div>
-  )
+  );
 }
 
 export function PlaylistPanel({
@@ -333,146 +385,151 @@ export function PlaylistPanel({
   onTrackRemove,
   onTrackReorder,
 }: PlaylistPanelProps) {
-  const [dragIndex, setDragIndex] = useState<number | null>(null)
-  const [dropIndex, setDropIndex] = useState<number | null>(null)
-  const trackRefs = useRef<(HTMLDivElement | null)[]>([])
-  const { loadAudioFiles } = useAudioFile()
+  const [dragIndex, setDragIndex] = useState<number | null>(null);
+  const [dropIndex, setDropIndex] = useState<number | null>(null);
+  const trackRefs = useRef<(HTMLDivElement | null)[]>([]);
+  const { loadAudioFiles } = useAudioFile();
 
   const handlePanelDragOver = (event: React.DragEvent<HTMLDivElement>) => {
-    if (event.dataTransfer.types.includes('Files')) {
-      event.preventDefault()
-      event.dataTransfer.dropEffect = 'copy'
+    if (event.dataTransfer.types.includes("Files")) {
+      event.preventDefault();
+      event.dataTransfer.dropEffect = "copy";
     }
-  }
+  };
 
   const handlePanelDrop = async (event: React.DragEvent<HTMLDivElement>) => {
-    event.preventDefault()
-    const files = await getFilesFromDataTransfer(event.dataTransfer)
+    event.preventDefault();
+    const files = await getFilesFromDataTransfer(event.dataTransfer);
     if (files.length > 0) {
       try {
-        await loadAudioFiles(files)
+        await loadAudioFiles(files);
       } catch {
         // Ignore load errors
       }
     }
-  }
+  };
 
   const handleDragStart = (event: React.DragEvent, index: number) => {
-    setDragIndex(index)
-    event.dataTransfer.setData('text/plain', index.toString())
-    event.dataTransfer.effectAllowed = 'move'
-    
+    setDragIndex(index);
+    event.dataTransfer.setData("text/plain", index.toString());
+    event.dataTransfer.effectAllowed = "move";
+
     // Create a custom drag image
-    const dragElement = event.currentTarget as HTMLElement
-    const rect = dragElement.getBoundingClientRect()
-    const dragImage = dragElement.cloneNode(true) as HTMLElement
-    dragImage.style.width = `${rect.width}px`
-    dragImage.style.opacity = '0.8'
-    dragImage.style.transform = 'rotate(5deg)'
-    dragImage.style.pointerEvents = 'none'
-    document.body.appendChild(dragImage)
-    
-    event.dataTransfer.setDragImage(dragImage, rect.width / 2, rect.height / 2)
-    
+    const dragElement = event.currentTarget as HTMLElement;
+    const rect = dragElement.getBoundingClientRect();
+    const dragImage = dragElement.cloneNode(true) as HTMLElement;
+    dragImage.style.width = `${rect.width}px`;
+    dragImage.style.opacity = "0.8";
+    dragImage.style.transform = "rotate(5deg)";
+    dragImage.style.pointerEvents = "none";
+    document.body.appendChild(dragImage);
+
+    event.dataTransfer.setDragImage(dragImage, rect.width / 2, rect.height / 2);
+
     // Remove the drag image after a short delay
     setTimeout(() => {
       if (document.body.contains(dragImage)) {
-        document.body.removeChild(dragImage)
+        document.body.removeChild(dragImage);
       }
-    }, 100)
-  }
+    }, 100);
+  };
 
   const handleDragEnd = () => {
-    setDragIndex(null)
-    setDropIndex(null)
-  }
+    setDragIndex(null);
+    setDropIndex(null);
+  };
 
   const handleDragOver = (event: React.DragEvent, index: number) => {
-    event.preventDefault()
-    event.dataTransfer.dropEffect = 'move'
-    
+    event.preventDefault();
+    event.dataTransfer.dropEffect = "move";
+
     if (dragIndex !== null && dragIndex !== index) {
-      setDropIndex(index)
+      setDropIndex(index);
     }
-  }
+  };
 
   const handleDrop = (event: React.DragEvent, dropIndex: number) => {
     if (event.dataTransfer.files.length > 0) {
-      return
+      return;
     }
-    event.preventDefault()
-    const data = event.dataTransfer.getData('text/plain')
-    if (!data) return
-    const dragIndex = parseInt(data, 10)
+    event.preventDefault();
+    const data = event.dataTransfer.getData("text/plain");
+    if (!data) return;
+    const dragIndex = parseInt(data, 10);
     if (dragIndex !== dropIndex) {
-      onTrackReorder(dragIndex, dropIndex)
+      onTrackReorder(dragIndex, dropIndex);
     }
-    setDragIndex(null)
-    setDropIndex(null)
-  }
+    setDragIndex(null);
+    setDropIndex(null);
+  };
 
-  const { searchQuery, setSearchQuery } = usePlaylistSearchStore()
+  const { searchQuery, setSearchQuery } = usePlaylistSearchStore();
 
   const searchIndex = useMemo(
     () =>
       tracks.map((track, index) => ({
         index,
-        title: track.metadata.title?.toLowerCase() ?? '',
-        artist: track.metadata.artist?.toLowerCase() ?? '',
-        album: track.metadata.album?.toLowerCase() ?? '',
-        genre: track.metadata.genre?.toLowerCase() ?? '',
-        year: track.metadata.year ? String(track.metadata.year) : '',
+        title: track.metadata.title?.toLowerCase() ?? "",
+        artist: track.metadata.artist?.toLowerCase() ?? "",
+        album: track.metadata.album?.toLowerCase() ?? "",
+        genre: track.metadata.genre?.toLowerCase() ?? "",
+        year: track.metadata.year ? String(track.metadata.year) : "",
       })),
-    [tracks]
-  )
+    [tracks],
+  );
 
-  type SuggestionType = 'title' | 'artist' | 'album' | 'genre' | 'year'
+  type SuggestionType = "title" | "artist" | "album" | "genre" | "year";
 
   const allSuggestions = useMemo(() => {
-    const map = new Map<string, { value: string; type: SuggestionType }>()
+    const map = new Map<string, { value: string; type: SuggestionType }>();
     tracks.forEach((track) => {
-      const { title, artist, album, genre, year } = track.metadata
-      if (title) map.set(`title-${title}`, { value: title, type: 'title' })
-      if (artist) map.set(`artist-${artist}`, { value: artist, type: 'artist' })
-      if (album) map.set(`album-${album}`, { value: album, type: 'album' })
-      if (genre) map.set(`genre-${genre}`, { value: genre, type: 'genre' })
-      if (year) map.set(`year-${year}`, { value: String(year), type: 'year' })
-    })
-    return Array.from(map.values())
-  }, [tracks])
+      const { title, artist, album, genre, year } = track.metadata;
+      if (title) map.set(`title-${title}`, { value: title, type: "title" });
+      if (artist)
+        map.set(`artist-${artist}`, { value: artist, type: "artist" });
+      if (album) map.set(`album-${album}`, { value: album, type: "album" });
+      if (genre) map.set(`genre-${genre}`, { value: genre, type: "genre" });
+      if (year) map.set(`year-${year}`, { value: String(year), type: "year" });
+    });
+    return Array.from(map.values());
+  }, [tracks]);
 
-  const { items: suggestions, hasMore: hasMoreSuggestions, moreCount } = useMemo(() => {
-    const limit = 10
+  const {
+    items: suggestions,
+    hasMore: hasMoreSuggestions,
+    moreCount,
+  } = useMemo(() => {
+    const limit = 10;
     if (!searchQuery.trim()) {
       return {
         items: allSuggestions.slice(0, limit),
         hasMore: allSuggestions.length > limit,
         moreCount: Math.max(allSuggestions.length - limit, 0),
-      }
+      };
     }
-    const q = searchQuery.toLowerCase()
+    const q = searchQuery.toLowerCase();
     const scored = allSuggestions
       .map((s) => ({ ...s, score: fuzzyScore(q, s.value) }))
       .filter((s) => s.score !== Infinity)
-      .sort((a, b) => a.score - b.score)
+      .sort((a, b) => a.score - b.score);
     return {
       items: scored.slice(0, limit),
       hasMore: scored.length > limit,
       moreCount: Math.max(scored.length - limit, 0),
-    }
-  }, [allSuggestions, searchQuery])
+    };
+  }, [allSuggestions, searchQuery]);
 
   const typeSymbols: Record<SuggestionType, string> = {
-    title: '🎵',
-    artist: '👤',
-    album: '💿',
-    genre: '🎼',
-    year: '📅',
-  }
+    title: "🎵",
+    artist: "👤",
+    album: "💿",
+    genre: "🎼",
+    year: "📅",
+  };
 
   const filteredIndexes = useMemo(() => {
-    if (!searchQuery.trim()) return searchIndex.map((item) => item.index)
-    const q = searchQuery.toLowerCase()
+    if (!searchQuery.trim()) return searchIndex.map((item) => item.index);
+    const q = searchQuery.toLowerCase();
     return searchIndex
       .filter(
         (item) =>
@@ -480,23 +537,23 @@ export function PlaylistPanel({
           fuzzyMatch(q, item.artist) ||
           fuzzyMatch(q, item.album) ||
           fuzzyMatch(q, item.genre) ||
-          fuzzyMatch(q, item.year)
+          fuzzyMatch(q, item.year),
       )
-      .map((item) => item.index)
-  }, [searchIndex, searchQuery])
+      .map((item) => item.index);
+  }, [searchIndex, searchQuery]);
 
   const filteredTracks = useMemo(
     () => filteredIndexes.map((i) => tracks[i]),
-    [filteredIndexes, tracks]
-  )
+    [filteredIndexes, tracks],
+  );
 
   const totalDuration = filteredTracks.reduce(
     (total, track) => total + track.duration,
-    0
-  )
+    0,
+  );
 
   const renderAlbumArt = (track: AudioTrack, index: number) => {
-    const isCurrentTrack = currentTrackIndex === index
+    const isCurrentTrack = currentTrackIndex === index;
 
     if (track.isLoading) {
       return (
@@ -506,7 +563,7 @@ export function PlaylistPanel({
         >
           <Loader2 size={20} className="text-neutral-500 animate-spin" />
         </div>
-      )
+      );
     }
 
     if (isCurrentTrack) {
@@ -524,28 +581,27 @@ export function PlaylistPanel({
             // Seek to progress
           }}
         />
-      )
+      );
     }
-    
+
     // Regular album art for non-current tracks
     // Use the new artwork system if available
-    
-    
+
     if (track.artwork && track.artwork.data && track.artwork.data.length > 0) {
       try {
-        const artworkData = track.artwork.data
-        const mimeType = track.artwork.mimeType || 'image/jpeg'
+        const artworkData = track.artwork.data;
+        const mimeType = track.artwork.mimeType || "image/jpeg";
 
         // Validate the data before creating blob
         if (artworkData.length < 100) {
-          return renderFallbackAlbumArt(index)
+          return renderFallbackAlbumArt(index);
         }
 
         // Ensure we have a Uint8Array
         const dataArray =
           artworkData instanceof Uint8Array
             ? artworkData
-            : new Uint8Array(artworkData)
+            : new Uint8Array(artworkData);
 
         return (
           <div className="relative flex-shrink-0">
@@ -556,21 +612,21 @@ export function PlaylistPanel({
               onClick={() => onTrackSelect(index)}
             />
           </div>
-        )
+        );
       } catch (error) {
-        return renderFallbackAlbumArt(index)
+        return renderFallbackAlbumArt(index);
       }
     }
 
     // Fallback to old metadata album art if available
     if (track.metadata.album_art && track.metadata.album_art.length > 0) {
       try {
-        const albumArtData = track.metadata.album_art
-        const mimeType = track.metadata.album_art_mime || 'image/jpeg'
+        const albumArtData = track.metadata.album_art;
+        const mimeType = track.metadata.album_art_mime || "image/jpeg";
 
         // Validate the data before creating blob
         if (albumArtData.length < 100) {
-          return renderFallbackAlbumArt(index)
+          return renderFallbackAlbumArt(index);
         }
 
         return (
@@ -582,15 +638,15 @@ export function PlaylistPanel({
               onClick={() => onTrackSelect(index)}
             />
           </div>
-        )
+        );
       } catch (error) {
-        return renderFallbackAlbumArt(index)
+        return renderFallbackAlbumArt(index);
       }
     }
-    
+
     // Fallback album art placeholder
-    return renderFallbackAlbumArt(index)
-  }
+    return renderFallbackAlbumArt(index);
+  };
 
   const renderFallbackAlbumArt = (index: number) => (
     <div
@@ -599,7 +655,7 @@ export function PlaylistPanel({
     >
       <FileAudio size={20} className="text-neutral-500" />
     </div>
-  )
+  );
 
   return (
     <div
@@ -631,7 +687,10 @@ export function PlaylistPanel({
           className="w-full px-2 py-1 bg-neutral-900 rounded-md text-sm text-neutral-100 border border-neutral-800 focus:outline-none focus:ring-1 focus:ring-accent-blue"
           data-testid="playlist-search-input"
         />
-        <datalist id="playlist-search-suggestions" data-testid="playlist-search-suggestions">
+        <datalist
+          id="playlist-search-suggestions"
+          data-testid="playlist-search-suggestions"
+        >
           {suggestions.map((s) => (
             <option
               key={`${s.type}-${s.value}`}
@@ -667,9 +726,9 @@ export function PlaylistPanel({
         ) : (
           <div className="p-1 space-y-1">
             {filteredIndexes.map((originalIndex) => {
-              const track = tracks[originalIndex]
-              const isDragging = dragIndex === originalIndex
-              const isDropTarget = dropIndex === originalIndex
+              const track = tracks[originalIndex];
+              const isDragging = dragIndex === originalIndex;
+              const isDropTarget = dropIndex === originalIndex;
 
               return (
                 <div
@@ -681,12 +740,13 @@ export function PlaylistPanel({
                   onDragOver={(e) => handleDragOver(e, originalIndex)}
                   onDrop={(e) => handleDrop(e, originalIndex)}
                   className={cn(
-                    'group flex items-center gap-3 p-2 rounded-md cursor-pointer transition-all duration-300 ease-out',
-                    'hover:bg-neutral-800 hover:shadow-sm',
-                    'border border-transparent hover:border-neutral-700',
-                    currentTrackIndex === originalIndex && 'bg-neutral-800 border-neutral-600 shadow-sm',
-                    isDragging && 'opacity-50 scale-95 rotate-1 z-50',
-                    isDropTarget && 'bg-neutral-700/30'
+                    "group flex items-center gap-3 p-2 rounded-md cursor-pointer transition-all duration-300 ease-out",
+                    "hover:bg-neutral-800 hover:shadow-sm",
+                    "border border-transparent hover:border-neutral-700",
+                    currentTrackIndex === originalIndex &&
+                      "bg-neutral-800 border-neutral-600 shadow-sm",
+                    isDragging && "opacity-50 scale-95 rotate-1 z-50",
+                    isDropTarget && "bg-neutral-700/30",
                   )}
                   onClick={() => onTrackSelect(originalIndex)}
                 >
@@ -699,10 +759,10 @@ export function PlaylistPanel({
                     <div className="mb-1">
                       <h4
                         className={cn(
-                          'text-sm font-medium truncate',
+                          "text-sm font-medium truncate",
                           currentTrackIndex === originalIndex
-                            ? 'text-accent-blue'
-                            : 'text-neutral-100'
+                            ? "text-accent-blue"
+                            : "text-neutral-100",
                         )}
                       >
                         {track.metadata.title || track.file.name}
@@ -712,7 +772,7 @@ export function PlaylistPanel({
                     {/* Artist and Duration - Second most important */}
                     <div className="flex items-center justify-between text-xs text-neutral-400 mb-0.5">
                       <span className="truncate">
-                        {track.metadata.artist || 'Unknown Artist'}
+                        {track.metadata.artist || "Unknown Artist"}
                       </span>
                       <span className="flex-shrink-0 ml-2 text-neutral-500">
                         {formatDuration(track.duration)}
@@ -731,12 +791,12 @@ export function PlaylistPanel({
                   <div className="flex items-center gap-1 opacity-0 group-hover:opacity-100 transition-opacity absolute right-2">
                     <button
                       onClick={(e) => {
-                        e.stopPropagation()
-                        onTrackRemove(originalIndex)
+                        e.stopPropagation();
+                        onTrackRemove(originalIndex);
                       }}
                       className={cn(
-                        'p-1.5 rounded transition-colors',
-                        'text-neutral-400 hover:text-red-400 hover:bg-red-400/10'
+                        "p-1.5 rounded transition-colors",
+                        "text-neutral-400 hover:text-red-400 hover:bg-red-400/10",
                       )}
                       title="Remove from playlist"
                     >
@@ -744,7 +804,7 @@ export function PlaylistPanel({
                     </button>
                   </div>
                 </div>
-              )
+              );
             })}
           </div>
         )}
@@ -756,7 +816,8 @@ export function PlaylistPanel({
           <div className="flex items-center justify-between text-xs">
             <div className="flex flex-col gap-0.5">
               <span className="text-neutral-300 font-medium">
-                {filteredTracks.length} track{filteredTracks.length !== 1 ? 's' : ''}
+                {filteredTracks.length} track
+                {filteredTracks.length !== 1 ? "s" : ""}
               </span>
               <span className="text-neutral-400">
                 {formatDuration(totalDuration)}
@@ -769,5 +830,5 @@ export function PlaylistPanel({
         </div>
       )}
     </div>
-  )
+  );
 }

--- a/web/apps/mfe-spectrogram/src/features/playlist/PlaylistPanel.tsx
+++ b/web/apps/mfe-spectrogram/src/features/playlist/PlaylistPanel.tsx
@@ -1,188 +1,233 @@
-import React, { useState, useRef, useCallback, useMemo, useEffect } from 'react'
-import { X, Play, Trash2, FileAudio, Pause, Loader2 } from 'lucide-react'
-import { AudioTrack } from '@/shared/types'
-import { cn } from '@/shared/utils/cn'
-import { formatDuration } from '@/shared/utils/audio'
-import { useAudioFile } from '@/shared/hooks/useAudioFile'
-import { getFilesFromDataTransfer } from '@/shared/utils/file'
-import { fuzzyMatch, fuzzyScore } from '@/shared/utils/fuzzy'
-import { usePlaylistSearchStore } from '@/shared/stores/playlistSearchStore'
+import React, {
+  useState,
+  useRef,
+  useCallback,
+  useMemo,
+  useEffect,
+} from "react";
+import { X, Play, Trash2, FileAudio, Pause, Loader2 } from "lucide-react";
+import { AudioTrack } from "@/shared/types";
+import { cn } from "@/shared/utils/cn";
+import { formatDuration } from "@/shared/utils/audio";
+import { useAudioFile } from "@/shared/hooks/useAudioFile";
+import { getFilesFromDataTransfer } from "@/shared/utils/file";
+import { fuzzyMatch, fuzzyScore } from "@/shared/utils/fuzzy";
+import { usePlaylistSearchStore } from "@/shared/stores/playlistSearchStore";
+import { useSettingsStore } from "@/shared/stores/settingsStore";
+import { THEME_COLORS } from "@/shared/theme";
 
 interface PlaylistPanelProps {
-  tracks: AudioTrack[]
-  currentTrackIndex: number
-  isOpen: boolean
-  onClose: () => void
-  onTrackSelect: (index: number) => void
-  onTrackRemove: (index: number) => void
-  onTrackReorder: (fromIndex: number, toIndex: number) => void
+  tracks: AudioTrack[];
+  currentTrackIndex: number;
+  isOpen: boolean;
+  onClose: () => void;
+  onTrackSelect: (index: number) => void;
+  onTrackRemove: (index: number) => void;
+  onTrackReorder: (fromIndex: number, toIndex: number) => void;
 }
 
 interface CircularProgressControlProps {
-  track: AudioTrack
-  size?: number
-  progress?: number
-  buffered?: number
-  isPlaying?: boolean
-  onPlayPause?: () => void
-  onSeek?: (progress: number) => void
+  track: AudioTrack;
+  size?: number;
+  progress?: number;
+  buffered?: number;
+  isPlaying?: boolean;
+  onPlayPause?: () => void;
+  onSeek?: (progress: number) => void;
 }
 
 interface LazyAlbumArtProps {
-  data: Uint8Array
-  mimeType: string
-  className?: string
-  onClick?: () => void
+  data: Uint8Array;
+  mimeType: string;
+  className?: string;
+  onClick?: () => void;
 }
 
-function LazyAlbumArt({ data, mimeType, className, onClick }: LazyAlbumArtProps) {
-  const imgRef = useRef<HTMLImageElement>(null)
+function LazyAlbumArt({
+  data,
+  mimeType,
+  className,
+  onClick,
+}: LazyAlbumArtProps) {
+  const imgRef = useRef<HTMLImageElement>(null);
 
   useEffect(() => {
-    const img = imgRef.current
-    if (!img) return
+    const img = imgRef.current;
+    if (!img) return;
 
-    let url: string | null = null
+    let url: string | null = null;
 
     const load = () => {
-      if (url || !data || data.length === 0) return
-      const blob = new Blob([data], { type: mimeType })
-      url = URL.createObjectURL(blob)
-      img.src = url
-    }
+      if (url || !data || data.length === 0) return;
+      const blob = new Blob([data], { type: mimeType });
+      url = URL.createObjectURL(blob);
+      img.src = url;
+    };
 
     const unload = () => {
       if (url) {
-        URL.revokeObjectURL(url)
-        url = null
+        URL.revokeObjectURL(url);
+        url = null;
       }
-      img.src = ''
-    }
+      img.src = "";
+    };
 
     const observer = new IntersectionObserver((entries) => {
       entries.forEach((entry) => {
         if (entry.isIntersecting) {
-          load()
+          load();
         } else {
-          unload()
+          unload();
         }
-      })
-    })
+      });
+    });
 
-    observer.observe(img)
+    observer.observe(img);
 
     return () => {
-      observer.disconnect()
-      unload()
-    }
-  }, [data, mimeType])
-
-  return <img ref={imgRef} alt="Album Art" className={className} onClick={onClick} />
-}
-
-function CircularProgressControl({ 
-  track, 
-  size = 64, 
-  progress = 0, 
-  buffered = 0, 
-  isPlaying = false, 
-  onPlayPause,
-  onSeek 
-}: CircularProgressControlProps) {
-  const [isHovered, setIsHovered] = useState(false)
-  const [isScrubbing, setIsScrubbing] = useState(false)
-  const containerRef = useRef<HTMLDivElement>(null)
-  
-  // Calculate dimensions
-  const strokeWidth = 3
-  const radius = (size - strokeWidth) / 2
-  const circumference = 2 * Math.PI * radius
-  
-  // Calculate stroke dasharray for progress
-  const progressDasharray = `${progress * circumference} ${circumference}`
-  const bufferedDasharray = `${buffered * circumference} ${circumference}`
-  
-  // Handle play/pause click
-  const handlePlayPause = useCallback((e: React.MouseEvent) => {
-    e.stopPropagation()
-    onPlayPause?.()
-  }, [onPlayPause])
-  
-  // Calculate progress from mouse position
-  const getProgressFromMouse = useCallback((clientX: number, clientY: number): number => {
-    if (!containerRef.current) return 0
-    
-    const rect = containerRef.current.getBoundingClientRect()
-    const centerX = rect.left + rect.width / 2
-    const centerY = rect.top + rect.height / 2
-    
-    // Calculate angle from center
-    const deltaX = clientX - centerX
-    const deltaY = clientY - centerY
-    const angle = Math.atan2(deltaY, deltaX) * (180 / Math.PI)
-    
-    // Convert to 0-1 progress (starting from top, clockwise)
-    let progress = (angle + 90) / 360
-    if (progress < 0) progress += 1
-    
-    return Math.max(0, Math.min(1, progress))
-  }, [])
-  
-  // Handle ring click for seeking
-  const handleRingClick = useCallback((e: React.MouseEvent) => {
-    if (isScrubbing) return
-    
-    const newProgress = getProgressFromMouse(e.clientX, e.clientY)
-    onSeek?.(newProgress)
-  }, [isScrubbing, getProgressFromMouse, onSeek])
-  
-  // Handle mouse down for scrubbing
-  const handleMouseDown = useCallback((e: React.MouseEvent) => {
-    e.preventDefault()
-    setIsScrubbing(true)
-    
-    const handleMouseMove = (moveEvent: MouseEvent) => {
-      if (!isScrubbing) return
-      
-      const newProgress = getProgressFromMouse(moveEvent.clientX, moveEvent.clientY)
-      onSeek?.(newProgress)
-    }
-    
-    const handleMouseUp = () => {
-      setIsScrubbing(false)
-      document.removeEventListener('mousemove', handleMouseMove)
-      document.removeEventListener('mouseup', handleMouseUp)
-    }
-    
-    document.addEventListener('mousemove', handleMouseMove)
-    document.addEventListener('mouseup', handleMouseUp)
-  }, [isScrubbing, getProgressFromMouse, onSeek])
-  
-  // Handle keyboard controls
-  const handleKeyDown = useCallback((e: React.KeyboardEvent) => {
-    switch (e.key) {
-      case ' ':
-      case 'Enter':
-        e.preventDefault()
-        onPlayPause?.()
-        break
-      case 'ArrowLeft':
-        e.preventDefault()
-        const seekBack = e.shiftKey ? 10 : 5
-        const newProgressBack = Math.max(0, progress - seekBack / track.duration)
-        onSeek?.(newProgressBack)
-        break
-      case 'ArrowRight':
-        e.preventDefault()
-        const seekForward = e.shiftKey ? 10 : 5
-        const newProgressForward = Math.min(1, progress + seekForward / track.duration)
-        onSeek?.(newProgressForward)
-        break
-    }
-  }, [progress, track.duration, onPlayPause, onSeek])
+      observer.disconnect();
+      unload();
+    };
+  }, [data, mimeType]);
 
   return (
-    <div 
+    <img ref={imgRef} alt="Album Art" className={className} onClick={onClick} />
+  );
+}
+
+/**
+ * Renders a circular progress/seek control for playlist items. Colours are
+ * drawn from the active theme to avoid hard-coded hex values.
+ */
+function CircularProgressControl({
+  track,
+  size = 64,
+  progress = 0,
+  buffered = 0,
+  isPlaying = false,
+  onPlayPause,
+  onSeek,
+}: CircularProgressControlProps) {
+  const [isHovered, setIsHovered] = useState(false);
+  const [isScrubbing, setIsScrubbing] = useState(false);
+  const containerRef = useRef<HTMLDivElement>(null);
+  const theme = useSettingsStore((s) => s.theme);
+  const { accent, primary } = THEME_COLORS[theme];
+
+  // Calculate dimensions
+  const strokeWidth = 3;
+  const radius = (size - strokeWidth) / 2;
+  const circumference = 2 * Math.PI * radius;
+
+  // Calculate stroke dasharray for progress
+  const progressDasharray = `${progress * circumference} ${circumference}`;
+  const bufferedDasharray = `${buffered * circumference} ${circumference}`;
+
+  // Handle play/pause click
+  const handlePlayPause = useCallback(
+    (e: React.MouseEvent) => {
+      e.stopPropagation();
+      onPlayPause?.();
+    },
+    [onPlayPause],
+  );
+
+  // Calculate progress from mouse position
+  const getProgressFromMouse = useCallback(
+    (clientX: number, clientY: number): number => {
+      if (!containerRef.current) return 0;
+
+      const rect = containerRef.current.getBoundingClientRect();
+      const centerX = rect.left + rect.width / 2;
+      const centerY = rect.top + rect.height / 2;
+
+      // Calculate angle from center
+      const deltaX = clientX - centerX;
+      const deltaY = clientY - centerY;
+      const angle = Math.atan2(deltaY, deltaX) * (180 / Math.PI);
+
+      // Convert to 0-1 progress (starting from top, clockwise)
+      let progress = (angle + 90) / 360;
+      if (progress < 0) progress += 1;
+
+      return Math.max(0, Math.min(1, progress));
+    },
+    [],
+  );
+
+  // Handle ring click for seeking
+  const handleRingClick = useCallback(
+    (e: React.MouseEvent) => {
+      if (isScrubbing) return;
+
+      const newProgress = getProgressFromMouse(e.clientX, e.clientY);
+      onSeek?.(newProgress);
+    },
+    [isScrubbing, getProgressFromMouse, onSeek],
+  );
+
+  // Handle mouse down for scrubbing
+  const handleMouseDown = useCallback(
+    (e: React.MouseEvent) => {
+      e.preventDefault();
+      setIsScrubbing(true);
+
+      const handleMouseMove = (moveEvent: MouseEvent) => {
+        if (!isScrubbing) return;
+
+        const newProgress = getProgressFromMouse(
+          moveEvent.clientX,
+          moveEvent.clientY,
+        );
+        onSeek?.(newProgress);
+      };
+
+      const handleMouseUp = () => {
+        setIsScrubbing(false);
+        document.removeEventListener("mousemove", handleMouseMove);
+        document.removeEventListener("mouseup", handleMouseUp);
+      };
+
+      document.addEventListener("mousemove", handleMouseMove);
+      document.addEventListener("mouseup", handleMouseUp);
+    },
+    [isScrubbing, getProgressFromMouse, onSeek],
+  );
+
+  // Handle keyboard controls
+  const handleKeyDown = useCallback(
+    (e: React.KeyboardEvent) => {
+      switch (e.key) {
+        case " ":
+        case "Enter":
+          e.preventDefault();
+          onPlayPause?.();
+          break;
+        case "ArrowLeft":
+          e.preventDefault();
+          const seekBack = e.shiftKey ? 10 : 5;
+          const newProgressBack = Math.max(
+            0,
+            progress - seekBack / track.duration,
+          );
+          onSeek?.(newProgressBack);
+          break;
+        case "ArrowRight":
+          e.preventDefault();
+          const seekForward = e.shiftKey ? 10 : 5;
+          const newProgressForward = Math.min(
+            1,
+            progress + seekForward / track.duration,
+          );
+          onSeek?.(newProgressForward);
+          break;
+      }
+    },
+    [progress, track.duration, onPlayPause, onSeek],
+  );
+
+  return (
+    <div
       ref={containerRef}
       className="relative flex-shrink-0"
       onMouseEnter={() => setIsHovered(true)}
@@ -192,12 +237,16 @@ function CircularProgressControl({
       <div className="relative">
         {(() => {
           try {
-            if (track.artwork && track.artwork.data && track.artwork.data.length > 0) {
+            if (
+              track.artwork &&
+              track.artwork.data &&
+              track.artwork.data.length > 0
+            ) {
               const artworkData =
                 track.artwork.data instanceof Uint8Array
                   ? track.artwork.data
-                  : new Uint8Array(track.artwork.data)
-              const mimeType = track.artwork.mimeType || 'image/jpeg'
+                  : new Uint8Array(track.artwork.data);
+              const mimeType = track.artwork.mimeType || "image/jpeg";
 
               return (
                 <LazyAlbumArt
@@ -205,12 +254,15 @@ function CircularProgressControl({
                   mimeType={mimeType}
                   className="w-16 h-16 object-cover rounded-md transition-transform hover:scale-105"
                 />
-              )
+              );
             }
 
-            if (track.metadata.album_art && track.metadata.album_art.length > 0) {
-              const albumArtData = track.metadata.album_art
-              const mimeType = track.metadata.album_art_mime || 'image/jpeg'
+            if (
+              track.metadata.album_art &&
+              track.metadata.album_art.length > 0
+            ) {
+              const albumArtData = track.metadata.album_art;
+              const mimeType = track.metadata.album_art_mime || "image/jpeg";
 
               return (
                 <LazyAlbumArt
@@ -218,20 +270,20 @@ function CircularProgressControl({
                   mimeType={mimeType}
                   className="w-16 h-16 object-cover rounded-md transition-transform hover:scale-105"
                 />
-              )
+              );
             }
 
             return (
               <div className="w-16 h-16 bg-neutral-800 rounded-md flex items-center justify-center">
                 <FileAudio size={20} className="text-neutral-500" />
               </div>
-            )
+            );
           } catch (error) {
             return (
               <div className="w-16 h-16 bg-neutral-800 rounded-md flex items-center justify-center">
                 <FileAudio size={20} className="text-neutral-500" />
               </div>
-            )
+            );
           }
         })()}
       </div>
@@ -242,7 +294,7 @@ function CircularProgressControl({
           width={size}
           height={size}
           className="absolute inset-0"
-          style={{ transform: 'rotate(-90deg)' }}
+          style={{ transform: "rotate(-90deg)" }}
         >
           {/* Background track */}
           <circle
@@ -250,11 +302,11 @@ function CircularProgressControl({
             cy={size / 2}
             r={radius}
             fill="none"
-            stroke="#374151"
+            stroke={primary}
             strokeWidth={strokeWidth}
             opacity={0.3}
           />
-          
+
           {/* Buffered progress */}
           {buffered > 0 && (
             <circle
@@ -262,36 +314,36 @@ function CircularProgressControl({
               cy={size / 2}
               r={radius}
               fill="none"
-              stroke="#6b7280"
+              stroke={primary}
               strokeWidth={strokeWidth}
               strokeDasharray={bufferedDasharray}
               opacity={0.6}
             />
           )}
-          
+
           {/* Progress arc */}
           <circle
             cx={size / 2}
             cy={size / 2}
             r={radius}
             fill="none"
-            stroke="#3b82f6"
+            stroke={accent}
             strokeWidth={strokeWidth}
             strokeDasharray={progressDasharray}
             strokeLinecap="round"
             className="transition-all duration-300 ease-out"
           />
         </svg>
-        
+
         {/* Clickable ring area for seeking */}
         <div
           className="absolute inset-0 cursor-pointer"
           onClick={handleRingClick}
           onMouseDown={handleMouseDown}
-          style={{ transform: 'rotate(-90deg)' }}
+          style={{ transform: "rotate(-90deg)" }}
         />
       </div>
-      
+
       {/* Play/Pause Button */}
       <button
         className={cn(
@@ -299,29 +351,29 @@ function CircularProgressControl({
           "transition-all duration-300 ease-out",
           "bg-black/60 backdrop-blur-sm",
           isHovered && "bg-black/80 scale-105",
-          isScrubbing && "scale-110"
+          isScrubbing && "scale-110",
         )}
         onClick={handlePlayPause}
         onKeyDown={handleKeyDown}
         role="button"
         aria-pressed={isPlaying}
-        aria-label={`${isPlaying ? 'Pause' : 'Play'} ${track.metadata.title || track.file.name}`}
+        aria-label={`${isPlaying ? "Pause" : "Play"} ${track.metadata.title || track.file.name}`}
         tabIndex={0}
       >
         {isPlaying ? (
-          <Pause 
-            size={16} 
+          <Pause
+            size={16}
             className="text-white fill-white transition-transform duration-200"
           />
         ) : (
-          <Play 
-            size={16} 
+          <Play
+            size={16}
             className="text-white fill-white transition-transform duration-200 ml-0.5"
           />
         )}
       </button>
     </div>
-  )
+  );
 }
 
 export function PlaylistPanel({
@@ -333,146 +385,151 @@ export function PlaylistPanel({
   onTrackRemove,
   onTrackReorder,
 }: PlaylistPanelProps) {
-  const [dragIndex, setDragIndex] = useState<number | null>(null)
-  const [dropIndex, setDropIndex] = useState<number | null>(null)
-  const trackRefs = useRef<(HTMLDivElement | null)[]>([])
-  const { loadAudioFiles } = useAudioFile()
+  const [dragIndex, setDragIndex] = useState<number | null>(null);
+  const [dropIndex, setDropIndex] = useState<number | null>(null);
+  const trackRefs = useRef<(HTMLDivElement | null)[]>([]);
+  const { loadAudioFiles } = useAudioFile();
 
   const handlePanelDragOver = (event: React.DragEvent<HTMLDivElement>) => {
-    if (event.dataTransfer.types.includes('Files')) {
-      event.preventDefault()
-      event.dataTransfer.dropEffect = 'copy'
+    if (event.dataTransfer.types.includes("Files")) {
+      event.preventDefault();
+      event.dataTransfer.dropEffect = "copy";
     }
-  }
+  };
 
   const handlePanelDrop = async (event: React.DragEvent<HTMLDivElement>) => {
-    event.preventDefault()
-    const files = await getFilesFromDataTransfer(event.dataTransfer)
+    event.preventDefault();
+    const files = await getFilesFromDataTransfer(event.dataTransfer);
     if (files.length > 0) {
       try {
-        await loadAudioFiles(files)
+        await loadAudioFiles(files);
       } catch {
         // Ignore load errors
       }
     }
-  }
+  };
 
   const handleDragStart = (event: React.DragEvent, index: number) => {
-    setDragIndex(index)
-    event.dataTransfer.setData('text/plain', index.toString())
-    event.dataTransfer.effectAllowed = 'move'
-    
+    setDragIndex(index);
+    event.dataTransfer.setData("text/plain", index.toString());
+    event.dataTransfer.effectAllowed = "move";
+
     // Create a custom drag image
-    const dragElement = event.currentTarget as HTMLElement
-    const rect = dragElement.getBoundingClientRect()
-    const dragImage = dragElement.cloneNode(true) as HTMLElement
-    dragImage.style.width = `${rect.width}px`
-    dragImage.style.opacity = '0.8'
-    dragImage.style.transform = 'rotate(5deg)'
-    dragImage.style.pointerEvents = 'none'
-    document.body.appendChild(dragImage)
-    
-    event.dataTransfer.setDragImage(dragImage, rect.width / 2, rect.height / 2)
-    
+    const dragElement = event.currentTarget as HTMLElement;
+    const rect = dragElement.getBoundingClientRect();
+    const dragImage = dragElement.cloneNode(true) as HTMLElement;
+    dragImage.style.width = `${rect.width}px`;
+    dragImage.style.opacity = "0.8";
+    dragImage.style.transform = "rotate(5deg)";
+    dragImage.style.pointerEvents = "none";
+    document.body.appendChild(dragImage);
+
+    event.dataTransfer.setDragImage(dragImage, rect.width / 2, rect.height / 2);
+
     // Remove the drag image after a short delay
     setTimeout(() => {
       if (document.body.contains(dragImage)) {
-        document.body.removeChild(dragImage)
+        document.body.removeChild(dragImage);
       }
-    }, 100)
-  }
+    }, 100);
+  };
 
   const handleDragEnd = () => {
-    setDragIndex(null)
-    setDropIndex(null)
-  }
+    setDragIndex(null);
+    setDropIndex(null);
+  };
 
   const handleDragOver = (event: React.DragEvent, index: number) => {
-    event.preventDefault()
-    event.dataTransfer.dropEffect = 'move'
-    
+    event.preventDefault();
+    event.dataTransfer.dropEffect = "move";
+
     if (dragIndex !== null && dragIndex !== index) {
-      setDropIndex(index)
+      setDropIndex(index);
     }
-  }
+  };
 
   const handleDrop = (event: React.DragEvent, dropIndex: number) => {
     if (event.dataTransfer.files.length > 0) {
-      return
+      return;
     }
-    event.preventDefault()
-    const data = event.dataTransfer.getData('text/plain')
-    if (!data) return
-    const dragIndex = parseInt(data, 10)
+    event.preventDefault();
+    const data = event.dataTransfer.getData("text/plain");
+    if (!data) return;
+    const dragIndex = parseInt(data, 10);
     if (dragIndex !== dropIndex) {
-      onTrackReorder(dragIndex, dropIndex)
+      onTrackReorder(dragIndex, dropIndex);
     }
-    setDragIndex(null)
-    setDropIndex(null)
-  }
+    setDragIndex(null);
+    setDropIndex(null);
+  };
 
-  const { searchQuery, setSearchQuery } = usePlaylistSearchStore()
+  const { searchQuery, setSearchQuery } = usePlaylistSearchStore();
 
   const searchIndex = useMemo(
     () =>
       tracks.map((track, index) => ({
         index,
-        title: track.metadata.title?.toLowerCase() ?? '',
-        artist: track.metadata.artist?.toLowerCase() ?? '',
-        album: track.metadata.album?.toLowerCase() ?? '',
-        genre: track.metadata.genre?.toLowerCase() ?? '',
-        year: track.metadata.year ? String(track.metadata.year) : '',
+        title: track.metadata.title?.toLowerCase() ?? "",
+        artist: track.metadata.artist?.toLowerCase() ?? "",
+        album: track.metadata.album?.toLowerCase() ?? "",
+        genre: track.metadata.genre?.toLowerCase() ?? "",
+        year: track.metadata.year ? String(track.metadata.year) : "",
       })),
-    [tracks]
-  )
+    [tracks],
+  );
 
-  type SuggestionType = 'title' | 'artist' | 'album' | 'genre' | 'year'
+  type SuggestionType = "title" | "artist" | "album" | "genre" | "year";
 
   const allSuggestions = useMemo(() => {
-    const map = new Map<string, { value: string; type: SuggestionType }>()
+    const map = new Map<string, { value: string; type: SuggestionType }>();
     tracks.forEach((track) => {
-      const { title, artist, album, genre, year } = track.metadata
-      if (title) map.set(`title-${title}`, { value: title, type: 'title' })
-      if (artist) map.set(`artist-${artist}`, { value: artist, type: 'artist' })
-      if (album) map.set(`album-${album}`, { value: album, type: 'album' })
-      if (genre) map.set(`genre-${genre}`, { value: genre, type: 'genre' })
-      if (year) map.set(`year-${year}`, { value: String(year), type: 'year' })
-    })
-    return Array.from(map.values())
-  }, [tracks])
+      const { title, artist, album, genre, year } = track.metadata;
+      if (title) map.set(`title-${title}`, { value: title, type: "title" });
+      if (artist)
+        map.set(`artist-${artist}`, { value: artist, type: "artist" });
+      if (album) map.set(`album-${album}`, { value: album, type: "album" });
+      if (genre) map.set(`genre-${genre}`, { value: genre, type: "genre" });
+      if (year) map.set(`year-${year}`, { value: String(year), type: "year" });
+    });
+    return Array.from(map.values());
+  }, [tracks]);
 
-  const { items: suggestions, hasMore: hasMoreSuggestions, moreCount } = useMemo(() => {
-    const limit = 10
+  const {
+    items: suggestions,
+    hasMore: hasMoreSuggestions,
+    moreCount,
+  } = useMemo(() => {
+    const limit = 10;
     if (!searchQuery.trim()) {
       return {
         items: allSuggestions.slice(0, limit),
         hasMore: allSuggestions.length > limit,
         moreCount: Math.max(allSuggestions.length - limit, 0),
-      }
+      };
     }
-    const q = searchQuery.toLowerCase()
+    const q = searchQuery.toLowerCase();
     const scored = allSuggestions
       .map((s) => ({ ...s, score: fuzzyScore(q, s.value) }))
       .filter((s) => s.score !== Infinity)
-      .sort((a, b) => a.score - b.score)
+      .sort((a, b) => a.score - b.score);
     return {
       items: scored.slice(0, limit),
       hasMore: scored.length > limit,
       moreCount: Math.max(scored.length - limit, 0),
-    }
-  }, [allSuggestions, searchQuery])
+    };
+  }, [allSuggestions, searchQuery]);
 
   const typeSymbols: Record<SuggestionType, string> = {
-    title: '🎵',
-    artist: '👤',
-    album: '💿',
-    genre: '🎼',
-    year: '📅',
-  }
+    title: "🎵",
+    artist: "👤",
+    album: "💿",
+    genre: "🎼",
+    year: "📅",
+  };
 
   const filteredIndexes = useMemo(() => {
-    if (!searchQuery.trim()) return searchIndex.map((item) => item.index)
-    const q = searchQuery.toLowerCase()
+    if (!searchQuery.trim()) return searchIndex.map((item) => item.index);
+    const q = searchQuery.toLowerCase();
     return searchIndex
       .filter(
         (item) =>
@@ -480,23 +537,23 @@ export function PlaylistPanel({
           fuzzyMatch(q, item.artist) ||
           fuzzyMatch(q, item.album) ||
           fuzzyMatch(q, item.genre) ||
-          fuzzyMatch(q, item.year)
+          fuzzyMatch(q, item.year),
       )
-      .map((item) => item.index)
-  }, [searchIndex, searchQuery])
+      .map((item) => item.index);
+  }, [searchIndex, searchQuery]);
 
   const filteredTracks = useMemo(
     () => filteredIndexes.map((i) => tracks[i]),
-    [filteredIndexes, tracks]
-  )
+    [filteredIndexes, tracks],
+  );
 
   const totalDuration = filteredTracks.reduce(
     (total, track) => total + track.duration,
-    0
-  )
+    0,
+  );
 
   const renderAlbumArt = (track: AudioTrack, index: number) => {
-    const isCurrentTrack = currentTrackIndex === index
+    const isCurrentTrack = currentTrackIndex === index;
 
     if (track.isLoading) {
       return (
@@ -506,7 +563,7 @@ export function PlaylistPanel({
         >
           <Loader2 size={20} className="text-neutral-500 animate-spin" />
         </div>
-      )
+      );
     }
 
     if (isCurrentTrack) {
@@ -524,28 +581,27 @@ export function PlaylistPanel({
             // Seek to progress
           }}
         />
-      )
+      );
     }
-    
+
     // Regular album art for non-current tracks
     // Use the new artwork system if available
-    
-    
+
     if (track.artwork && track.artwork.data && track.artwork.data.length > 0) {
       try {
-        const artworkData = track.artwork.data
-        const mimeType = track.artwork.mimeType || 'image/jpeg'
+        const artworkData = track.artwork.data;
+        const mimeType = track.artwork.mimeType || "image/jpeg";
 
         // Validate the data before creating blob
         if (artworkData.length < 100) {
-          return renderFallbackAlbumArt(index)
+          return renderFallbackAlbumArt(index);
         }
 
         // Ensure we have a Uint8Array
         const dataArray =
           artworkData instanceof Uint8Array
             ? artworkData
-            : new Uint8Array(artworkData)
+            : new Uint8Array(artworkData);
 
         return (
           <div className="relative flex-shrink-0">
@@ -556,21 +612,21 @@ export function PlaylistPanel({
               onClick={() => onTrackSelect(index)}
             />
           </div>
-        )
+        );
       } catch (error) {
-        return renderFallbackAlbumArt(index)
+        return renderFallbackAlbumArt(index);
       }
     }
 
     // Fallback to old metadata album art if available
     if (track.metadata.album_art && track.metadata.album_art.length > 0) {
       try {
-        const albumArtData = track.metadata.album_art
-        const mimeType = track.metadata.album_art_mime || 'image/jpeg'
+        const albumArtData = track.metadata.album_art;
+        const mimeType = track.metadata.album_art_mime || "image/jpeg";
 
         // Validate the data before creating blob
         if (albumArtData.length < 100) {
-          return renderFallbackAlbumArt(index)
+          return renderFallbackAlbumArt(index);
         }
 
         return (
@@ -582,15 +638,15 @@ export function PlaylistPanel({
               onClick={() => onTrackSelect(index)}
             />
           </div>
-        )
+        );
       } catch (error) {
-        return renderFallbackAlbumArt(index)
+        return renderFallbackAlbumArt(index);
       }
     }
-    
+
     // Fallback album art placeholder
-    return renderFallbackAlbumArt(index)
-  }
+    return renderFallbackAlbumArt(index);
+  };
 
   const renderFallbackAlbumArt = (index: number) => (
     <div
@@ -599,7 +655,7 @@ export function PlaylistPanel({
     >
       <FileAudio size={20} className="text-neutral-500" />
     </div>
-  )
+  );
 
   return (
     <div
@@ -631,7 +687,10 @@ export function PlaylistPanel({
           className="w-full px-2 py-1 bg-neutral-900 rounded-md text-sm text-neutral-100 border border-neutral-800 focus:outline-none focus:ring-1 focus:ring-accent-blue"
           data-testid="playlist-search-input"
         />
-        <datalist id="playlist-search-suggestions" data-testid="playlist-search-suggestions">
+        <datalist
+          id="playlist-search-suggestions"
+          data-testid="playlist-search-suggestions"
+        >
           {suggestions.map((s) => (
             <option
               key={`${s.type}-${s.value}`}
@@ -667,9 +726,9 @@ export function PlaylistPanel({
         ) : (
           <div className="p-1 space-y-1">
             {filteredIndexes.map((originalIndex) => {
-              const track = tracks[originalIndex]
-              const isDragging = dragIndex === originalIndex
-              const isDropTarget = dropIndex === originalIndex
+              const track = tracks[originalIndex];
+              const isDragging = dragIndex === originalIndex;
+              const isDropTarget = dropIndex === originalIndex;
 
               return (
                 <div
@@ -681,12 +740,13 @@ export function PlaylistPanel({
                   onDragOver={(e) => handleDragOver(e, originalIndex)}
                   onDrop={(e) => handleDrop(e, originalIndex)}
                   className={cn(
-                    'group flex items-center gap-3 p-2 rounded-md cursor-pointer transition-all duration-300 ease-out',
-                    'hover:bg-neutral-800 hover:shadow-sm',
-                    'border border-transparent hover:border-neutral-700',
-                    currentTrackIndex === originalIndex && 'bg-neutral-800 border-neutral-600 shadow-sm',
-                    isDragging && 'opacity-50 scale-95 rotate-1 z-50',
-                    isDropTarget && 'bg-neutral-700/30'
+                    "group flex items-center gap-3 p-2 rounded-md cursor-pointer transition-all duration-300 ease-out",
+                    "hover:bg-neutral-800 hover:shadow-sm",
+                    "border border-transparent hover:border-neutral-700",
+                    currentTrackIndex === originalIndex &&
+                      "bg-neutral-800 border-neutral-600 shadow-sm",
+                    isDragging && "opacity-50 scale-95 rotate-1 z-50",
+                    isDropTarget && "bg-neutral-700/30",
                   )}
                   onClick={() => onTrackSelect(originalIndex)}
                 >
@@ -699,10 +759,10 @@ export function PlaylistPanel({
                     <div className="mb-1">
                       <h4
                         className={cn(
-                          'text-sm font-medium truncate',
+                          "text-sm font-medium truncate",
                           currentTrackIndex === originalIndex
-                            ? 'text-accent-blue'
-                            : 'text-neutral-100'
+                            ? "text-accent-blue"
+                            : "text-neutral-100",
                         )}
                       >
                         {track.metadata.title || track.file.name}
@@ -712,7 +772,7 @@ export function PlaylistPanel({
                     {/* Artist and Duration - Second most important */}
                     <div className="flex items-center justify-between text-xs text-neutral-400 mb-0.5">
                       <span className="truncate">
-                        {track.metadata.artist || 'Unknown Artist'}
+                        {track.metadata.artist || "Unknown Artist"}
                       </span>
                       <span className="flex-shrink-0 ml-2 text-neutral-500">
                         {formatDuration(track.duration)}
@@ -731,12 +791,12 @@ export function PlaylistPanel({
                   <div className="flex items-center gap-1 opacity-0 group-hover:opacity-100 transition-opacity absolute right-2">
                     <button
                       onClick={(e) => {
-                        e.stopPropagation()
-                        onTrackRemove(originalIndex)
+                        e.stopPropagation();
+                        onTrackRemove(originalIndex);
                       }}
                       className={cn(
-                        'p-1.5 rounded transition-colors',
-                        'text-neutral-400 hover:text-red-400 hover:bg-red-400/10'
+                        "p-1.5 rounded transition-colors",
+                        "text-neutral-400 hover:text-red-400 hover:bg-red-400/10",
                       )}
                       title="Remove from playlist"
                     >
@@ -744,7 +804,7 @@ export function PlaylistPanel({
                     </button>
                   </div>
                 </div>
-              )
+              );
             })}
           </div>
         )}
@@ -756,7 +816,8 @@ export function PlaylistPanel({
           <div className="flex items-center justify-between text-xs">
             <div className="flex flex-col gap-0.5">
               <span className="text-neutral-300 font-medium">
-                {filteredTracks.length} track{filteredTracks.length !== 1 ? 's' : ''}
+                {filteredTracks.length} track
+                {filteredTracks.length !== 1 ? "s" : ""}
               </span>
               <span className="text-neutral-400">
                 {formatDuration(totalDuration)}
@@ -769,5 +830,5 @@ export function PlaylistPanel({
         </div>
       )}
     </div>
-  )
+  );
 }

--- a/web/apps/mfe-spectrogram/src/index.css
+++ b/web/apps/mfe-spectrogram/src/index.css
@@ -11,8 +11,9 @@
   be further overridden via settings.
 */
 :root {
-  --accent-color: #3b82f6;
-  --primary-color: #6b7280;
+  /* Default colours mirror the japanese-a-light theme: black on white. */
+  --accent-color: #000000;
+  --primary-color: #000000;
   /* Seekbar theme variables */
   --seek-played: var(--accent-color);
   --seek-unplayed: var(--primary-color);
@@ -43,6 +44,40 @@
 .theme-high-contrast {
   --accent-color: #ffffff;
   --primary-color: #000000;
+}
+
+/* Minimal black/white theme inspired by traditional Japanese design */
+.theme-japanese-a-light {
+  --accent-color: #000000;
+  --primary-color: #000000;
+}
+
+/* Dark inversion of the monochrome Japanese palette */
+.theme-japanese-a-dark {
+  --accent-color: #ffffff;
+  --primary-color: #ffffff;
+}
+
+/* Japanese flag motif: red sun with black or white text */
+.theme-japanese-b-light {
+  --accent-color: #e60026;
+  --primary-color: #000000;
+}
+
+.theme-japanese-b-dark {
+  --accent-color: #e60026;
+  --primary-color: #ffffff;
+}
+
+/* Bauhaus primary colour blocks */
+.theme-bauhaus-light {
+  --accent-color: #ff0000;
+  --primary-color: #0000ff;
+}
+
+.theme-bauhaus-dark {
+  --accent-color: #ff0000;
+  --primary-color: #ffff00;
 }
 
 /* Custom scrollbar styles */

--- a/web/apps/mfe-spectrogram/src/shared/stores/settingsStore.test.ts
+++ b/web/apps/mfe-spectrogram/src/shared/stores/settingsStore.test.ts
@@ -41,6 +41,22 @@ describe("settingsStore seekbar configuration", () => {
     expect(useSettingsStore.getState().seekPlayedColor).toBe("");
   });
 
+  it("uses a safe default theme and sanitises loaded theme", () => {
+    // Default theme should be the conservative japanese-a-light palette.
+    expect(useSettingsStore.getState().theme).toBe("japanese-a-light");
+    // Invalid theme strings should revert to the default.
+    localStorage.setItem(STORAGE_KEY, JSON.stringify({ theme: "invalid" }));
+    useSettingsStore.getState().loadFromStorage();
+    expect(useSettingsStore.getState().theme).toBe("japanese-a-light");
+    // Supported themes should persist correctly.
+    localStorage.setItem(
+      STORAGE_KEY,
+      JSON.stringify({ theme: "bauhaus-dark" }),
+    );
+    useSettingsStore.getState().loadFromStorage();
+    expect(useSettingsStore.getState().theme).toBe("bauhaus-dark");
+  });
+
   it("sanitises loaded settings", () => {
     localStorage.setItem(
       STORAGE_KEY,
@@ -55,7 +71,8 @@ describe("settingsStore seekbar configuration", () => {
     const state = useSettingsStore.getState();
     expect(state.seekbarMode).toBe("waveform");
     expect(state.seekbarSignificance).toBe(1);
-    expect(state.seekbarAmplitudeScale).toBe(1);
+    // Invalid amplitude scale falls back to default (8) rather than 1.
+    expect(state.seekbarAmplitudeScale).toBe(8);
     expect(state.seekPlayedColor).toBe("");
   });
 });

--- a/web/apps/mfe-spectrogram/src/shared/stores/settingsStore.ts
+++ b/web/apps/mfe-spectrogram/src/shared/stores/settingsStore.ts
@@ -66,7 +66,8 @@ interface SettingsStore extends SpectrogramSettings {
 
 /** Default settings used when no user overrides are present. */
 const defaultSettings: SpectrogramSettings = {
-  theme: "dark",
+  // Conservative monochrome theme avoids overly bright colours by default.
+  theme: "japanese-a-light",
   amplitudeScale: "db",
   frequencyScale: "logarithmic",
   resolution: "medium",
@@ -135,20 +136,31 @@ function sanitiseSettings(input: any): SpectrogramSettings {
     result.theme = input.theme as Theme;
 
   // Spectrogram settings
-  if (typeof input.amplitudeScale === "string" && ["linear", "logarithmic", "db"].includes(input.amplitudeScale))
+  if (
+    typeof input.amplitudeScale === "string" &&
+    ["linear", "logarithmic", "db"].includes(input.amplitudeScale)
+  )
     result.amplitudeScale = input.amplitudeScale as AmplitudeScale;
 
-  if (typeof input.frequencyScale === "string" && ["linear", "logarithmic"].includes(input.frequencyScale))
+  if (
+    typeof input.frequencyScale === "string" &&
+    ["linear", "logarithmic"].includes(input.frequencyScale)
+  )
     result.frequencyScale = input.frequencyScale as FrequencyScale;
 
-  if (typeof input.resolution === "string" && ["low", "medium", "high"].includes(input.resolution))
+  if (
+    typeof input.resolution === "string" &&
+    ["low", "medium", "high"].includes(input.resolution)
+  )
     result.resolution = input.resolution as Resolution;
 
-  if (typeof input.refreshRate === "number" && [30, 60].includes(input.refreshRate))
+  if (
+    typeof input.refreshRate === "number" &&
+    [30, 60].includes(input.refreshRate)
+  )
     result.refreshRate = input.refreshRate as RefreshRate;
 
-  if (typeof input.colormap === "string")
-    result.colormap = input.colormap;
+  if (typeof input.colormap === "string") result.colormap = input.colormap;
 
   if (typeof input.showLegend === "boolean")
     result.showLegend = input.showLegend;
@@ -189,20 +201,36 @@ function sanitiseSettings(input: any): SpectrogramSettings {
   // API Keys
   if (typeof input.apiKeys === "object" && input.apiKeys) {
     result.apiKeys = {
-      acoustid: typeof input.apiKeys.acoustid === "string" ? input.apiKeys.acoustid : "",
-      musicbrainz: typeof input.apiKeys.musicbrainz === "string" ? input.apiKeys.musicbrainz : "",
+      acoustid:
+        typeof input.apiKeys.acoustid === "string"
+          ? input.apiKeys.acoustid
+          : "",
+      musicbrainz:
+        typeof input.apiKeys.musicbrainz === "string"
+          ? input.apiKeys.musicbrainz
+          : "",
     };
   }
 
   if (typeof input.apiKeyStatus === "object" && input.apiKeyStatus) {
     result.apiKeyStatus = {
-      acoustid: { 
-        valid: typeof input.apiKeyStatus.acoustid?.valid === "boolean" ? input.apiKeyStatus.acoustid.valid : false,
-        lastChecked: input.apiKeyStatus.acoustid?.lastChecked ? new Date(input.apiKeyStatus.acoustid.lastChecked) : undefined,
+      acoustid: {
+        valid:
+          typeof input.apiKeyStatus.acoustid?.valid === "boolean"
+            ? input.apiKeyStatus.acoustid.valid
+            : false,
+        lastChecked: input.apiKeyStatus.acoustid?.lastChecked
+          ? new Date(input.apiKeyStatus.acoustid.lastChecked)
+          : undefined,
       },
-      musicbrainz: { 
-        valid: typeof input.apiKeyStatus.musicbrainz?.valid === "boolean" ? input.apiKeyStatus.musicbrainz.valid : false,
-        lastChecked: input.apiKeyStatus.musicbrainz?.lastChecked ? new Date(input.apiKeyStatus.musicbrainz.lastChecked) : undefined,
+      musicbrainz: {
+        valid:
+          typeof input.apiKeyStatus.musicbrainz?.valid === "boolean"
+            ? input.apiKeyStatus.musicbrainz.valid
+            : false,
+        lastChecked: input.apiKeyStatus.musicbrainz?.lastChecked
+          ? new Date(input.apiKeyStatus.musicbrainz.lastChecked)
+          : undefined,
       },
     };
   }
@@ -221,18 +249,23 @@ function sanitiseSettings(input: any): SpectrogramSettings {
     result.enablePlaceholderArtwork = input.enablePlaceholderArtwork;
 
   // LUT settings
-  if (typeof input.lutMode === "string" && ["builtin", "custom", "file"].includes(input.lutMode))
+  if (
+    typeof input.lutMode === "string" &&
+    ["builtin", "custom", "file"].includes(input.lutMode)
+  )
     result.lutMode = input.lutMode as LUTMode;
 
   if (input.currentLUT && typeof input.currentLUT === "object")
     result.currentLUT = input.currentLUT as LUT;
 
   if (Array.isArray(input.customLUTs))
-    result.customLUTs = input.customLUTs.filter(lut => 
-      lut && typeof lut === "object" && 
-      typeof lut.id === "string" && 
-      typeof lut.name === "string" &&
-      Array.isArray(lut.entries)
+    result.customLUTs = input.customLUTs.filter(
+      (lut) =>
+        lut &&
+        typeof lut === "object" &&
+        typeof lut.id === "string" &&
+        typeof lut.name === "string" &&
+        Array.isArray(lut.entries),
     ) as LUT[];
 
   return result;
@@ -243,10 +276,13 @@ export const useSettingsStore = create<SettingsStore>()(
     ...defaultSettings,
 
     setTheme: (theme) => set((state) => ({ ...state, theme })),
-    setAmplitudeScale: (amplitudeScale) => set((state) => ({ ...state, amplitudeScale })),
-    setFrequencyScale: (frequencyScale) => set((state) => ({ ...state, frequencyScale })),
+    setAmplitudeScale: (amplitudeScale) =>
+      set((state) => ({ ...state, amplitudeScale })),
+    setFrequencyScale: (frequencyScale) =>
+      set((state) => ({ ...state, frequencyScale })),
     setResolution: (resolution) => set((state) => ({ ...state, resolution })),
-    setRefreshRate: (refreshRate) => set((state) => ({ ...state, refreshRate })),
+    setRefreshRate: (refreshRate) =>
+      set((state) => ({ ...state, refreshRate })),
     setColormap: (colormap) => set((state) => ({ ...state, colormap })),
     setShowLegend: (showLegend) => set((state) => ({ ...state, showLegend })),
     setEnableToastNotifications: (enableToastNotifications) =>
@@ -258,10 +294,16 @@ export const useSettingsStore = create<SettingsStore>()(
       set((state) => ({ ...state, seekUnplayedColor: sanitiseColor(color) })),
     setSeekPlayheadColor: (color) =>
       set((state) => ({ ...state, seekPlayheadColor: sanitiseColor(color) })),
-    setShowSeekbarPlayhead: (show) => set((state) => ({ ...state, showSeekbarPlayhead: show })),
+    setShowSeekbarPlayhead: (show) =>
+      set((state) => ({ ...state, showSeekbarPlayhead: show })),
     // Reset both colours back to theme-driven defaults in one cheap update.
     resetSeekbarColors: () =>
-      set((state) => ({ ...state, seekPlayedColor: "", seekUnplayedColor: "", seekPlayheadColor: "" })),
+      set((state) => ({
+        ...state,
+        seekPlayedColor: "",
+        seekUnplayedColor: "",
+        seekPlayheadColor: "",
+      })),
 
     // Seek bar configuration setters with basic validation to fail fast on
     // invalid input. Each setter clamps or verifies inputs instead of silently
@@ -406,32 +448,37 @@ export const useSettingsStore = create<SettingsStore>()(
     // Artwork settings actions
     setEnableExternalArtwork: (enable) =>
       set((state) => ({ ...state, enableExternalArtwork: enable })),
-    setEnableAcoustID: (enable) => set((state) => ({ ...state, enableAcoustID: enable })),
-    setEnableMusicBrainz: (enable) => set((state) => ({ ...state, enableMusicBrainz: enable })),
+    setEnableAcoustID: (enable) =>
+      set((state) => ({ ...state, enableAcoustID: enable })),
+    setEnableMusicBrainz: (enable) =>
+      set((state) => ({ ...state, enableMusicBrainz: enable })),
     setEnablePlaceholderArtwork: (enable) =>
       set((state) => ({ ...state, enablePlaceholderArtwork: enable })),
 
     // LUT actions
     setLUTMode: (mode) => set((state) => ({ ...state, lutMode: mode })),
-    
+
     setCurrentLUT: (lut) => set((state) => ({ ...state, currentLUT: lut })),
-    
-    addCustomLUT: (lut) => set((state) => ({
-      ...state,
-      customLUTs: [...state.customLUTs, lut]
-    })),
-    
-    removeCustomLUT: (id) => set((state) => ({
-      ...state,
-      customLUTs: state.customLUTs.filter(l => l.id !== id)
-    })),
-    
-    updateCustomLUT: (id, updates) => set((state) => ({
-      ...state,
-      customLUTs: state.customLUTs.map(l => 
-        l.id === id ? { ...l, ...updates } : l
-      )
-    })),
+
+    addCustomLUT: (lut) =>
+      set((state) => ({
+        ...state,
+        customLUTs: [...state.customLUTs, lut],
+      })),
+
+    removeCustomLUT: (id) =>
+      set((state) => ({
+        ...state,
+        customLUTs: state.customLUTs.filter((l) => l.id !== id),
+      })),
+
+    updateCustomLUT: (id, updates) =>
+      set((state) => ({
+        ...state,
+        customLUTs: state.customLUTs.map((l) =>
+          l.id === id ? { ...l, ...updates } : l,
+        ),
+      })),
   })),
 );
 

--- a/web/apps/mfe-spectrogram/src/shared/theme.ts
+++ b/web/apps/mfe-spectrogram/src/shared/theme.ts
@@ -10,15 +10,56 @@ import { Theme } from "@/shared/types";
  * Both accent and primary colors are hex strings and intentionally kept
  * minimal to reduce memory and avoid runtime color computation.
  */
-export const THEME_COLORS: Record<Theme, { accent: string; primary: string }> =
-  {
-    // Classic dark theme: blue accents with neutral grays.
-    dark: { accent: "#3b82f6", primary: "#6b7280" },
-    // Light theme uses slightly darker blues and lighter grays for contrast.
-    light: { accent: "#2563eb", primary: "#9ca3af" },
-    // Neon theme favours a vivid teal accent; primary remains neutral to
-    // prevent eye strain despite the bright palette.
-    neon: { accent: "#14b8a6", primary: "#a3a3a3" },
-    // High contrast aims for maximal legibility: white accent on black primary.
-    "high-contrast": { accent: "#ffffff", primary: "#000000" },
-  } as const;
+export const THEME_COLORS: Record<
+  Theme,
+  { accent: string; primary: string; background: string }
+> = {
+  // Classic dark theme: blue accents with neutral grays on near-black base.
+  dark: { accent: "#3b82f6", primary: "#6b7280", background: "#0a0a0a" },
+  // Light theme mirrors dark but with brighter base and slightly darker accent.
+  light: { accent: "#2563eb", primary: "#9ca3af", background: "#ffffff" },
+  // Neon theme favours vivid teal accents on a dark base for maximum pop.
+  neon: { accent: "#14b8a6", primary: "#a3a3a3", background: "#0a0a0a" },
+  // High contrast maximises legibility: white elements on pure black base.
+  "high-contrast": {
+    accent: "#ffffff",
+    primary: "#000000",
+    background: "#000000",
+  },
+  // Japanese A: strict black and white; light uses white canvas with black ink.
+  "japanese-a-light": {
+    accent: "#000000",
+    primary: "#000000",
+    background: "#ffffff",
+  },
+  // Japanese A dark flips the monochrome scheme for night viewing.
+  "japanese-a-dark": {
+    accent: "#ffffff",
+    primary: "#ffffff",
+    background: "#000000",
+  },
+  // Japanese B introduces the flag's red sun against neutral companions.
+  "japanese-b-light": {
+    accent: "#e60026",
+    primary: "#000000",
+    background: "#ffffff",
+  },
+  // Japanese B dark keeps the red accent while swapping text to white.
+  "japanese-b-dark": {
+    accent: "#e60026",
+    primary: "#ffffff",
+    background: "#000000",
+  },
+  // Bauhaus light draws from modernist primaries: red accents, blue primaries.
+  "bauhaus-light": {
+    accent: "#ff0000",
+    primary: "#0000ff",
+    background: "#ffffff",
+  },
+  // Bauhaus dark uses red on yellow with black backdrop for stark blocks.
+  "bauhaus-dark": {
+    accent: "#ff0000",
+    primary: "#ffff00",
+    background: "#000000",
+  },
+} as const;

--- a/web/apps/mfe-spectrogram/src/shared/types/index.ts
+++ b/web/apps/mfe-spectrogram/src/shared/types/index.ts
@@ -120,7 +120,23 @@ export interface AudioTrack {
 }
 
 export interface SpectrogramSettings {
-  theme: "dark" | "light" | "neon" | "high-contrast";
+  /**
+   * Name of the active UI colour theme.
+   * Expanded to cover experimental palettes including Japanese-inspired
+   * monochrome and red-accented variants, plus Bauhaus primary colours.
+   * Using a string union ensures only supported themes persist in settings.
+   */
+  theme:
+    | "dark"
+    | "light"
+    | "neon"
+    | "high-contrast"
+    | "japanese-a-light"
+    | "japanese-a-dark"
+    | "japanese-b-light"
+    | "japanese-b-dark"
+    | "bauhaus-light"
+    | "bauhaus-dark";
   amplitudeScale: "linear" | "logarithmic" | "db";
   frequencyScale: "linear" | "logarithmic";
   resolution: "low" | "medium" | "high";
@@ -322,7 +338,21 @@ export interface SettingsPanelProps {
 }
 
 // Utility types
-export type Theme = "dark" | "light" | "neon" | "high-contrast";
+/**
+ * Enumerates all supported theme identifiers. These drive look-and-feel
+ * selection across the application and gate persisted values.
+ */
+export type Theme =
+  | "dark"
+  | "light"
+  | "neon"
+  | "high-contrast"
+  | "japanese-a-light"
+  | "japanese-a-dark"
+  | "japanese-b-light"
+  | "japanese-b-dark"
+  | "bauhaus-light"
+  | "bauhaus-dark";
 export type AmplitudeScale = "linear" | "logarithmic" | "db";
 export type FrequencyScale = "linear" | "logarithmic";
 export type Resolution = "low" | "medium" | "high";
@@ -330,19 +360,19 @@ export type RefreshRate = 30 | 60;
 
 // LUT (Look-Up Table) types
 export interface LUTEntry {
-  position: number // 0.0 to 1.0
-  color: [number, number, number, number] // RGBA values
+  position: number; // 0.0 to 1.0
+  color: [number, number, number, number]; // RGBA values
 }
 
 export interface LUT {
-  id: string
-  name: string
-  description?: string
-  entries: LUTEntry[]
-  interpolation: 'linear' | 'cubic' | 'step'
+  id: string;
+  name: string;
+  description?: string;
+  entries: LUTEntry[];
+  interpolation: "linear" | "cubic" | "step";
 }
 
-export type LUTMode = 'builtin' | 'custom' | 'file'
+export type LUTMode = "builtin" | "custom" | "file";
 
 // WASM types
 export interface WASMModule {

--- a/web/apps/mfe-spectrogram/src/shared/utils/toast.ts
+++ b/web/apps/mfe-spectrogram/src/shared/utils/toast.ts
@@ -1,69 +1,82 @@
-import toast from 'react-hot-toast'
-import { useSettingsStore } from '@/stores/settingsStore'
+import toast from "react-hot-toast";
+import { useSettingsStore } from "@/stores/settingsStore";
+import { THEME_COLORS } from "@/shared/theme";
 
-// Conditional toast function that respects the user's settings
+// Conditional toast function that respects the user's settings.
+// Colours are pulled from THEME_COLORS so toasts match the active light/dark
+// palette without embedding hex codes.
 export const conditionalToast = {
   success: (message: string) => {
-    const { enableToastNotifications } = useSettingsStore.getState()
+    const { enableToastNotifications } = useSettingsStore.getState();
     if (enableToastNotifications) {
-      toast.success(message)
+      toast.success(message);
     }
   },
-  
+
   error: (message: string) => {
-    const { enableToastNotifications } = useSettingsStore.getState()
+    const { enableToastNotifications } = useSettingsStore.getState();
     if (enableToastNotifications) {
-      toast.error(message)
+      toast.error(message);
     }
   },
-  
+
   warning: (message: string) => {
-    const { enableToastNotifications } = useSettingsStore.getState()
+    const { enableToastNotifications } = useSettingsStore.getState();
     if (enableToastNotifications) {
       toast(message, {
-        icon: '⚠️',
-        style: {
-          borderRadius: '10px',
-          background: '#333',
-          color: '#fff',
-        },
-      })
+        icon: "⚠️",
+        style: (() => {
+          const { theme } = useSettingsStore.getState();
+          const { accent, background } = THEME_COLORS[theme];
+          return {
+            borderRadius: "10px",
+            background,
+            color: accent,
+          };
+        })(),
+      });
     }
   },
-  
+
   info: (message: string) => {
-    const { enableToastNotifications } = useSettingsStore.getState()
+    const { enableToastNotifications } = useSettingsStore.getState();
     if (enableToastNotifications) {
       toast(message, {
-        icon: 'ℹ️',
-        style: {
-          borderRadius: '10px',
-          background: '#333',
-          color: '#fff',
-        },
-      })
+        icon: "ℹ️",
+        style: (() => {
+          const { theme } = useSettingsStore.getState();
+          const { accent, background } = THEME_COLORS[theme];
+          return {
+            borderRadius: "10px",
+            background,
+            color: accent,
+          };
+        })(),
+      });
     }
-  }
-}
+  },
+};
 
 // Direct toast functions (always show, regardless of settings)
 export const directToast = {
   success: toast.success,
   error: toast.error,
-  warning: (message: string) => toast(message, {
-    icon: '⚠️',
-    style: {
-      borderRadius: '10px',
-      background: '#333',
-      color: '#fff',
-    },
-  }),
-  info: (message: string) => toast(message, {
-    icon: 'ℹ️',
-    style: {
-      borderRadius: '10px',
-      background: '#333',
-      color: '#fff',
-    },
-  })
-}
+  warning: (message: string) =>
+    toast(message, {
+      icon: "⚠️",
+      style: (() => {
+        const { theme } = useSettingsStore.getState();
+        const { accent, background } = THEME_COLORS[theme];
+        return { borderRadius: "10px", background, color: accent };
+      })(),
+    }),
+  info: (message: string) =>
+    toast(message, {
+      icon: "ℹ️",
+      style: (() => {
+        const { theme } = useSettingsStore.getState();
+        const { accent, background } = THEME_COLORS[theme];
+        return { borderRadius: "10px", background, color: accent };
+      })(),
+    }),
+};

--- a/web/apps/mfe-spectrogram/src/types/index.ts
+++ b/web/apps/mfe-spectrogram/src/types/index.ts
@@ -120,7 +120,23 @@ export interface AudioTrack {
 }
 
 export interface SpectrogramSettings {
-  theme: "dark" | "light" | "neon" | "high-contrast";
+  /**
+   * Name of the active UI colour theme.
+   * Expanded to cover experimental palettes including Japanese-inspired
+   * monochrome and red-accented variants, plus Bauhaus primary colours.
+   * Using a string union ensures only supported themes persist in settings.
+   */
+  theme:
+    | "dark"
+    | "light"
+    | "neon"
+    | "high-contrast"
+    | "japanese-a-light"
+    | "japanese-a-dark"
+    | "japanese-b-light"
+    | "japanese-b-dark"
+    | "bauhaus-light"
+    | "bauhaus-dark";
   amplitudeScale: "linear" | "logarithmic" | "db";
   frequencyScale: "linear" | "logarithmic";
   resolution: "low" | "medium" | "high";
@@ -324,7 +340,21 @@ export interface SettingsPanelProps {
 }
 
 // Utility types
-export type Theme = "dark" | "light" | "neon" | "high-contrast";
+/**
+ * Enumerates all supported theme identifiers. These drive look-and-feel
+ * selection across the application and gate persisted values.
+ */
+export type Theme =
+  | "dark"
+  | "light"
+  | "neon"
+  | "high-contrast"
+  | "japanese-a-light"
+  | "japanese-a-dark"
+  | "japanese-b-light"
+  | "japanese-b-dark"
+  | "bauhaus-light"
+  | "bauhaus-dark";
 export type AmplitudeScale = "linear" | "logarithmic" | "db";
 export type FrequencyScale = "linear" | "logarithmic";
 export type Resolution = "low" | "medium" | "high";

--- a/web/apps/mfe-spectrogram/src/utils/__tests__/keyboard.test.ts
+++ b/web/apps/mfe-spectrogram/src/utils/__tests__/keyboard.test.ts
@@ -1,4 +1,5 @@
-import { describe, it, expect } from 'vitest'
+// @vitest-environment jsdom
+import { describe, it, expect } from "vitest";
 import {
   parseKeyCombo,
   isKeyComboPressed,
@@ -7,102 +8,113 @@ import {
   saveShortcuts,
   loadShortcuts,
   SHORTCUTS_STORAGE_KEY,
-} from '../keyboard'
+} from "../keyboard";
 
-describe('Keyboard Utils', () => {
-  describe('parseKeyCombo', () => {
-    it('parses simple key combinations', () => {
-      expect(parseKeyCombo('a')).toEqual(['a'])
-      expect(parseKeyCombo('space')).toEqual(['space'])
-    })
+describe("Keyboard Utils", () => {
+  describe("parseKeyCombo", () => {
+    it("parses simple key combinations", () => {
+      expect(parseKeyCombo("a")).toEqual(["a"]);
+      expect(parseKeyCombo("space")).toEqual(["space"]);
+    });
 
-    it('parses modifier key combinations', () => {
-      expect(parseKeyCombo('Control+Shift+s')).toEqual(['control', 'shift', 's'])
-      expect(parseKeyCombo('Alt+Enter')).toEqual(['alt', 'enter'])
-    })
+    it("parses modifier key combinations", () => {
+      expect(parseKeyCombo("Control+Shift+s")).toEqual([
+        "control",
+        "shift",
+        "s",
+      ]);
+      expect(parseKeyCombo("Alt+Enter")).toEqual(["alt", "enter"]);
+    });
 
-    it('handles whitespace', () => {
-      expect(parseKeyCombo(' Control + Shift + S ')).toEqual(['control', 'shift', 's'])
-    })
+    it("handles whitespace", () => {
+      expect(parseKeyCombo(" Control + Shift + S ")).toEqual([
+        "control",
+        "shift",
+        "s",
+      ]);
+    });
 
-    it('normalizes meta key aliases', () => {
-      expect(parseKeyCombo('Cmd+S')).toEqual(['meta', 's'])
-      expect(parseKeyCombo('Command+S')).toEqual(['meta', 's'])
-    })
-  })
+    it("normalizes meta key aliases", () => {
+      expect(parseKeyCombo("Cmd+S")).toEqual(["meta", "s"]);
+      expect(parseKeyCombo("Command+S")).toEqual(["meta", "s"]);
+    });
+  });
 
-  describe('isKeyComboPressed', () => {
-    it('matches simple keys', () => {
-      const event = new KeyboardEvent('keydown', { key: 'a' })
-      expect(isKeyComboPressed(event, 'a')).toBe(true)
-      expect(isKeyComboPressed(event, 'b')).toBe(false)
-    })
+  describe("isKeyComboPressed", () => {
+    it("matches simple keys", () => {
+      const event = new KeyboardEvent("keydown", { key: "a" });
+      expect(isKeyComboPressed(event, "a")).toBe(true);
+      expect(isKeyComboPressed(event, "b")).toBe(false);
+    });
 
-    it('matches modifier combinations', () => {
-      const event = new KeyboardEvent('keydown', { 
-        key: 's',
+    it("matches modifier combinations", () => {
+      const event = new KeyboardEvent("keydown", {
+        key: "s",
         ctrlKey: true,
-        shiftKey: true 
-      })
-      
-      expect(isKeyComboPressed(event, 'Control+Shift+s')).toBe(true)
-      expect(isKeyComboPressed(event, 'Control+s')).toBe(true) // Should match partial
-      expect(isKeyComboPressed(event, 'Shift+s')).toBe(true) // Should match partial
-    })
+        shiftKey: true,
+      });
 
-    it('handles case insensitive matching', () => {
-      const event = new KeyboardEvent('keydown', { key: 'S' })
-      expect(isKeyComboPressed(event, 's')).toBe(true)
-      expect(isKeyComboPressed(event, 'S')).toBe(true)
-    })
+      expect(isKeyComboPressed(event, "Control+Shift+s")).toBe(true);
+      expect(isKeyComboPressed(event, "Control+s")).toBe(true); // Should match partial
+      expect(isKeyComboPressed(event, "Shift+s")).toBe(true); // Should match partial
+    });
 
-    it('distinguishes control and meta keys', () => {
-      const metaEvent = new KeyboardEvent('keydown', { key: 's', metaKey: true })
-      expect(isKeyComboPressed(metaEvent, 'meta+s')).toBe(true)
-      expect(isKeyComboPressed(metaEvent, 'control+s')).toBe(false)
-    })
-  })
+    it("handles case insensitive matching", () => {
+      const event = new KeyboardEvent("keydown", { key: "S" });
+      expect(isKeyComboPressed(event, "s")).toBe(true);
+      expect(isKeyComboPressed(event, "S")).toBe(true);
+    });
 
-  describe('getShortcutDisplay', () => {
-    it('formats simple keys', () => {
-      expect(getShortcutDisplay('a')).toBe('A')
-      expect(getShortcutDisplay('space')).toBe('Space')
-    })
+    it("distinguishes control and meta keys", () => {
+      const metaEvent = new KeyboardEvent("keydown", {
+        key: "s",
+        metaKey: true,
+      });
+      expect(isKeyComboPressed(metaEvent, "meta+s")).toBe(true);
+      expect(isKeyComboPressed(metaEvent, "control+s")).toBe(false);
+    });
+  });
 
-    it('formats modifier combinations', () => {
-      expect(getShortcutDisplay('Control+Shift+s')).toBe('Control + Shift + S')
-      expect(getShortcutDisplay('Alt+Enter')).toBe('Alt + Enter')
-    })
-  })
+  describe("getShortcutDisplay", () => {
+    it("formats simple keys", () => {
+      expect(getShortcutDisplay("a")).toBe("A");
+      expect(getShortcutDisplay("space")).toBe("Space");
+    });
 
-  describe('DEFAULT_SHORTCUTS', () => {
-    it('has all required shortcuts', () => {
-      expect(DEFAULT_SHORTCUTS.playPause).toBe(' ')
-      expect(DEFAULT_SHORTCUTS.seekBackward).toBe('ArrowLeft')
-      expect(DEFAULT_SHORTCUTS.seekForward).toBe('ArrowRight')
-      expect(DEFAULT_SHORTCUTS.rewind).toBe('j')
-      expect(DEFAULT_SHORTCUTS.fastForward).toBe('l')
-      expect(DEFAULT_SHORTCUTS.previousTrack).toBe('Control+ArrowLeft')
-      expect(DEFAULT_SHORTCUTS.nextTrack).toBe('Control+ArrowRight')
-      expect(DEFAULT_SHORTCUTS.toggleMetadata).toBe('i')
-      expect(DEFAULT_SHORTCUTS.togglePlaylist).toBe('p')
-      expect(DEFAULT_SHORTCUTS.openSettings).toBe('s')
-      expect(DEFAULT_SHORTCUTS.snapshot).toBe('Control+Shift+s')
-      expect(DEFAULT_SHORTCUTS.volumeUp).toBe('ArrowUp')
-      expect(DEFAULT_SHORTCUTS.volumeDown).toBe('ArrowDown')
-      expect(DEFAULT_SHORTCUTS.mute).toBe('m')
-      expect(DEFAULT_SHORTCUTS.help).toBe('?')
-    })
-  })
+    it("formats modifier combinations", () => {
+      expect(getShortcutDisplay("Control+Shift+s")).toBe("Ctrl + Shift + S");
+      expect(getShortcutDisplay("Alt+Enter")).toBe("Alt + Enter");
+    });
+  });
 
-  describe('storage helpers', () => {
-    it('saves and loads shortcuts using a constant key', () => {
-      const custom = { ...DEFAULT_SHORTCUTS, playPause: 'k' }
-      saveShortcuts(custom)
-      const stored = localStorage.getItem(SHORTCUTS_STORAGE_KEY)
-      expect(stored).not.toBeNull()
-      const loaded = loadShortcuts()
-      expect(loaded.playPause).toBe('k')
-    })
-  })
-})
+  describe("DEFAULT_SHORTCUTS", () => {
+    it("has all required shortcuts", () => {
+      expect(DEFAULT_SHORTCUTS.playPause).toBe(" ");
+      expect(DEFAULT_SHORTCUTS.seekBackward).toBe("ArrowLeft");
+      expect(DEFAULT_SHORTCUTS.seekForward).toBe("ArrowRight");
+      expect(DEFAULT_SHORTCUTS.rewind).toBe("j");
+      expect(DEFAULT_SHORTCUTS.fastForward).toBe("l");
+      expect(DEFAULT_SHORTCUTS.previousTrack).toBe("Control+ArrowLeft");
+      expect(DEFAULT_SHORTCUTS.nextTrack).toBe("Control+ArrowRight");
+      expect(DEFAULT_SHORTCUTS.toggleMetadata).toBe("i");
+      expect(DEFAULT_SHORTCUTS.togglePlaylist).toBe("p");
+      expect(DEFAULT_SHORTCUTS.openSettings).toBe("s");
+      expect(DEFAULT_SHORTCUTS.snapshot).toBe("Control+Shift+s");
+      expect(DEFAULT_SHORTCUTS.volumeUp).toBe("ArrowUp");
+      expect(DEFAULT_SHORTCUTS.volumeDown).toBe("ArrowDown");
+      expect(DEFAULT_SHORTCUTS.mute).toBe("m");
+      expect(DEFAULT_SHORTCUTS.help).toBe("?");
+    });
+  });
+
+  describe("storage helpers", () => {
+    it("saves and loads shortcuts using a constant key", () => {
+      const custom = { ...DEFAULT_SHORTCUTS, playPause: "k" };
+      saveShortcuts(custom);
+      const stored = localStorage.getItem(SHORTCUTS_STORAGE_KEY);
+      expect(stored).not.toBeNull();
+      const loaded = loadShortcuts();
+      expect(loaded.playPause).toBe("k");
+    });
+  });
+});

--- a/web/apps/mfe-spectrogram/src/utils/keyboard.ts
+++ b/web/apps/mfe-spectrogram/src/utils/keyboard.ts
@@ -1,31 +1,31 @@
-import { KeyboardShortcuts } from '@/types'
+import { KeyboardShortcuts } from "@/types";
 
 /**
  * LocalStorage key for persisting user-defined keyboard shortcuts.
  */
-export const SHORTCUTS_STORAGE_KEY = 'spectrogram-shortcuts'
+export const SHORTCUTS_STORAGE_KEY = "spectrogram-shortcuts";
 
 /**
  * Default key bindings for the spectrogram application.
  * Each property maps an action to the key combination that triggers it.
  */
 export const DEFAULT_SHORTCUTS: KeyboardShortcuts = {
-  playPause: ' ',
-  seekBackward: 'ArrowLeft',
-  seekForward: 'ArrowRight',
-  rewind: 'j',
-  fastForward: 'l',
-  previousTrack: 'Control+ArrowLeft',
-  nextTrack: 'Control+ArrowRight',
-  toggleMetadata: 'i',
-  togglePlaylist: 'p',
-  openSettings: 's',
-  snapshot: 'Control+Shift+s',
-  volumeUp: 'ArrowUp',
-  volumeDown: 'ArrowDown',
-  mute: 'm',
-  help: '?',
-}
+  playPause: " ",
+  seekBackward: "ArrowLeft",
+  seekForward: "ArrowRight",
+  rewind: "j",
+  fastForward: "l",
+  previousTrack: "Control+ArrowLeft",
+  nextTrack: "Control+ArrowRight",
+  toggleMetadata: "i",
+  togglePlaylist: "p",
+  openSettings: "s",
+  snapshot: "Control+Shift+s",
+  volumeUp: "ArrowUp",
+  volumeDown: "ArrowDown",
+  mute: "m",
+  help: "?",
+};
 
 /**
  * Breaks a combination string like "Control+S" into normalized key names.
@@ -36,11 +36,11 @@ export const DEFAULT_SHORTCUTS: KeyboardShortcuts = {
 export function parseKeyCombo(combo: string): string[] {
   return combo
     .toLowerCase()
-    .split('+')
-    .map(key => {
-      const trimmed = key.trim()
-      return trimmed === 'cmd' || trimmed === 'command' ? 'meta' : trimmed
-    })
+    .split("+")
+    .map((key) => {
+      const trimmed = key.trim();
+      return trimmed === "cmd" || trimmed === "command" ? "meta" : trimmed;
+    });
 }
 
 /**
@@ -49,21 +49,24 @@ export function parseKeyCombo(combo: string): string[] {
  * @param event Keyboard event to inspect.
  * @param combo Key combination such as "Control+S".
  */
-export function isKeyComboPressed(event: KeyboardEvent, combo: string): boolean {
-  const keys = parseKeyCombo(combo)
-  const pressedKeys = new Set<string>()
+export function isKeyComboPressed(
+  event: KeyboardEvent,
+  combo: string,
+): boolean {
+  const keys = parseKeyCombo(combo);
+  const pressedKeys = new Set<string>();
 
   // Add modifier keys
-  if (event.ctrlKey) pressedKeys.add('control')
-  if (event.metaKey) pressedKeys.add('meta')
-  if (event.shiftKey) pressedKeys.add('shift')
-  if (event.altKey) pressedKeys.add('alt')
+  if (event.ctrlKey) pressedKeys.add("control");
+  if (event.metaKey) pressedKeys.add("meta");
+  if (event.shiftKey) pressedKeys.add("shift");
+  if (event.altKey) pressedKeys.add("alt");
 
   // Add the main key
-  pressedKeys.add(event.key.toLowerCase())
+  pressedKeys.add(event.key.toLowerCase());
 
   // Check if all required keys are pressed
-  return keys.every(key => pressedKeys.has(key))
+  return keys.every((key) => pressedKeys.has(key));
 }
 
 /**
@@ -74,7 +77,7 @@ export function isKeyComboPressed(event: KeyboardEvent, combo: string): boolean 
  */
 export function createKeyboardHandler(
   shortcuts: KeyboardShortcuts,
-  handlers: Record<string, () => void>
+  handlers: Record<string, () => void>,
 ) {
   return (event: KeyboardEvent) => {
     // Don't handle shortcuts when typing in input fields
@@ -83,20 +86,20 @@ export function createKeyboardHandler(
       event.target instanceof HTMLTextAreaElement ||
       event.target instanceof HTMLSelectElement
     ) {
-      return
+      return;
     }
 
     // Check each shortcut
     Object.entries(shortcuts).forEach(([action, combo]) => {
       if (isKeyComboPressed(event, combo)) {
-        event.preventDefault()
-        const handler = handlers[action]
+        event.preventDefault();
+        const handler = handlers[action];
         if (handler) {
-          handler()
+          handler();
         }
       }
-    })
-  }
+    });
+  };
 }
 
 /**
@@ -104,25 +107,25 @@ export function createKeyboardHandler(
  * @param combo Combination string to format.
  */
 export function getShortcutDisplay(combo: string): string {
-  return combo
-    .split('+')
-    .map(key => key.charAt(0).toUpperCase() + key.slice(1))
-  // Map normalized key names to display names
-  const isMac = typeof navigator !== 'undefined' && /Mac|iPod|iPhone|iPad/.test(navigator.platform);
+  // Map normalized key names to user-friendly labels. Platform detection keeps
+  // meta/alt naming intuitive across macOS and other systems.
+  const isMac =
+    typeof navigator !== "undefined" &&
+    /Mac|iPod|iPhone|iPad/.test(navigator.platform);
   const keyDisplayMap: Record<string, string> = {
-    meta: isMac ? 'Cmd' : 'Meta',
-    control: 'Ctrl',
-    shift: 'Shift',
-    alt: isMac ? 'Option' : 'Alt',
-    // Add more mappings as needed
+    meta: isMac ? "Cmd" : "Meta",
+    control: "Ctrl",
+    shift: "Shift",
+    alt: isMac ? "Option" : "Alt",
+    // Additional mappings can be added here as needed.
   };
   return combo
-    .split('+')
-    .map(key => {
+    .split("+")
+    .map((key) => {
       const lower = key.trim().toLowerCase();
-      return keyDisplayMap[lower] || (key.charAt(0).toUpperCase() + key.slice(1));
+      return keyDisplayMap[lower] || key.charAt(0).toUpperCase() + key.slice(1);
     })
-    .join(' + ');
+    .join(" + ");
 }
 
 /**
@@ -132,9 +135,9 @@ export function getShortcutDisplay(combo: string): string {
  */
 export function saveShortcuts(shortcuts: KeyboardShortcuts): void {
   try {
-    localStorage.setItem(SHORTCUTS_STORAGE_KEY, JSON.stringify(shortcuts))
+    localStorage.setItem(SHORTCUTS_STORAGE_KEY, JSON.stringify(shortcuts));
   } catch (error) {
-    console.error('Failed to save shortcuts', error)
+    console.error("Failed to save shortcuts", error);
   }
 }
 
@@ -145,12 +148,12 @@ export function saveShortcuts(shortcuts: KeyboardShortcuts): void {
  */
 export function loadShortcuts(): KeyboardShortcuts {
   try {
-    const stored = localStorage.getItem(SHORTCUTS_STORAGE_KEY)
+    const stored = localStorage.getItem(SHORTCUTS_STORAGE_KEY);
     if (stored) {
-      return { ...DEFAULT_SHORTCUTS, ...JSON.parse(stored) }
+      return { ...DEFAULT_SHORTCUTS, ...JSON.parse(stored) };
     }
   } catch (error) {
-    console.error('Failed to load shortcuts', error)
+    console.error("Failed to load shortcuts", error);
   }
-  return DEFAULT_SHORTCUTS
+  return DEFAULT_SHORTCUTS;
 }

--- a/web/apps/mfe-spectrogram/src/utils/toast.ts
+++ b/web/apps/mfe-spectrogram/src/utils/toast.ts
@@ -1,69 +1,82 @@
-import toast from 'react-hot-toast'
-import { useSettingsStore } from '@/stores/settingsStore'
+import toast from "react-hot-toast";
+import { useSettingsStore } from "@/stores/settingsStore";
+import { THEME_COLORS } from "@/shared/theme";
 
-// Conditional toast function that respects the user's settings
+// Conditional toast function that respects the user's settings.
+// Colours are derived from THEME_COLORS to stay consistent with the active
+// light or dark theme without hard-coded hex values.
 export const conditionalToast = {
   success: (message: string) => {
-    const { enableToastNotifications } = useSettingsStore.getState()
+    const { enableToastNotifications } = useSettingsStore.getState();
     if (enableToastNotifications) {
-      toast.success(message)
+      toast.success(message);
     }
   },
-  
+
   error: (message: string) => {
-    const { enableToastNotifications } = useSettingsStore.getState()
+    const { enableToastNotifications } = useSettingsStore.getState();
     if (enableToastNotifications) {
-      toast.error(message)
+      toast.error(message);
     }
   },
-  
+
   warning: (message: string) => {
-    const { enableToastNotifications } = useSettingsStore.getState()
+    const { enableToastNotifications } = useSettingsStore.getState();
     if (enableToastNotifications) {
       toast(message, {
-        icon: '⚠️',
-        style: {
-          borderRadius: '10px',
-          background: '#333',
-          color: '#fff',
-        },
-      })
+        icon: "⚠️",
+        style: (() => {
+          const { theme } = useSettingsStore.getState();
+          const { accent, background } = THEME_COLORS[theme];
+          return {
+            borderRadius: "10px",
+            background,
+            color: accent,
+          };
+        })(),
+      });
     }
   },
-  
+
   info: (message: string) => {
-    const { enableToastNotifications } = useSettingsStore.getState()
+    const { enableToastNotifications } = useSettingsStore.getState();
     if (enableToastNotifications) {
       toast(message, {
-        icon: 'ℹ️',
-        style: {
-          borderRadius: '10px',
-          background: '#333',
-          color: '#fff',
-        },
-      })
+        icon: "ℹ️",
+        style: (() => {
+          const { theme } = useSettingsStore.getState();
+          const { accent, background } = THEME_COLORS[theme];
+          return {
+            borderRadius: "10px",
+            background,
+            color: accent,
+          };
+        })(),
+      });
     }
-  }
-}
+  },
+};
 
 // Direct toast functions (always show, regardless of settings)
 export const directToast = {
   success: toast.success,
   error: toast.error,
-  warning: (message: string) => toast(message, {
-    icon: '⚠️',
-    style: {
-      borderRadius: '10px',
-      background: '#333',
-      color: '#fff',
-    },
-  }),
-  info: (message: string) => toast(message, {
-    icon: 'ℹ️',
-    style: {
-      borderRadius: '10px',
-      background: '#333',
-      color: '#fff',
-    },
-  })
-}
+  warning: (message: string) =>
+    toast(message, {
+      icon: "⚠️",
+      style: (() => {
+        const { theme } = useSettingsStore.getState();
+        const { accent, background } = THEME_COLORS[theme];
+        return { borderRadius: "10px", background, color: accent };
+      })(),
+    }),
+  info: (message: string) =>
+    toast(message, {
+      icon: "ℹ️",
+      style: (() => {
+        const { theme } = useSettingsStore.getState();
+        const { accent, background } = THEME_COLORS[theme];
+        return { borderRadius: "10px", background, color: accent };
+      })(),
+    }),
+};


### PR DESCRIPTION
## Summary
- extend theme types and map colors for Japanese A/B and Bauhaus variants
- swap hard-coded color literals for theme-aware references
- default to japanese-a-light theme with validation and tests

## Testing
- `npx vitest run src/shared/stores/settingsStore.test.ts src/utils/__tests__/keyboard.test.ts --coverage`
- `npm test` *(fails: numerous existing suite errors and missing browser APIs)*

------
https://chatgpt.com/codex/tasks/task_e_68a716dd97d4832b95c4fcc4ae4b941d