### PR TITLE
feat: add spectrogram snapshot utility and shortcuts

### DIFF
--- a/web/apps/mfe-spectrogram/src/components/layout/Header.tsx
+++ b/web/apps/mfe-spectrogram/src/components/layout/Header.tsx
@@ -1,63 +1,86 @@
-import React, { useRef, useCallback, useMemo } from 'react'
-import { useUIStore } from '@/stores/uiStore'
-import { useAudioStore } from '@/stores/audioStore'
-import { useAudioFile } from '@/hooks/useAudioFile'
-import { useMicrophone } from '@/hooks/useMicrophone'
-import { useScreenSize } from '@/hooks/useScreenSize'
-import { useKeyboardShortcuts } from '@/hooks/useKeyboardShortcuts'
-import { 
-  FileAudio, 
-  Mic, 
-  MicOff, 
-  Settings, 
+import React, { useRef, useCallback, useMemo } from "react";
+import { useUIStore } from "@/stores/uiStore";
+import { useAudioStore } from "@/stores/audioStore";
+import { useAudioFile } from "@/hooks/useAudioFile";
+import { useMicrophone } from "@/hooks/useMicrophone";
+import { useScreenSize } from "@/hooks/useScreenSize";
+import { useKeyboardShortcuts } from "@/hooks/useKeyboardShortcuts";
+import {
+  FileAudio,
+  Mic,
+  MicOff,
+  Settings,
   Camera,
   Info,
   List,
-  Menu
-} from 'lucide-react'
-import { cn } from '@/utils/cn'
+  Menu,
+} from "lucide-react";
+import { cn } from "@/utils/cn";
+import { useSpectrogramStore } from "@/shared/stores/spectrogramStore";
+import {
+  takeSnapshot as captureSnapshot,
+  DEFAULT_SNAPSHOT_FILENAME,
+  SNAPSHOT_SUCCESS_MESSAGE,
+  SNAPSHOT_ERROR_MESSAGE,
+} from "@/utils/takeSnapshot";
+import { conditionalToast } from "@/utils/toast";
 
 export const Header: React.FC = () => {
-  const fileInputRef = useRef<HTMLInputElement>(null)
-  const { metadataPanelOpen, playlistPanelOpen, setMetadataPanelOpen, setPlaylistPanelOpen, setSettingsPanelOpen } = useUIStore()
-  const { isMicrophoneActive } = useAudioStore()
-  const { isMobile, isTablet } = useScreenSize()
-  
-  const audioFile = useAudioFile()
-  const microphone = useMicrophone()
+  const fileInputRef = useRef<HTMLInputElement>(null);
+  const {
+    metadataPanelOpen,
+    playlistPanelOpen,
+    setMetadataPanelOpen,
+    setPlaylistPanelOpen,
+    setSettingsPanelOpen,
+  } = useUIStore();
+  const { isMicrophoneActive } = useAudioStore();
+  const { isMobile, isTablet } = useScreenSize();
+
+  const audioFile = useAudioFile();
+  const microphone = useMicrophone();
 
   // Handle file selection
-  const handleFileSelect = useCallback(async (event: React.ChangeEvent<HTMLInputElement>) => {
-    const files = event.target.files
-    if (files && files.length > 0) {
-      try {
-        await audioFile.loadAudioFiles(Array.from(files))
-      } catch (error) {
-        console.error('Failed to load files:', error)
+  const handleFileSelect = useCallback(
+    async (event: React.ChangeEvent<HTMLInputElement>) => {
+      const files = event.target.files;
+      if (files && files.length > 0) {
+        try {
+          await audioFile.loadAudioFiles(Array.from(files));
+        } catch (error) {
+          console.error("Failed to load files:", error);
+        }
       }
-    }
-    // Reset input value to allow selecting the same file again
-    event.target.value = ''
-  }, [audioFile])
+      // Reset input value to allow selecting the same file again
+      event.target.value = "";
+    },
+    [audioFile],
+  );
 
   // Open file dialog
   const openFileDialog = useCallback(() => {
-    fileInputRef.current?.click()
-  }, [])
+    fileInputRef.current?.click();
+  }, []);
 
   // Toggle microphone
   const toggleMicrophone = useCallback(async () => {
-    await microphone.toggleMicrophone()
-  }, [microphone])
+    await microphone.toggleMicrophone();
+  }, [microphone]);
 
-  // Take snapshot
-  const takeSnapshot = useCallback(() => {
-    // TODO: Implement snapshot functionality
-    console.log('Snapshot feature not yet implemented')
-  }, [])
+  // Capture the spectrogram canvas and download it. Errors are reported via
+  // toast notifications so the user knows if the operation failed.
+  const handleSnapshot = useCallback(() => {
+    try {
+      const canvas = useSpectrogramStore.getState().canvasRef?.getCanvas();
+      captureSnapshot({ canvas, fileName: DEFAULT_SNAPSHOT_FILENAME });
+      conditionalToast.success(SNAPSHOT_SUCCESS_MESSAGE);
+    } catch (error) {
+      conditionalToast.error(SNAPSHOT_ERROR_MESSAGE);
+    }
+  }, []);
 
   // Keyboard shortcuts
-  useKeyboardShortcuts()
+  useKeyboardShortcuts();
 
   // Determine which buttons to show based on screen size
   const buttonConfig = useMemo(() => {
@@ -69,8 +92,8 @@ export const Header: React.FC = () => {
         showMetadataButton: true,
         showPlaylistButton: true,
         showSnapshotButton: false, // Hide on mobile to save space
-        showMenuButton: true
-      }
+        showMenuButton: true,
+      };
     } else if (isTablet) {
       return {
         showFileButton: true,
@@ -79,8 +102,8 @@ export const Header: React.FC = () => {
         showMetadataButton: true,
         showPlaylistButton: true,
         showSnapshotButton: true,
-        showMenuButton: false
-      }
+        showMenuButton: false,
+      };
     } else {
       return {
         showFileButton: true,
@@ -89,18 +112,18 @@ export const Header: React.FC = () => {
         showMetadataButton: true,
         showPlaylistButton: true,
         showSnapshotButton: true,
-        showMenuButton: false
-      }
+        showMenuButton: false,
+      };
     }
-  }, [isMobile, isTablet])
+  }, [isMobile, isTablet]);
 
   return (
-    <header 
+    <header
       className={cn(
-        'bg-neutral-900 border-b border-neutral-800',
-        'flex items-center justify-between px-4',
-        'transition-colors duration-300',
-        isMobile ? 'h-14' : 'h-12'
+        "bg-neutral-900 border-b border-neutral-800",
+        "flex items-center justify-between px-4",
+        "transition-colors duration-300",
+        isMobile ? "h-14" : "h-12",
       )}
       data-testid="header"
       role="banner"
@@ -108,10 +131,12 @@ export const Header: React.FC = () => {
     >
       {/* Left side - App title */}
       <div className="flex items-center min-w-0 flex-1">
-        <h1 className={cn(
-          'font-semibold text-neutral-100 truncate',
-          isMobile ? 'text-base' : 'text-lg'
-        )}>
+        <h1
+          className={cn(
+            "font-semibold text-neutral-100 truncate",
+            isMobile ? "text-base" : "text-lg",
+          )}
+        >
           Spectrogram
         </h1>
       </div>
@@ -122,10 +147,10 @@ export const Header: React.FC = () => {
           <button
             onClick={() => setMetadataPanelOpen(!metadataPanelOpen)}
             className={cn(
-              'p-2 rounded-lg transition-colors duration-200',
-              'hover:bg-neutral-800 active:bg-neutral-700',
-              'text-neutral-400 hover:text-neutral-200',
-              'min-w-[44px] min-h-[44px] flex items-center justify-center'
+              "p-2 rounded-lg transition-colors duration-200",
+              "hover:bg-neutral-800 active:bg-neutral-700",
+              "text-neutral-400 hover:text-neutral-200",
+              "min-w-[44px] min-h-[44px] flex items-center justify-center",
             )}
             title="Track info (I)"
             data-testid="mobile-info-button"
@@ -133,14 +158,14 @@ export const Header: React.FC = () => {
           >
             <Info size={isMobile ? 20 : 18} />
           </button>
-          
+
           <button
             onClick={() => setPlaylistPanelOpen(!playlistPanelOpen)}
             className={cn(
-              'p-2 rounded-lg transition-colors duration-200',
-              'hover:bg-neutral-800 active:bg-neutral-700',
-              'text-neutral-400 hover:text-neutral-200',
-              'min-w-[44px] min-h-[44px] flex items-center justify-center'
+              "p-2 rounded-lg transition-colors duration-200",
+              "hover:bg-neutral-800 active:bg-neutral-700",
+              "text-neutral-400 hover:text-neutral-200",
+              "min-w-[44px] min-h-[44px] flex items-center justify-center",
             )}
             title="Playlist (P)"
             data-testid="mobile-playlist-button"
@@ -152,19 +177,18 @@ export const Header: React.FC = () => {
       )}
 
       {/* Right side - Controls */}
-      <div className={cn(
-        'flex items-center gap-1',
-        isMobile ? 'gap-1' : 'gap-2'
-      )}>
+      <div
+        className={cn("flex items-center gap-1", isMobile ? "gap-1" : "gap-2")}
+      >
         {/* File input button */}
         {buttonConfig.showFileButton && (
           <button
             onClick={openFileDialog}
             className={cn(
-              'p-2 rounded-lg transition-colors duration-200',
-              'hover:bg-neutral-800 active:bg-neutral-700',
-              'text-neutral-400 hover:text-neutral-200',
-              'min-w-[44px] min-h-[44px] flex items-center justify-center'
+              "p-2 rounded-lg transition-colors duration-200",
+              "hover:bg-neutral-800 active:bg-neutral-700",
+              "text-neutral-400 hover:text-neutral-200",
+              "min-w-[44px] min-h-[44px] flex items-center justify-center",
             )}
             title="Open audio file (O)"
             data-testid="open-file-button"
@@ -179,18 +203,24 @@ export const Header: React.FC = () => {
           <button
             onClick={toggleMicrophone}
             className={cn(
-              'p-2 rounded-lg transition-colors duration-200',
-              'min-w-[44px] min-h-[44px] flex items-center justify-center',
-              isMicrophoneActive 
-                ? 'text-red-400 hover:text-red-300 bg-red-500/10 hover:bg-red-500/20' 
-                : 'text-neutral-400 hover:text-neutral-200 hover:bg-neutral-800 active:bg-neutral-700'
+              "p-2 rounded-lg transition-colors duration-200",
+              "min-w-[44px] min-h-[44px] flex items-center justify-center",
+              isMicrophoneActive
+                ? "text-red-400 hover:text-red-300 bg-red-500/10 hover:bg-red-500/20"
+                : "text-neutral-400 hover:text-neutral-200 hover:bg-neutral-800 active:bg-neutral-700",
             )}
             title="Toggle microphone"
             data-testid="microphone-button"
-            aria-label={isMicrophoneActive ? "Disable microphone" : "Enable microphone"}
+            aria-label={
+              isMicrophoneActive ? "Disable microphone" : "Enable microphone"
+            }
             aria-pressed={isMicrophoneActive}
           >
-            {isMicrophoneActive ? <Mic size={isMobile ? 20 : 18} /> : <MicOff size={isMobile ? 20 : 18} />}
+            {isMicrophoneActive ? (
+              <Mic size={isMobile ? 20 : 18} />
+            ) : (
+              <MicOff size={isMobile ? 20 : 18} />
+            )}
           </button>
         )}
 
@@ -199,10 +229,10 @@ export const Header: React.FC = () => {
           <button
             onClick={() => setSettingsPanelOpen(true)}
             className={cn(
-              'p-2 rounded-lg transition-colors duration-200',
-              'hover:bg-neutral-800 active:bg-neutral-700',
-              'text-neutral-400 hover:text-neutral-200',
-              'min-w-[44px] min-h-[44px] flex items-center justify-center'
+              "p-2 rounded-lg transition-colors duration-200",
+              "hover:bg-neutral-800 active:bg-neutral-700",
+              "text-neutral-400 hover:text-neutral-200",
+              "min-w-[44px] min-h-[44px] flex items-center justify-center",
             )}
             title="Settings (S)"
             data-testid="settings-button"
@@ -215,12 +245,12 @@ export const Header: React.FC = () => {
         {/* Snapshot button */}
         {buttonConfig.showSnapshotButton && (
           <button
-            onClick={takeSnapshot}
+            onClick={handleSnapshot}
             className={cn(
-              'p-2 rounded-lg transition-colors duration-200',
-              'hover:bg-neutral-800 active:bg-neutral-700',
-              'text-neutral-400 hover:text-neutral-200',
-              'min-w-[44px] min-h-[44px] flex items-center justify-center'
+              "p-2 rounded-lg transition-colors duration-200",
+              "hover:bg-neutral-800 active:bg-neutral-700",
+              "text-neutral-400 hover:text-neutral-200",
+              "min-w-[44px] min-h-[44px] flex items-center justify-center",
             )}
             title="Take snapshot (Ctrl+Shift+S)"
             data-testid="snapshot-button"
@@ -235,12 +265,12 @@ export const Header: React.FC = () => {
           <button
             onClick={() => setMetadataPanelOpen(!metadataPanelOpen)}
             className={cn(
-              'p-2 rounded-lg transition-colors duration-200',
-              'hover:bg-neutral-800 active:bg-neutral-700',
-              metadataPanelOpen 
-                ? 'text-blue-400 hover:text-blue-300 bg-blue-500/10 hover:bg-blue-500/20' 
-                : 'text-neutral-400 hover:text-neutral-200',
-              'min-w-[44px] min-h-[44px] flex items-center justify-center'
+              "p-2 rounded-lg transition-colors duration-200",
+              "hover:bg-neutral-800 active:bg-neutral-700",
+              metadataPanelOpen
+                ? "text-blue-400 hover:text-blue-300 bg-blue-500/10 hover:bg-blue-500/20"
+                : "text-neutral-400 hover:text-neutral-200",
+              "min-w-[44px] min-h-[44px] flex items-center justify-center",
             )}
             title="Toggle metadata panel (I)"
             data-testid="metadata-panel-button"
@@ -256,12 +286,12 @@ export const Header: React.FC = () => {
           <button
             onClick={() => setPlaylistPanelOpen(!playlistPanelOpen)}
             className={cn(
-              'p-2 rounded-lg transition-colors duration-200',
-              'hover:bg-neutral-800 active:bg-neutral-700',
-              playlistPanelOpen 
-                ? 'text-green-400 hover:text-green-300 bg-green-500/10 hover:bg-green-500/20' 
-                : 'text-neutral-400 hover:text-neutral-200',
-              'min-w-[44px] min-h-[44px] flex items-center justify-center'
+              "p-2 rounded-lg transition-colors duration-200",
+              "hover:bg-neutral-800 active:bg-neutral-700",
+              playlistPanelOpen
+                ? "text-green-400 hover:text-green-300 bg-green-500/10 hover:bg-green-500/20"
+                : "text-neutral-400 hover:text-neutral-200",
+              "min-w-[44px] min-h-[44px] flex items-center justify-center",
             )}
             title="Toggle playlist panel (P)"
             data-testid="playlist-panel-button"
@@ -285,5 +315,5 @@ export const Header: React.FC = () => {
         aria-label="Select audio files"
       />
     </header>
-  )
-}
+  );
+};

--- a/web/apps/mfe-spectrogram/src/hooks/__tests__/useKeyboardShortcuts.test.ts
+++ b/web/apps/mfe-spectrogram/src/hooks/__tests__/useKeyboardShortcuts.test.ts
@@ -1,0 +1,68 @@
+/* @vitest-environment jsdom */
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { renderHook } from "@testing-library/react";
+import { useKeyboardShortcuts } from "../useKeyboardShortcuts";
+import { useSpectrogramStore } from "@/shared/stores/spectrogramStore";
+
+const { snapshotMock, toastSuccess, toastError } = vi.hoisted(() => ({
+  snapshotMock: vi.fn(),
+  toastSuccess: vi.fn(),
+  toastError: vi.fn(),
+}));
+
+vi.mock("@/utils/takeSnapshot", () => ({
+  takeSnapshot: snapshotMock,
+  DEFAULT_SNAPSHOT_FILENAME: "test.png",
+  SNAPSHOT_SUCCESS_MESSAGE: "Snapshot saved",
+  SNAPSHOT_ERROR_MESSAGE: "Failed to capture snapshot",
+}));
+
+vi.mock("@/utils/toast", () => ({
+  conditionalToast: {
+    success: toastSuccess,
+    error: toastError,
+  },
+}));
+
+vi.mock("@/shared/utils/wasm", () => ({}));
+
+afterEach(() => {
+  snapshotMock.mockReset();
+  toastSuccess.mockReset();
+  toastError.mockReset();
+});
+
+describe("useKeyboardShortcuts snapshot integration", () => {
+  it("invokes snapshot utility on shortcut", () => {
+    const canvas = document.createElement("canvas");
+    useSpectrogramStore.setState({
+      canvasRef: { getCanvas: () => canvas } as any,
+    });
+
+    renderHook(() => useKeyboardShortcuts());
+
+    window.dispatchEvent(
+      new KeyboardEvent("keydown", { key: "s", ctrlKey: true, shiftKey: true }),
+    );
+
+    expect(snapshotMock).toHaveBeenCalled();
+    expect(toastSuccess).toHaveBeenCalledWith("Snapshot saved");
+  });
+
+  it("shows error toast when snapshot fails", () => {
+    snapshotMock.mockImplementation(() => {
+      throw new Error("fail");
+    });
+    useSpectrogramStore.setState({
+      canvasRef: { getCanvas: () => null } as any,
+    });
+
+    renderHook(() => useKeyboardShortcuts());
+
+    window.dispatchEvent(
+      new KeyboardEvent("keydown", { key: "s", ctrlKey: true, shiftKey: true }),
+    );
+
+    expect(toastError).toHaveBeenCalledWith("Failed to capture snapshot");
+  });
+});

--- a/web/apps/mfe-spectrogram/src/hooks/useKeyboardShortcuts.ts
+++ b/web/apps/mfe-spectrogram/src/hooks/useKeyboardShortcuts.ts
@@ -3,6 +3,13 @@ import { useUIStore } from "@/stores/uiStore";
 import { useAudioStore } from "@/stores/audioStore";
 import { useAudioFile } from "@/hooks/useAudioFile";
 import { conditionalToast } from "@/utils/toast";
+import { useSpectrogramStore } from "@/shared/stores/spectrogramStore";
+import {
+  takeSnapshot as captureSnapshot,
+  DEFAULT_SNAPSHOT_FILENAME,
+  SNAPSHOT_SUCCESS_MESSAGE,
+  SNAPSHOT_ERROR_MESSAGE,
+} from "@/utils/takeSnapshot";
 
 export const useKeyboardShortcuts = () => {
   const {
@@ -64,8 +71,7 @@ export const useKeyboardShortcuts = () => {
 
       // Spacebar or K - Play/Pause. Browsers inconsistently report the
       // space key so we defensively check both `key` and `code` variations.
-      const isSpace =
-        code === "Space" || key === " " || key === "Spacebar";
+      const isSpace = code === "Space" || key === " " || key === "Spacebar";
       const isK = key.toLowerCase() === "k" || code === "KeyK";
       if ((isSpace || isK) && !ctrlKey && !shiftKey && !metaKey) {
         event.preventDefault();
@@ -196,8 +202,13 @@ export const useKeyboardShortcuts = () => {
       // Ctrl/Cmd + Shift + S - Snapshot
       if (key.toLowerCase() === "s" && (ctrlKey || metaKey) && shiftKey) {
         event.preventDefault();
-        // TODO: Implement snapshot functionality
-        conditionalToast.success("Snapshot taken!");
+        try {
+          const canvas = useSpectrogramStore.getState().canvasRef?.getCanvas();
+          captureSnapshot({ canvas, fileName: DEFAULT_SNAPSHOT_FILENAME });
+          conditionalToast.success(SNAPSHOT_SUCCESS_MESSAGE);
+        } catch (error) {
+          conditionalToast.error(SNAPSHOT_ERROR_MESSAGE);
+        }
         return;
       }
 
@@ -302,8 +313,13 @@ export const useKeyboardShortcuts = () => {
     togglePlaylistPanel: () => setPlaylistPanelOpen(!playlistPanelOpen),
     openSettings: () => setSettingsPanelOpen(true),
     takeSnapshot: () => {
-      // TODO: Implement snapshot functionality
-      conditionalToast.success("Snapshot taken!");
+      try {
+        const canvas = useSpectrogramStore.getState().canvasRef?.getCanvas();
+        captureSnapshot({ canvas, fileName: DEFAULT_SNAPSHOT_FILENAME });
+        conditionalToast.success(SNAPSHOT_SUCCESS_MESSAGE);
+      } catch (error) {
+        conditionalToast.error(SNAPSHOT_ERROR_MESSAGE);
+      }
     },
   };
 };

--- a/web/apps/mfe-spectrogram/src/layout/Header.tsx
+++ b/web/apps/mfe-spectrogram/src/layout/Header.tsx
@@ -1,97 +1,268 @@
-import React, { useRef, useCallback, useMemo } from 'react'
-import { useUIStore } from '../shared/stores/uiStore'
-import { useAudioStore } from '../shared/stores/audioStore'
-import { useAudioFile } from '../shared/hooks/useAudioFile'
-import { useMicrophone } from '../shared/hooks/useMicrophone'
-import { useScreenSize } from '../shared/hooks/useScreenSize'
-import { useKeyboardShortcuts } from '../shared/hooks/useKeyboardShortcuts'
-import { FileAudio, Mic, MicOff, Settings, Camera, Info, List } from 'lucide-react'
-import { cn } from '../shared/utils/cn'
+import React, { useRef, useCallback, useMemo } from "react";
+import { useUIStore } from "../shared/stores/uiStore";
+import { useAudioStore } from "../shared/stores/audioStore";
+import { useAudioFile } from "../shared/hooks/useAudioFile";
+import { useMicrophone } from "../shared/hooks/useMicrophone";
+import { useScreenSize } from "../shared/hooks/useScreenSize";
+import { useKeyboardShortcuts } from "../shared/hooks/useKeyboardShortcuts";
+import {
+  FileAudio,
+  Mic,
+  MicOff,
+  Settings,
+  Camera,
+  Info,
+  List,
+} from "lucide-react";
+import { cn } from "../shared/utils/cn";
+import { useSpectrogramStore } from "../shared/stores/spectrogramStore";
+import {
+  takeSnapshot as captureSnapshot,
+  DEFAULT_SNAPSHOT_FILENAME,
+  SNAPSHOT_SUCCESS_MESSAGE,
+  SNAPSHOT_ERROR_MESSAGE,
+} from "../shared/utils/takeSnapshot";
+import { conditionalToast } from "../shared/utils/toast";
 
 export const Header: React.FC = () => {
-  const fileInputRef = useRef<HTMLInputElement>(null)
-  const { metadataPanelOpen, playlistPanelOpen, setMetadataPanelOpen, setPlaylistPanelOpen, setSettingsPanelOpen } = useUIStore()
-  const { isMicrophoneActive } = useAudioStore()
-  const { isMobile, isTablet } = useScreenSize()
-  const audioFile = useAudioFile()
-  const microphone = useMicrophone()
+  const fileInputRef = useRef<HTMLInputElement>(null);
+  const {
+    metadataPanelOpen,
+    playlistPanelOpen,
+    setMetadataPanelOpen,
+    setPlaylistPanelOpen,
+    setSettingsPanelOpen,
+  } = useUIStore();
+  const { isMicrophoneActive } = useAudioStore();
+  const { isMobile, isTablet } = useScreenSize();
+  const audioFile = useAudioFile();
+  const microphone = useMicrophone();
 
-  const handleFileSelect = useCallback(async (event: React.ChangeEvent<HTMLInputElement>) => {
-    const files = event.target.files
-    if (files && files.length > 0) {
-      await audioFile.loadAudioFiles(Array.from(files))
-    }
-    event.target.value = ''
-  }, [audioFile])
+  const handleFileSelect = useCallback(
+    async (event: React.ChangeEvent<HTMLInputElement>) => {
+      const files = event.target.files;
+      if (files && files.length > 0) {
+        await audioFile.loadAudioFiles(Array.from(files));
+      }
+      event.target.value = "";
+    },
+    [audioFile],
+  );
 
   const openFileDialog = useCallback(() => {
-    fileInputRef.current?.click()
-  }, [])
+    fileInputRef.current?.click();
+  }, []);
 
   const toggleMicrophone = useCallback(async () => {
-    await microphone.toggleMicrophone()
-  }, [microphone])
+    await microphone.toggleMicrophone();
+  }, [microphone]);
 
-  const takeSnapshot = useCallback(() => {
-    // Placeholder; host can provide callback via props if needed
-    console.log('Snapshot not implemented in MFE')
-  }, [])
+  const handleSnapshot = useCallback(() => {
+    try {
+      const canvas = useSpectrogramStore.getState().canvasRef?.getCanvas();
+      captureSnapshot({ canvas, fileName: DEFAULT_SNAPSHOT_FILENAME });
+      conditionalToast.success(SNAPSHOT_SUCCESS_MESSAGE);
+    } catch (error) {
+      conditionalToast.error(SNAPSHOT_ERROR_MESSAGE);
+    }
+  }, []);
 
-  useKeyboardShortcuts()
+  useKeyboardShortcuts();
 
   const buttonConfig = useMemo(() => {
     if (isMobile) {
-      return { showFileButton: true, showMicButton: true, showSettingsButton: true, showMetadataButton: true, showPlaylistButton: true, showSnapshotButton: false, showMenuButton: true }
+      return {
+        showFileButton: true,
+        showMicButton: true,
+        showSettingsButton: true,
+        showMetadataButton: true,
+        showPlaylistButton: true,
+        showSnapshotButton: false,
+        showMenuButton: true,
+      };
     } else if (isTablet) {
-      return { showFileButton: true, showMicButton: true, showSettingsButton: true, showMetadataButton: true, showPlaylistButton: true, showSnapshotButton: true, showMenuButton: false }
+      return {
+        showFileButton: true,
+        showMicButton: true,
+        showSettingsButton: true,
+        showMetadataButton: true,
+        showPlaylistButton: true,
+        showSnapshotButton: true,
+        showMenuButton: false,
+      };
     }
-    return { showFileButton: true, showMicButton: true, showSettingsButton: true, showMetadataButton: true, showPlaylistButton: true, showSnapshotButton: true, showMenuButton: false }
-  }, [isMobile, isTablet])
+    return {
+      showFileButton: true,
+      showMicButton: true,
+      showSettingsButton: true,
+      showMetadataButton: true,
+      showPlaylistButton: true,
+      showSnapshotButton: true,
+      showMenuButton: false,
+    };
+  }, [isMobile, isTablet]);
 
   return (
-    <header className={cn('bg-neutral-900 border-b border-neutral-800','flex items-center justify-between px-4','transition-colors duration-300', isMobile ? 'h-14' : 'h-12')}>
+    <header
+      className={cn(
+        "bg-neutral-900 border-b border-neutral-800",
+        "flex items-center justify-between px-4",
+        "transition-colors duration-300",
+        isMobile ? "h-14" : "h-12",
+      )}
+    >
       <div className="flex items-center min-w-0 flex-1">
-        <h1 className={cn('font-semibold text-neutral-100 truncate', isMobile ? 'text-base' : 'text-lg')}>Spectrogram</h1>
+        <h1
+          className={cn(
+            "font-semibold text-neutral-100 truncate",
+            isMobile ? "text-base" : "text-lg",
+          )}
+        >
+          Spectrogram
+        </h1>
       </div>
 
       {buttonConfig.showMenuButton && (
         <div className="flex items-center gap-1">
-          <button onClick={() => setMetadataPanelOpen(!metadataPanelOpen)} className={cn('p-2 rounded-lg transition-colors duration-200','hover:bg-neutral-800 active:bg-neutral-700','text-neutral-400 hover:text-neutral-200','min-w-[44px] min-h-[44px] flex items-center justify-center')} title="Track info (I)"><Info size={isMobile ? 20 : 18} /></button>
-          <button onClick={() => setPlaylistPanelOpen(!playlistPanelOpen)} className={cn('p-2 rounded-lg transition-colors duration-200','hover:bg-neutral-800 active:bg-neutral-700','text-neutral-400 hover:text-neutral-200','min-w-[44px] min-h-[44px] flex items-center justify-center')} title="Playlist (P)"><List size={isMobile ? 20 : 18} /></button>
+          <button
+            onClick={() => setMetadataPanelOpen(!metadataPanelOpen)}
+            className={cn(
+              "p-2 rounded-lg transition-colors duration-200",
+              "hover:bg-neutral-800 active:bg-neutral-700",
+              "text-neutral-400 hover:text-neutral-200",
+              "min-w-[44px] min-h-[44px] flex items-center justify-center",
+            )}
+            title="Track info (I)"
+          >
+            <Info size={isMobile ? 20 : 18} />
+          </button>
+          <button
+            onClick={() => setPlaylistPanelOpen(!playlistPanelOpen)}
+            className={cn(
+              "p-2 rounded-lg transition-colors duration-200",
+              "hover:bg-neutral-800 active:bg-neutral-700",
+              "text-neutral-400 hover:text-neutral-200",
+              "min-w-[44px] min-h-[44px] flex items-center justify-center",
+            )}
+            title="Playlist (P)"
+          >
+            <List size={isMobile ? 20 : 18} />
+          </button>
         </div>
       )}
 
-      <div className={cn('flex items-center gap-1', isMobile ? 'gap-1' : 'gap-2')}>
+      <div
+        className={cn("flex items-center gap-1", isMobile ? "gap-1" : "gap-2")}
+      >
         {buttonConfig.showFileButton && (
-          <button onClick={openFileDialog} className={cn('p-2 rounded-lg transition-colors duration-200','hover:bg-neutral-800 active:bg-neutral-700','text-neutral-400 hover:text-neutral-200','min-w-[44px] min-h-[44px] flex items-center justify-center')} title="Open audio file (O)"><FileAudio size={isMobile ? 20 : 18} /></button>
+          <button
+            onClick={openFileDialog}
+            className={cn(
+              "p-2 rounded-lg transition-colors duration-200",
+              "hover:bg-neutral-800 active:bg-neutral-700",
+              "text-neutral-400 hover:text-neutral-200",
+              "min-w-[44px] min-h-[44px] flex items-center justify-center",
+            )}
+            title="Open audio file (O)"
+          >
+            <FileAudio size={isMobile ? 20 : 18} />
+          </button>
         )}
 
         {buttonConfig.showMicButton && (
-          <button onClick={toggleMicrophone} className={cn('p-2 rounded-lg transition-colors duration-200','min-w-[44px] min-h-[44px] flex items-center justify-center', isMicrophoneActive ? 'text-red-400 hover:text-red-300 bg-red-500/10 hover:bg-red-500/20' : 'text-neutral-400 hover:text-neutral-200 hover:bg-neutral-800 active:bg-neutral-700')} title="Toggle microphone" aria-pressed={isMicrophoneActive}>
-            {isMicrophoneActive ? <Mic size={isMobile ? 20 : 18} /> : <MicOff size={isMobile ? 20 : 18} />}
+          <button
+            onClick={toggleMicrophone}
+            className={cn(
+              "p-2 rounded-lg transition-colors duration-200",
+              "min-w-[44px] min-h-[44px] flex items-center justify-center",
+              isMicrophoneActive
+                ? "text-red-400 hover:text-red-300 bg-red-500/10 hover:bg-red-500/20"
+                : "text-neutral-400 hover:text-neutral-200 hover:bg-neutral-800 active:bg-neutral-700",
+            )}
+            title="Toggle microphone"
+            aria-pressed={isMicrophoneActive}
+          >
+            {isMicrophoneActive ? (
+              <Mic size={isMobile ? 20 : 18} />
+            ) : (
+              <MicOff size={isMobile ? 20 : 18} />
+            )}
           </button>
         )}
 
         {buttonConfig.showSettingsButton && (
-          <button onClick={() => setSettingsPanelOpen(true)} className={cn('p-2 rounded-lg transition-colors duration-200','hover:bg-neutral-800 active:bg-neutral-700','text-neutral-400 hover:text-neutral-200','min-w-[44px] min-h-[44px] flex items-center justify-center')} title="Settings (S)"><Settings size={isMobile ? 20 : 18} /></button>
+          <button
+            onClick={() => setSettingsPanelOpen(true)}
+            className={cn(
+              "p-2 rounded-lg transition-colors duration-200",
+              "hover:bg-neutral-800 active:bg-neutral-700",
+              "text-neutral-400 hover:text-neutral-200",
+              "min-w-[44px] min-h-[44px] flex items-center justify-center",
+            )}
+            title="Settings (S)"
+          >
+            <Settings size={isMobile ? 20 : 18} />
+          </button>
         )}
 
         {buttonConfig.showSnapshotButton && (
-          <button onClick={takeSnapshot} className={cn('p-2 rounded-lg transition-colors duration-200','hover:bg-neutral-800 active:bg-neutral-700','text-neutral-400 hover:text-neutral-200','min-w-[44px] min-h-[44px] flex items-center justify-center')} title="Take snapshot (Ctrl+Shift+S)"><Camera size={isMobile ? 20 : 18} /></button>
+          <button
+            onClick={handleSnapshot}
+            className={cn(
+              "p-2 rounded-lg transition-colors duration-200",
+              "hover:bg-neutral-800 active:bg-neutral-700",
+              "text-neutral-400 hover:text-neutral-200",
+              "min-w-[44px] min-h-[44px] flex items-center justify-center",
+            )}
+            title="Take snapshot (Ctrl+Shift+S)"
+          >
+            <Camera size={isMobile ? 20 : 18} />
+          </button>
         )}
 
         {!isMobile && buttonConfig.showMetadataButton && (
-          <button onClick={() => setMetadataPanelOpen(!metadataPanelOpen)} className={cn('p-2 rounded-lg transition-colors duration-200','hover:bg-neutral-800 active:bg-neutral-700', metadataPanelOpen ? 'text-blue-400 hover:text-blue-300 bg-blue-500/10 hover:bg-blue-500/20' : 'text-neutral-400 hover:text-neutral-200','min-w-[44px] min-h-[44px] flex items-center justify-center')} title="Toggle metadata panel (I)"><Info size={18} /></button>
+          <button
+            onClick={() => setMetadataPanelOpen(!metadataPanelOpen)}
+            className={cn(
+              "p-2 rounded-lg transition-colors duration-200",
+              "hover:bg-neutral-800 active:bg-neutral-700",
+              metadataPanelOpen
+                ? "text-blue-400 hover:text-blue-300 bg-blue-500/10 hover:bg-blue-500/20"
+                : "text-neutral-400 hover:text-neutral-200",
+              "min-w-[44px] min-h-[44px] flex items-center justify-center",
+            )}
+            title="Toggle metadata panel (I)"
+          >
+            <Info size={18} />
+          </button>
         )}
 
         {!isMobile && buttonConfig.showPlaylistButton && (
-          <button onClick={() => setPlaylistPanelOpen(!playlistPanelOpen)} className={cn('p-2 rounded-lg transition-colors duration-200','hover:bg-neutral-800 active:bg-neutral-700', playlistPanelOpen ? 'text-green-400 hover:text-green-300 bg-green-500/10 hover:bg-green-500/20' : 'text-neutral-400 hover:text-neutral-200','min-w-[44px] min-h-[44px] flex items-center justify-center')} title="Toggle playlist panel (P)"><List size={18} /></button>
+          <button
+            onClick={() => setPlaylistPanelOpen(!playlistPanelOpen)}
+            className={cn(
+              "p-2 rounded-lg transition-colors duration-200",
+              "hover:bg-neutral-800 active:bg-neutral-700",
+              playlistPanelOpen
+                ? "text-green-400 hover:text-green-300 bg-green-500/10 hover:bg-green-500/20"
+                : "text-neutral-400 hover:text-neutral-200",
+              "min-w-[44px] min-h-[44px] flex items-center justify-center",
+            )}
+            title="Toggle playlist panel (P)"
+          >
+            <List size={18} />
+          </button>
         )}
       </div>
 
-      <input ref={fileInputRef} type="file" accept="audio/*" multiple onChange={handleFileSelect} className="hidden" />
+      <input
+        ref={fileInputRef}
+        type="file"
+        accept="audio/*"
+        multiple
+        onChange={handleFileSelect}
+        className="hidden"
+      />
     </header>
-  )
-}
-
-
+  );
+};

--- a/web/apps/mfe-spectrogram/src/shared/hooks/useKeyboardShortcuts.ts
+++ b/web/apps/mfe-spectrogram/src/shared/hooks/useKeyboardShortcuts.ts
@@ -3,6 +3,13 @@ import { useUIStore } from "@/shared/stores/uiStore";
 import { useAudioStore } from "@/shared/stores/audioStore";
 import { useAudioFile } from "@/shared/hooks/useAudioFile";
 import { conditionalToast } from "@/shared/utils/toast";
+import { useSpectrogramStore } from "@/shared/stores/spectrogramStore";
+import {
+  takeSnapshot as captureSnapshot,
+  DEFAULT_SNAPSHOT_FILENAME,
+  SNAPSHOT_SUCCESS_MESSAGE,
+  SNAPSHOT_ERROR_MESSAGE,
+} from "@/shared/utils/takeSnapshot";
 
 export const useKeyboardShortcuts = () => {
   const {
@@ -64,8 +71,7 @@ export const useKeyboardShortcuts = () => {
 
       // Spacebar or K - Play/Pause. Browsers inconsistently report the
       // space key so we defensively check both `key` and `code` variations.
-      const isSpace =
-        code === "Space" || key === " " || key === "Spacebar";
+      const isSpace = code === "Space" || key === " " || key === "Spacebar";
       const isK = key.toLowerCase() === "k" || code === "KeyK";
       if ((isSpace || isK) && !ctrlKey && !shiftKey && !metaKey) {
         event.preventDefault();
@@ -196,8 +202,13 @@ export const useKeyboardShortcuts = () => {
       // Ctrl/Cmd + Shift + S - Snapshot
       if (key.toLowerCase() === "s" && (ctrlKey || metaKey) && shiftKey) {
         event.preventDefault();
-        // TODO: Implement snapshot functionality
-        conditionalToast.success("Snapshot taken!");
+        try {
+          const canvas = useSpectrogramStore.getState().canvasRef?.getCanvas();
+          captureSnapshot({ canvas, fileName: DEFAULT_SNAPSHOT_FILENAME });
+          conditionalToast.success(SNAPSHOT_SUCCESS_MESSAGE);
+        } catch (error) {
+          conditionalToast.error(SNAPSHOT_ERROR_MESSAGE);
+        }
         return;
       }
 
@@ -302,8 +313,13 @@ export const useKeyboardShortcuts = () => {
     togglePlaylistPanel: () => setPlaylistPanelOpen(!playlistPanelOpen),
     openSettings: () => setSettingsPanelOpen(true),
     takeSnapshot: () => {
-      // TODO: Implement snapshot functionality
-      conditionalToast.success("Snapshot taken!");
+      try {
+        const canvas = useSpectrogramStore.getState().canvasRef?.getCanvas();
+        captureSnapshot({ canvas, fileName: DEFAULT_SNAPSHOT_FILENAME });
+        conditionalToast.success(SNAPSHOT_SUCCESS_MESSAGE);
+      } catch (error) {
+        conditionalToast.error(SNAPSHOT_ERROR_MESSAGE);
+      }
     },
   };
 };

--- a/web/apps/mfe-spectrogram/src/shared/utils/takeSnapshot.ts
+++ b/web/apps/mfe-spectrogram/src/shared/utils/takeSnapshot.ts
@@ -1,0 +1,73 @@
+// Utility for capturing spectrogram canvas snapshots.
+// Provides a single function `takeSnapshot` that converts the current
+// spectrogram canvas to a PNG data URL and either downloads it or passes it
+// to a caller-supplied callback. The function validates all inputs and
+// fails fast with clear errors so that calling code can provide user
+// feedback. The implementation avoids unnecessary allocations and cleans up
+// any created DOM nodes to prevent memory leaks.
+
+/**
+ * Default filename used when saving a spectrogram snapshot.
+ * Named constant avoids hard-coded strings throughout the codebase.
+ */
+export const DEFAULT_SNAPSHOT_FILENAME = "spectrogram-snapshot.png" as const;
+
+/** Message shown when a snapshot is successfully captured. */
+export const SNAPSHOT_SUCCESS_MESSAGE = "Snapshot saved" as const;
+
+/** Message shown when snapshot capture fails. */
+export const SNAPSHOT_ERROR_MESSAGE = "Failed to capture snapshot" as const;
+
+/**
+ * Options for the `takeSnapshot` utility.
+ * `canvas`   - The canvas element to capture. Required.
+ * `fileName` - Optional file name for the download. Defaults to
+ *              `DEFAULT_SNAPSHOT_FILENAME`.
+ * `onSnapshot` - Optional callback invoked with the data URL. Use this
+ *                when the host application wants to handle storage itself
+ *                instead of triggering a download.
+ */
+export interface SnapshotOptions {
+  canvas: HTMLCanvasElement | null;
+  fileName?: string;
+  onSnapshot?: (dataUrl: string) => void;
+}
+
+/**
+ * Capture the provided canvas as a PNG image.
+ *
+ * @param options - Configuration describing how the snapshot should be
+ *                  handled.
+ * @returns The PNG data URL representing the snapshot.
+ * @throws If the canvas is null/undefined or if canvas serialization fails.
+ */
+export function takeSnapshot(options: SnapshotOptions): string {
+  const { canvas, fileName = DEFAULT_SNAPSHOT_FILENAME, onSnapshot } = options;
+
+  // Validate input early to fail fast and surface clear errors to callers.
+  if (!canvas) {
+    throw new Error("takeSnapshot: canvas is required");
+  }
+
+  // toDataURL is synchronous and returns a base64-encoded string. We call it
+  // once to avoid extra allocations or conversions.
+  const dataUrl = canvas.toDataURL("image/png");
+
+  if (onSnapshot) {
+    // Delegate saving to caller for maximum flexibility. This avoids DOM
+    // manipulation when not needed and lets apps persist the data in state
+    // or elsewhere.
+    onSnapshot(dataUrl);
+  } else {
+    // Trigger a download by creating a temporary anchor element. The element
+    // is immediately removed after the click to avoid polluting the DOM.
+    const link = document.createElement("a");
+    link.href = dataUrl;
+    link.download = fileName;
+    // The click is synchronous; no need to append to the DOM first.
+    link.click();
+    link.remove();
+  }
+
+  return dataUrl;
+}

--- a/web/apps/mfe-spectrogram/src/utils/__tests__/takeSnapshot.test.ts
+++ b/web/apps/mfe-spectrogram/src/utils/__tests__/takeSnapshot.test.ts
@@ -1,0 +1,38 @@
+/* @vitest-environment jsdom */
+import { describe, it, expect, vi } from "vitest";
+import { takeSnapshot, DEFAULT_SNAPSHOT_FILENAME } from "../takeSnapshot";
+
+// Helper to create a small canvas for testing without heavy memory use.
+function createTestCanvas(): HTMLCanvasElement {
+  const canvas = document.createElement("canvas");
+  canvas.width = 2;
+  canvas.height = 2;
+  const ctx = canvas.getContext("2d");
+  if (ctx) {
+    ctx.fillStyle = "black";
+    ctx.fillRect(0, 0, 2, 2);
+  }
+  return canvas;
+}
+
+describe("takeSnapshot", () => {
+  it("returns data URL and invokes callback on success", () => {
+    const canvas = createTestCanvas();
+    const onSnapshot = vi.fn();
+
+    const url = takeSnapshot({
+      canvas,
+      fileName: DEFAULT_SNAPSHOT_FILENAME,
+      onSnapshot,
+    });
+
+    expect(url.startsWith("data:image/png")).toBe(true);
+    expect(onSnapshot).toHaveBeenCalledWith(url);
+  });
+
+  it("throws an error when canvas is missing", () => {
+    expect(() => takeSnapshot({ canvas: null })).toThrow(
+      "takeSnapshot: canvas is required",
+    );
+  });
+});

--- a/web/apps/mfe-spectrogram/src/utils/takeSnapshot.ts
+++ b/web/apps/mfe-spectrogram/src/utils/takeSnapshot.ts
@@ -1,0 +1,3 @@
+// Re-export the shared snapshot utility so components can import from
+// "@/utils/takeSnapshot" without duplicating implementation logic.
+export * from "../shared/utils/takeSnapshot";


### PR DESCRIPTION
## Summary
- add reusable spectrogram snapshot utility with error handling
- wire snapshot capture into header controls and keyboard shortcut hook
- cover snapshot success, failure, and shortcut handling with tests

## Testing
- `npm test` *(fails: requestAnimationFrame is not defined, missing modules)*
- `npx vitest run src/utils/__tests__/takeSnapshot.test.ts src/hooks/__tests__/useKeyboardShortcuts.test.ts`
- `npm test` *(root cargo tests)*

------
https://chatgpt.com/codex/tasks/task_e_68a71caa0278832bba9b7a459901c7d0