### PR TITLE
feat(media): add waveform window constant and validation

### DIFF
--- a/src/media/playback.rs
+++ b/src/media/playback.rs
@@ -6,16 +6,67 @@
 //! available.
 
 use rusqlite::{params, Connection};
-use std::vec::Vec;
+use std::{error::Error, fmt, vec::Vec};
+
+/// Default number of audio samples aggregated into one waveform point.
+///
+/// A value of `100` offers a reasonable compromise between time resolution
+/// and computational overhead. At a sample rate of 44.1 kHz this represents
+/// roughly 2.3 ms of audio per point, which is typically sufficient for
+/// visualization while keeping processing inexpensive.
+pub const DEFAULT_WAVEFORM_WINDOW: usize = 100;
+
+/// Errors that can occur during waveform caching or generation.
+#[derive(Debug)]
+pub enum PlaybackError {
+    /// The configured waveform window size was zero.
+    InvalidWaveformWindow,
+    /// An error bubbled up from the underlying SQLite database.
+    Database(rusqlite::Error),
+}
+
+impl fmt::Display for PlaybackError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            PlaybackError::InvalidWaveformWindow => {
+                write!(f, "waveform window must be greater than zero")
+            }
+            PlaybackError::Database(e) => write!(f, "database error: {e}"),
+        }
+    }
+}
+
+impl Error for PlaybackError {
+    fn source(&self) -> Option<&(dyn Error + 'static)> {
+        match self {
+            PlaybackError::Database(e) => Some(e),
+            _ => None,
+        }
+    }
+}
+
+impl From<rusqlite::Error> for PlaybackError {
+    fn from(e: rusqlite::Error) -> Self {
+        PlaybackError::Database(e)
+    }
+}
 
 /// Initialize the waveform cache database schema.
-pub fn init_db(conn: &Connection) -> rusqlite::Result<()> {
+///
+/// Returns an error if the underlying SQLite operations fail.
+pub fn init_db(conn: &Connection) -> Result<(), PlaybackError> {
     conn.execute_batch(include_str!("waveform_schema.sql"))?;
     Ok(())
 }
 
 /// Store a waveform snapshot for the given track identifier.
-fn store_waveform(conn: &Connection, track_id: &str, waveform: &[f32]) -> rusqlite::Result<()> {
+///
+/// Fails if the database write cannot be completed.
+fn store_waveform(
+    conn: &Connection,
+    track_id: &str,
+    waveform: &[f32],
+) -> Result<(), PlaybackError> {
     let bytes = waveform_as_bytes(waveform);
     conn.execute(
         "INSERT OR REPLACE INTO waveform_samples (track_id, samples) VALUES (?1, ?2)",
@@ -25,7 +76,9 @@ fn store_waveform(conn: &Connection, track_id: &str, waveform: &[f32]) -> rusqli
 }
 
 /// Attempt to load a cached waveform snapshot.
-fn load_waveform(conn: &Connection, track_id: &str) -> rusqlite::Result<Option<Vec<f32>>> {
+///
+/// Returns `Ok(None)` when no cached waveform exists.
+fn load_waveform(conn: &Connection, track_id: &str) -> Result<Option<Vec<f32>>, PlaybackError> {
     let mut stmt = conn.prepare("SELECT samples FROM waveform_samples WHERE track_id = ?1")?;
     let mut rows = stmt.query(params![track_id])?;
     if let Some(row) = rows.next()? {
@@ -37,32 +90,46 @@ fn load_waveform(conn: &Connection, track_id: &str) -> rusqlite::Result<Option<V
 }
 
 /// Get the waveform snapshot for a track, generating and caching it if necessary.
+///
+/// Fails if database operations fail or if waveform generation parameters are invalid.
 pub fn get_or_generate_waveform(
     conn: &Connection,
     track_id: &str,
     audio: &[f32],
-) -> rusqlite::Result<Vec<f32>> {
+) -> Result<Vec<f32>, PlaybackError> {
     if let Some(cached) = load_waveform(conn, track_id)? {
         return Ok(cached);
     }
-    let waveform = generate_waveform(audio);
+    let waveform = generate_waveform(audio)?;
     store_waveform(conn, track_id, &waveform)?;
     Ok(waveform)
 }
 
-/// Simple waveform generation by averaging absolute amplitudes over windows of 100 samples.
-fn generate_waveform(audio: &[f32]) -> Vec<f32> {
-    let window = 100;
-    audio
-        .chunks(window)
-        .map(|chunk| chunk.iter().map(|v| v.abs()).sum::<f32>() / chunk.len() as f32)
-        .collect()
+/// Simple waveform generation by averaging absolute amplitudes over
+/// `DEFAULT_WAVEFORM_WINDOW` sized windows.
+fn generate_waveform(audio: &[f32]) -> Result<Vec<f32>, PlaybackError> {
+    generate_waveform_with_window(DEFAULT_WAVEFORM_WINDOW, audio)
 }
 
+/// Internal helper performing waveform generation for an arbitrary window size.
+///
+/// This facilitates testing of edge cases such as zero-sized windows.
+fn generate_waveform_with_window(window: usize, audio: &[f32]) -> Result<Vec<f32>, PlaybackError> {
+    if window == 0 {
+        return Err(PlaybackError::InvalidWaveformWindow);
+    }
+    Ok(audio
+        .chunks(window)
+        .map(|chunk| chunk.iter().map(|v| v.abs()).sum::<f32>() / chunk.len() as f32)
+        .collect())
+}
+
+/// Convert a waveform slice into a byte vector for database storage.
 fn waveform_as_bytes(waveform: &[f32]) -> Vec<u8> {
     waveform.iter().flat_map(|f| f.to_le_bytes()).collect()
 }
 
+/// Reconstruct a waveform from its byte representation loaded from the database.
 fn bytes_to_waveform(bytes: &[u8]) -> Vec<f32> {
     bytes
         .chunks_exact(4)
@@ -75,18 +142,20 @@ mod tests {
     use super::*;
     use alloc::vec;
 
+    /// Prepare an in-memory database initialized with the waveform schema.
     fn setup() -> Connection {
         let conn = Connection::open_in_memory().unwrap();
         init_db(&conn).unwrap();
         conn
     }
 
+    /// Ensure that generated waveforms are cached and retrieved on subsequent calls.
     #[test]
     fn generates_and_caches_waveform() {
         let conn = setup();
         let audio = vec![0.5f32; 200];
         let wf1 = get_or_generate_waveform(&conn, "track", &audio).unwrap();
-        // second call should retrieve from cache
+        // Second call should retrieve from cache
         let wf2 = get_or_generate_waveform(&conn, "track", &audio).unwrap();
         assert_eq!(wf1, wf2);
         let count: i64 = conn
@@ -95,6 +164,7 @@ mod tests {
         assert_eq!(count, 1);
     }
 
+    /// Cached waveform should be returned even if no audio samples are supplied.
     #[test]
     fn returns_cached_waveform_without_audio() {
         let conn = setup();
@@ -103,5 +173,13 @@ mod tests {
         // Provide empty audio to ensure cached result is used
         let wf2 = get_or_generate_waveform(&conn, "song", &[]).unwrap();
         assert_eq!(wf1, wf2);
+    }
+
+    /// Verifies that zero-sized windows are rejected to avoid division by zero.
+    #[test]
+    fn rejects_zero_window() {
+        let audio = vec![0.1f32; 10];
+        let err = generate_waveform_with_window(0, &audio).unwrap_err();
+        assert!(matches!(err, PlaybackError::InvalidWaveformWindow));
     }
 }

--- a/src/stft.rs
+++ b/src/stft.rs
@@ -66,6 +66,8 @@ compile_error!("stft requires `wasm` and `simd` features to be enabled");
 extern crate alloc;
 use crate::fft::{Complex32, FftError, FftImpl};
 use alloc::vec;
+#[cfg(feature = "parallel")]
+use core::mem::take; // for efficiently resetting buffers without reallocations
 
 /// Compute the STFT of a real-valued signal.
 ///


### PR DESCRIPTION
## Summary
- add `DEFAULT_WAVEFORM_WINDOW` constant for waveform downsampling
- validate non-zero window and introduce `PlaybackError`
- cover zero-window edge case in tests and fix STFT import

## Testing
- `cargo clippy --all-targets --all-features`
- `cargo test --features waveform-cache`


------
https://chatgpt.com/codex/tasks/task_e_68a71c9cd23c832bb7d7e725eb4645a1