### PR TITLE
Refactor layout using theme tokens

### DIFF
--- a/web/apps/mfe-spectrogram/src/components/layout/Footer.tsx
+++ b/web/apps/mfe-spectrogram/src/components/layout/Footer.tsx
@@ -26,6 +26,25 @@ import {
   NEXT_WINDOW_SEC,
   SIZE_SWAP_DURATION_MS,
 } from "@/shared/config";
+import { useSettingsStore } from "@/shared/stores/settingsStore";
+import { SPACING, BORDER_RADIUS, TYPOGRAPHY, GRID } from "@/shared/layout";
+import type { Theme } from "@/shared/types";
+
+/**
+ * Generates the footer's base classes using design tokens. Encapsulating this
+ * logic avoids scattering spacing/typography decisions throughout the
+ * component and enables simple unit tests.
+ */
+export function getFooterClasses(theme: Theme, height: string): string {
+  return cn(
+    "footer-controls",
+    SPACING[theme],
+    BORDER_RADIUS[theme],
+    TYPOGRAPHY[theme],
+    GRID[theme],
+    height,
+  );
+}
 
 export const Footer: React.FC = () => {
   const volumeSliderRef = useRef<HTMLInputElement>(null);
@@ -49,6 +68,7 @@ export const Footer: React.FC = () => {
   } = useAudioStore();
 
   const { isMobile, isTablet } = useScreenSize();
+  const theme = useSettingsStore((s) => s.theme);
   const audioFile = useAudioFile();
 
   const hasUpcomingTrack =
@@ -326,7 +346,7 @@ export const Footer: React.FC = () => {
 
   return (
     <footer
-      className={cn("footer-controls", layoutConfig.footerHeight)}
+      className={getFooterClasses(theme, layoutConfig.footerHeight)}
       data-testid="footer"
       role="contentinfo"
       aria-label="Playback controls"

--- a/web/apps/mfe-spectrogram/src/components/layout/SettingsPanel.tsx
+++ b/web/apps/mfe-spectrogram/src/components/layout/SettingsPanel.tsx
@@ -33,6 +33,7 @@ import { conditionalToast, directToast } from "@/utils/toast";
 import { MetadataStorePanel } from "./MetadataStorePanel";
 import { StatisticsPanel } from "./StatisticsPanel";
 import { LUTSettingsPanel } from "@/features/settings/LUTSettingsPanel";
+import { getPanelClasses } from "@/shared/layout";
 
 interface SettingsPanelProps {
   settings: SpectrogramSettings;
@@ -203,8 +204,8 @@ export function SettingsPanel({
     >
       <div
         className={cn(
+          getPanelClasses(settings.theme),
           "panel w-full max-w-4xl max-h-[90vh]",
-          "flex flex-col",
           "animate-scale-in",
         )}
       >

--- a/web/apps/mfe-spectrogram/src/features/metadata/MetadataPanel.tsx
+++ b/web/apps/mfe-spectrogram/src/features/metadata/MetadataPanel.tsx
@@ -3,6 +3,8 @@ import { AudioTrack } from '@/shared/types'
 import { formatDuration, formatFileSize } from '@/shared/utils/audio'
 import { useUIStore } from '@/shared/stores/uiStore'
 import { usePlaylistSearchStore } from '@/shared/stores/playlistSearchStore'
+import { useSettingsStore } from '@/shared/stores/settingsStore'
+import { getPanelClasses } from '@/shared/layout'
 
 // Helper function to format sample rate in kHz
 const formatSampleRate = (sampleRate: number): string => {
@@ -20,6 +22,7 @@ export function MetadataPanel({ track, isOpen, onClose }: MetadataPanelProps) {
 
   const { setPlaylistPanelOpen } = useUIStore()
   const { setSearchQuery } = usePlaylistSearchStore()
+  const theme = useSettingsStore((s) => s.theme)
 
   const handleMetadataSearch = (value: string) => {
     setSearchQuery(value)
@@ -33,7 +36,7 @@ export function MetadataPanel({ track, isOpen, onClose }: MetadataPanelProps) {
   )
   
   return (
-    <div className="h-full flex flex-col" data-testid="metadata-panel">
+    <div className={getPanelClasses(theme)} data-testid="metadata-panel">
       {/* Header */}
       <div className="flex items-center justify-between py-0.5 px-1 border-b border-neutral-800">
         <h3 className="text-sm font-medium text-neutral-100">Track Info</h3>

--- a/web/apps/mfe-spectrogram/src/features/playlist/PlaylistPanel.tsx
+++ b/web/apps/mfe-spectrogram/src/features/playlist/PlaylistPanel.tsx
@@ -15,6 +15,7 @@ import { fuzzyMatch, fuzzyScore } from "@/shared/utils/fuzzy";
 import { usePlaylistSearchStore } from "@/shared/stores/playlistSearchStore";
 import { useSettingsStore } from "@/shared/stores/settingsStore";
 import { THEME_COLORS } from "@/shared/theme";
+import { getPanelClasses } from "@/shared/layout";
 
 interface PlaylistPanelProps {
   tracks: AudioTrack[];
@@ -389,6 +390,7 @@ export function PlaylistPanel({
   const [dropIndex, setDropIndex] = useState<number | null>(null);
   const trackRefs = useRef<(HTMLDivElement | null)[]>([]);
   const { loadAudioFiles } = useAudioFile();
+  const theme = useSettingsStore((s) => s.theme);
 
   const handlePanelDragOver = (event: React.DragEvent<HTMLDivElement>) => {
     if (event.dataTransfer.types.includes("Files")) {
@@ -659,7 +661,7 @@ export function PlaylistPanel({
 
   return (
     <div
-      className="h-full flex flex-col"
+      className={getPanelClasses(theme)}
       data-testid="playlist-panel"
       onDragOver={handlePanelDragOver}
       onDrop={handlePanelDrop}

--- a/web/apps/mfe-spectrogram/src/layout/Footer.tsx
+++ b/web/apps/mfe-spectrogram/src/layout/Footer.tsx
@@ -1,3 +1,3 @@
-export { Footer } from '../components/layout/Footer';
+export { Footer, getFooterClasses } from '../components/layout/Footer';
 
 

--- a/web/apps/mfe-spectrogram/src/layout/Header.tsx
+++ b/web/apps/mfe-spectrogram/src/layout/Header.tsx
@@ -5,14 +5,35 @@ import { useAudioFile } from '../shared/hooks/useAudioFile'
 import { useMicrophone } from '../shared/hooks/useMicrophone'
 import { useScreenSize } from '../shared/hooks/useScreenSize'
 import { useKeyboardShortcuts } from '../shared/hooks/useKeyboardShortcuts'
+import { useSettingsStore } from '../shared/stores/settingsStore'
 import { FileAudio, Mic, MicOff, Settings, Camera, Info, List } from 'lucide-react'
 import { cn } from '../shared/utils/cn'
+import { SPACING, TYPOGRAPHY, GRID } from '../shared/layout'
+import type { Theme } from '../shared/types'
+
+/**
+ * Builds the header's class string from layout tokens. Centralising this logic
+ * guarantees every theme shares the same structural rules and keeps tests
+ * straightforward.
+ */
+export function getHeaderClasses(theme: Theme, isMobile: boolean): string {
+  return cn(
+    'bg-neutral-900 border-b border-neutral-800',
+    'flex items-center justify-between',
+    SPACING[theme],
+    TYPOGRAPHY[theme],
+    GRID[theme],
+    'transition-colors duration-300',
+    isMobile ? 'h-14' : 'h-12',
+  )
+}
 
 export const Header: React.FC = () => {
   const fileInputRef = useRef<HTMLInputElement>(null)
   const { metadataPanelOpen, playlistPanelOpen, setMetadataPanelOpen, setPlaylistPanelOpen, setSettingsPanelOpen } = useUIStore()
   const { isMicrophoneActive } = useAudioStore()
   const { isMobile, isTablet } = useScreenSize()
+  const theme = useSettingsStore((s) => s.theme)
   const audioFile = useAudioFile()
   const microphone = useMicrophone()
 
@@ -49,7 +70,7 @@ export const Header: React.FC = () => {
   }, [isMobile, isTablet])
 
   return (
-    <header className={cn('bg-neutral-900 border-b border-neutral-800','flex items-center justify-between px-4','transition-colors duration-300', isMobile ? 'h-14' : 'h-12')}>
+    <header className={getHeaderClasses(theme, isMobile)}>
       <div className="flex items-center min-w-0 flex-1">
         <h1 className={cn('font-semibold text-neutral-100 truncate', isMobile ? 'text-base' : 'text-lg')}>Spectrogram</h1>
       </div>
@@ -93,5 +114,3 @@ export const Header: React.FC = () => {
     </header>
   )
 }
-
-

--- a/web/apps/mfe-spectrogram/src/shared/layout.test.ts
+++ b/web/apps/mfe-spectrogram/src/shared/layout.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect } from 'vitest'
+import { SPACING, BORDER_RADIUS, TYPOGRAPHY, GRID, getPanelClasses } from './layout'
+import { getHeaderClasses } from '@/layout/Header'
+import { getFooterClasses } from '@/layout/Footer'
+import type { Theme } from '@/shared/types'
+
+// Enumerate all supported themes to ensure token maps stay in sync.
+const ALL_THEMES: Theme[] = [
+  'dark',
+  'light',
+  'neon',
+  'high-contrast',
+  'japanese-a-light',
+  'japanese-a-dark',
+  'japanese-b-light',
+  'japanese-b-dark',
+  'bauhaus-light',
+  'bauhaus-dark',
+]
+
+describe('layout tokens', () => {
+  it('define spacing for every theme', () => {
+    ALL_THEMES.forEach((t) => expect(SPACING).toHaveProperty(t))
+  })
+  it('define border radius for every theme', () => {
+    ALL_THEMES.forEach((t) => expect(BORDER_RADIUS).toHaveProperty(t))
+  })
+  it('define typography for every theme', () => {
+    ALL_THEMES.forEach((t) => expect(TYPOGRAPHY).toHaveProperty(t))
+  })
+  it('define grid units for every theme', () => {
+    ALL_THEMES.forEach((t) => expect(GRID).toHaveProperty(t))
+  })
+})
+
+describe('component class helpers', () => {
+  it('header uses theme tokens', () => {
+    const theme: Theme = 'japanese-a-light'
+    const cls = getHeaderClasses(theme, true)
+    expect(cls).toContain(SPACING[theme])
+    expect(cls).toContain(TYPOGRAPHY[theme])
+  })
+
+  it('footer uses theme tokens', () => {
+    const theme: Theme = 'bauhaus-dark'
+    const cls = getFooterClasses(theme, 'h-12')
+    expect(cls).toContain(SPACING[theme])
+    expect(cls).toContain(BORDER_RADIUS[theme])
+  })
+
+  it('panel helper applies tokens', () => {
+    const theme: Theme = 'dark'
+    const cls = getPanelClasses(theme)
+    expect(cls).toContain(GRID[theme])
+    expect(cls).toContain(TYPOGRAPHY[theme])
+  })
+})

--- a/web/apps/mfe-spectrogram/src/shared/layout.ts
+++ b/web/apps/mfe-spectrogram/src/shared/layout.ts
@@ -1,0 +1,110 @@
+import { Theme } from "@/shared/types";
+import { cn } from "@/shared/utils/cn";
+
+/**
+ * Base spacing tokens expressed as Tailwind utility strings. Values are kept as
+ * constants to avoid magic numbers and allow reuse across theme mappings.
+ */
+const SPACE_STANDARD = "px-4 py-2"; // Neutral balance for modern themes.
+const SPACE_JAPANESE = "px-6 py-3"; // Generous whitespace for Japanese minimalism.
+const SPACE_BAUHAUS = "px-3 py-2"; // Compact rhythm matching Bauhaus grids.
+
+/**
+ * Border radius tokens. Japanese styles prefer subtle rounding, Bauhaus keeps
+ * sharp edges to mirror modular geometry, while defaults remain moderately
+ * rounded for familiarity.
+ */
+const RADIUS_STANDARD = "rounded-md";
+const RADIUS_JAPANESE = "rounded-sm";
+const RADIUS_BAUHAUS = "rounded-none";
+
+/**
+ * Typography tokens. Japanese minimalism favours light weights, Bauhaus uses
+ * bold uppercase grid-aligned type, while defaults use regular sans text.
+ */
+const TYPO_STANDARD = "font-sans text-sm";
+const TYPO_JAPANESE = "font-light text-sm";
+const TYPO_BAUHAUS = "font-bold uppercase tracking-wide text-sm";
+
+/**
+ * Grid unit tokens. Defaults rely on simple flex layouts, Japanese themes
+ * favour single-column calmness, and Bauhaus uses a strict 12-column grid.
+ */
+const GRID_STANDARD = "flex";
+const GRID_JAPANESE = "grid grid-cols-1";
+const GRID_BAUHAUS = "grid grid-cols-12";
+
+/**
+ * Tailwind spacing classes keyed by theme. Each entry references a spacing
+ * constant above, enabling components to derive consistent whitespace
+ * without sprinkling literal values.
+ */
+export const SPACING: Record<Theme, string> = {
+  dark: SPACE_STANDARD,
+  light: SPACE_STANDARD,
+  neon: SPACE_STANDARD,
+  "high-contrast": SPACE_STANDARD,
+  "japanese-a-light": SPACE_JAPANESE,
+  "japanese-a-dark": SPACE_JAPANESE,
+  "japanese-b-light": SPACE_JAPANESE,
+  "japanese-b-dark": SPACE_JAPANESE,
+  "bauhaus-light": SPACE_BAUHAUS,
+  "bauhaus-dark": SPACE_BAUHAUS,
+} as const;
+
+/** Border radius classes keyed by theme. */
+export const BORDER_RADIUS: Record<Theme, string> = {
+  dark: RADIUS_STANDARD,
+  light: RADIUS_STANDARD,
+  neon: RADIUS_STANDARD,
+  "high-contrast": RADIUS_STANDARD,
+  "japanese-a-light": RADIUS_JAPANESE,
+  "japanese-a-dark": RADIUS_JAPANESE,
+  "japanese-b-light": RADIUS_JAPANESE,
+  "japanese-b-dark": RADIUS_JAPANESE,
+  "bauhaus-light": RADIUS_BAUHAUS,
+  "bauhaus-dark": RADIUS_BAUHAUS,
+} as const;
+
+/** Typography classes keyed by theme. */
+export const TYPOGRAPHY: Record<Theme, string> = {
+  dark: TYPO_STANDARD,
+  light: TYPO_STANDARD,
+  neon: TYPO_STANDARD,
+  "high-contrast": TYPO_STANDARD,
+  "japanese-a-light": TYPO_JAPANESE,
+  "japanese-a-dark": TYPO_JAPANESE,
+  "japanese-b-light": TYPO_JAPANESE,
+  "japanese-b-dark": TYPO_JAPANESE,
+  "bauhaus-light": TYPO_BAUHAUS,
+  "bauhaus-dark": TYPO_BAUHAUS,
+} as const;
+
+/** Grid classes keyed by theme. */
+export const GRID: Record<Theme, string> = {
+  dark: GRID_STANDARD,
+  light: GRID_STANDARD,
+  neon: GRID_STANDARD,
+  "high-contrast": GRID_STANDARD,
+  "japanese-a-light": GRID_JAPANESE,
+  "japanese-a-dark": GRID_JAPANESE,
+  "japanese-b-light": GRID_JAPANESE,
+  "japanese-b-dark": GRID_JAPANESE,
+  "bauhaus-light": GRID_BAUHAUS,
+  "bauhaus-dark": GRID_BAUHAUS,
+} as const;
+
+/**
+ * Derives a base panel class list for a given theme. Panels use this to avoid
+ * duplicating spacing/border/typography/grid logic and to ensure a cohesive
+ * aesthetic across the application.
+ */
+export function getPanelClasses(theme: Theme): string {
+  return cn(
+    "h-full", // Panels occupy available vertical space.
+    SPACING[theme],
+    BORDER_RADIUS[theme],
+    TYPOGRAPHY[theme],
+    GRID[theme],
+  );
+}


### PR DESCRIPTION
## Summary
- add spacing, radius, typography and grid tokens for each theme
- derive header, footer and panels from token-driven helpers
- verify layout token coverage and helper behaviour

## Testing
- `npm test` *(fails: Test Files 48 failed | 4 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68a71a044fa8832bb617f3827fdb16d8