### PR TITLE
Refactor STFT normalization and centralize epsilon

### DIFF
--- a/src/stft.rs
+++ b/src/stft.rs
@@ -67,6 +67,11 @@ extern crate alloc;
 use crate::fft::{Complex32, FftError, FftImpl};
 use alloc::vec;
 
+/// Minimum normalization denominator to avoid division by zero and unstable
+/// amplification when overlap-adding STFT frames. Any accumulated window power
+/// below this threshold is treated as silence.
+const NORM_EPSILON: f32 = 1e-8;
+
 /// Compute the STFT of a real-valued signal.
 ///
 /// - `signal`: input signal (real, length N)
@@ -132,9 +137,8 @@ pub fn istft<Fft: FftImpl<f32>>(
         return Err(FftError::MismatchedLengths);
     }
     let win_len = window.len();
-    for x in scratch.iter_mut() {
-        *x = 0.0;
-    }
+    // Clear normalization buffer before accumulating window power.
+    scratch.fill(0.0);
     // Overlap-add
     for (frame_idx, frame) in frames.iter_mut().enumerate() {
         let start = frame_idx * hop_size;
@@ -151,7 +155,7 @@ pub fn istft<Fft: FftImpl<f32>>(
     }
     // Normalize by window sum
     for i in 0..output.len() {
-        if scratch[i] > 1e-8 {
+        if scratch[i] > NORM_EPSILON {
             output[i] /= scratch[i];
         }
     }
@@ -334,7 +338,7 @@ pub fn inverse_parallel<Fft: FftImpl<f32> + Sync>(
                     acc[i] = time_buf[i].re * window[i];
                     norm[i] = window[i] * window[i];
                 }
-                Ok((start, take(acc), take(norm)))
+                Ok((start, acc.clone(), norm.clone()))
             },
         )
         .collect();
@@ -351,7 +355,7 @@ pub fn inverse_parallel<Fft: FftImpl<f32> + Sync>(
         }
     }
     for i in 0..output.len() {
-        if norm[i] > 1e-8 {
+        if norm[i] > NORM_EPSILON {
             output[i] /= norm[i];
         } else {
             output[i] = 0.0;
@@ -498,7 +502,7 @@ impl<'a, Fft: crate::fft::FftImpl<f32>> IstftStream<'a, Fft> {
         let out_end = self.out_pos + self.hop;
         // Normalize output before returning
         for i in out_start..out_end {
-            if self.norm_buf[i] > 1e-8 {
+            if self.norm_buf[i] > NORM_EPSILON {
                 self.buffer[i] /= self.norm_buf[i];
             }
             self.norm_buf[i] = 0.0;
@@ -532,7 +536,7 @@ impl<'a, Fft: crate::fft::FftImpl<f32>> IstftStream<'a, Fft> {
             return &[];
         }
         for i in out_start..out_end {
-            if self.norm_buf[i] > 1e-8 {
+            if self.norm_buf[i] > NORM_EPSILON {
                 self.buffer[i] /= self.norm_buf[i];
             }
             self.norm_buf[i] = 0.0;
@@ -576,7 +580,7 @@ mod tests {
             pos += hop;
         }
         for i in 0..n {
-            if norm[i] > 1e-8 {
+            if norm[i] > NORM_EPSILON {
                 output[i] /= norm[i];
             }
         }
@@ -856,6 +860,24 @@ mod edge_case_tests {
         output.truncate(signal.len());
         assert!(output.is_empty());
         assert!(tail.is_empty());
+    }
+
+    #[test]
+    fn test_tiny_window_threshold() {
+        let signal = [1.0f32, 2.0];
+        // Extremely small non-zero window ensures accumulated power stays below NORM_EPSILON
+        let window = [1e-9, 1e-9];
+        let required = signal.len().div_ceil(1);
+        let mut frames = vec![vec![Complex32::new(0.0, 0.0); window.len()]; required];
+        let fft = ScalarFftImpl::<f32>::default();
+        stft(&signal, &window, 1, &mut frames, &fft).unwrap();
+        let mut output = vec![0.0f32; signal.len()];
+        let mut scratch = vec![0.0f32; output.len()];
+        istft(&mut frames, &window, 1, &mut output, &mut scratch, &fft).unwrap();
+        // With such a tiny window, normalization should treat the output as silence
+        assert!(output
+            .iter()
+            .all(|x| x.is_finite() && x.abs() <= NORM_EPSILON));
     }
 }
 


### PR DESCRIPTION
## Summary
- replace manual scratch clearing with `fill`
- add `NORM_EPSILON` constant and remove magic thresholds
- fix parallel ISTFT buffer reuse and add tiny-window test

## Testing
- `cargo clippy --all-features --all-targets -- -D warnings`
- `cargo test -p kofft --all-features`


------
https://chatgpt.com/codex/tasks/task_e_68a71ca43320832b8975191e9854e4bf