### PR TITLE
Add spectrogram snapshot utility and integrate keyboard shortcut

### DIFF
--- a/web/apps/mfe-spectrogram/src/components/__tests__/SnapshotShortcut.test.tsx
+++ b/web/apps/mfe-spectrogram/src/components/__tests__/SnapshotShortcut.test.tsx
@@ -1,0 +1,81 @@
+import { render, waitFor } from "@testing-library/react";
+import { describe, it, beforeEach, expect, vi, Mock } from "vitest";
+import React from "react";
+
+// Mock modules that carry heavy dependencies to keep the test lightweight
+vi.mock("@/shared/hooks/useAudioFile", () => ({
+  useAudioFile: () => ({
+    playTrack: vi.fn(),
+    pausePlayback: vi.fn(),
+    resumePlayback: vi.fn(),
+    seekTo: vi.fn(),
+    setAudioVolume: vi.fn(),
+    toggleMute: vi.fn(),
+  }),
+}));
+
+vi.mock("@/shared/utils/takeSnapshot", () => ({
+  takeSnapshot: vi.fn(),
+}));
+
+vi.mock("@/shared/utils/toast", () => ({
+  conditionalToast: {
+    success: vi.fn(),
+    error: vi.fn(),
+    warning: vi.fn(),
+    info: vi.fn(),
+  },
+}));
+
+// Mock WASM utilities to avoid loading heavy modules
+vi.mock("@/shared/utils/wasm", () => ({
+  extractMetadata: vi.fn(),
+  generateAmplitudeEnvelope: vi.fn(),
+  resampleAudio: vi.fn(),
+}));
+
+vi.mock("@wasm/web_spectrogram", () => ({}));
+
+import { useKeyboardShortcuts } from "@/shared/hooks/useKeyboardShortcuts";
+import { conditionalToast } from "@/shared/utils/toast";
+import { takeSnapshot } from "@/shared/utils/takeSnapshot";
+
+/** Simple component that wires up the keyboard shortcuts hook. */
+const TestHarness: React.FC = () => {
+  useKeyboardShortcuts();
+  return <canvas data-testid="spectrogram-canvas" />;
+};
+
+describe("snapshot keyboard shortcut", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("shows success toast on snapshot", async () => {
+    (takeSnapshot as Mock).mockResolvedValue("data:image/png");
+    render(<TestHarness />);
+
+    window.dispatchEvent(
+      new KeyboardEvent("keydown", { key: "s", ctrlKey: true, shiftKey: true }),
+    );
+
+    await waitFor(() => {
+      expect(takeSnapshot).toHaveBeenCalled();
+      expect(conditionalToast.success).toHaveBeenCalled();
+    });
+  });
+
+  it("shows error toast when snapshot fails", async () => {
+    (takeSnapshot as Mock).mockRejectedValue(new Error("fail"));
+    render(<TestHarness />);
+
+    window.dispatchEvent(
+      new KeyboardEvent("keydown", { key: "s", ctrlKey: true, shiftKey: true }),
+    );
+
+    await waitFor(() => {
+      expect(takeSnapshot).toHaveBeenCalled();
+      expect(conditionalToast.error).toHaveBeenCalled();
+    });
+  });
+});

--- a/web/apps/mfe-spectrogram/src/components/layout/Header.tsx
+++ b/web/apps/mfe-spectrogram/src/components/layout/Header.tsx
@@ -16,6 +16,13 @@ import {
   Menu,
 } from "lucide-react";
 import { cn } from "@/utils/cn";
+import { takeSnapshot } from "@/shared/utils/takeSnapshot";
+import { conditionalToast } from "@/shared/utils/toast";
+
+/** User-facing text shown when a snapshot succeeds. */
+const SNAPSHOT_SUCCESS_MESSAGE = "Snapshot captured";
+/** User-facing text shown when a snapshot fails. */
+const SNAPSHOT_ERROR_MESSAGE = "Snapshot failed";
 
 export const Header: React.FC = () => {
   const fileInputRef = useRef<HTMLInputElement>(null);
@@ -59,10 +66,18 @@ export const Header: React.FC = () => {
     await microphone.toggleMicrophone();
   }, [microphone]);
 
-  // Take snapshot
-  const takeSnapshot = useCallback(() => {
-    // TODO: Implement snapshot functionality
-    console.log("Snapshot feature not yet implemented");
+  /**
+   * Capture the spectrogram canvas and notify the user of the outcome.
+   * The utility returns a data URL which could be stored elsewhere if
+   * desired; here we simply trigger a download and toast the result.
+   */
+  const handleSnapshot = useCallback(async () => {
+    try {
+      await takeSnapshot();
+      conditionalToast.success(SNAPSHOT_SUCCESS_MESSAGE);
+    } catch {
+      conditionalToast.error(SNAPSHOT_ERROR_MESSAGE);
+    }
   }, []);
 
   // Keyboard shortcuts
@@ -231,7 +246,7 @@ export const Header: React.FC = () => {
         {/* Snapshot button */}
         {buttonConfig.showSnapshotButton && (
           <button
-            onClick={takeSnapshot}
+            onClick={handleSnapshot}
             className={cn(
               "p-2 rounded-lg transition-colors duration-200",
               "hover:bg-neutral-800 active:bg-neutral-700",

--- a/web/apps/mfe-spectrogram/src/shared/utils/__tests__/takeSnapshot.test.ts
+++ b/web/apps/mfe-spectrogram/src/shared/utils/__tests__/takeSnapshot.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { takeSnapshot, DEFAULT_SNAPSHOT_FILENAME } from "../takeSnapshot";
+
+/**
+ * Test suite for the takeSnapshot utility. The tests use a real canvas element
+ * but mock out DOM interactions like the synthetic download link to keep the
+ * environment deterministic.
+ */
+describe("takeSnapshot", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    document.body.innerHTML = "";
+  });
+
+  it("captures canvas and triggers download", async () => {
+    const canvas = document.createElement("canvas");
+    canvas.width = 10;
+    canvas.height = 10;
+    // Deterministically encode to a data URL
+    const dataUrl = "data:image/png;base64,TEST";
+    vi.spyOn(canvas, "toDataURL").mockReturnValue(dataUrl);
+    document.body.appendChild(canvas);
+
+    // Spy on link click without actually navigating
+    const clickSpy = vi
+      .spyOn(HTMLAnchorElement.prototype, "click")
+      .mockImplementation(() => {});
+
+    const result = await takeSnapshot({ canvas });
+
+    expect(result).toBe(dataUrl);
+    expect(canvas.toDataURL).toHaveBeenCalledWith("image/png");
+    expect(clickSpy).toHaveBeenCalled();
+    // Ensure default filename is applied
+    const link = clickSpy.mock.instances[0] as HTMLAnchorElement;
+    expect(link.download).toBe(DEFAULT_SNAPSHOT_FILENAME);
+  });
+
+  it("throws when no canvas is available", async () => {
+    await expect(takeSnapshot()).rejects.toThrow(
+      "Spectrogram canvas not found",
+    );
+  });
+});

--- a/web/apps/mfe-spectrogram/src/shared/utils/takeSnapshot.ts
+++ b/web/apps/mfe-spectrogram/src/shared/utils/takeSnapshot.ts
@@ -1,0 +1,77 @@
+/**
+ * Default filename used when saving a spectrogram snapshot to disk.
+ * Having a named constant avoids scattering magic strings and simplifies
+ * future refactors such as localisation.
+ */
+export const DEFAULT_SNAPSHOT_FILENAME = "spectrogram-snapshot.png";
+
+/**
+ * Configuration options for the takeSnapshot utility. Callers may provide
+ * a specific canvas and opt-out of the automatic download behaviour.
+ */
+export interface SnapshotOptions {
+  /**
+   * Canvas element to capture. When omitted the utility searches the DOM for
+   * the spectrogram canvas via its data-testid attribute. Passing a canvas
+   * reference avoids DOM queries and is slightly faster.
+   */
+  canvas?: HTMLCanvasElement | null;
+  /**
+   * Filename used when triggering a download. Defaults to
+   * DEFAULT_SNAPSHOT_FILENAME.
+   */
+  fileName?: string;
+  /**
+   * Whether the utility should automatically download the captured image.
+   * Disable to merely receive the data URL and handle it externally.
+   */
+  triggerDownload?: boolean;
+}
+
+/**
+ * Capture the current spectrogram canvas as a PNG image. The PNG data URL is
+ * returned so callers may store it in application state. When
+ * `triggerDownload` is true (default), a synthetic download is initiated.
+ *
+ * @throws Error if no canvas is available or the capture process fails.
+ */
+export const takeSnapshot = async ({
+  canvas,
+  fileName = DEFAULT_SNAPSHOT_FILENAME,
+  triggerDownload = true,
+}: SnapshotOptions = {}): Promise<string> => {
+  try {
+    // Prefer the explicitly provided canvas, otherwise search the DOM for
+    // the spectrogram element. This keeps the utility reusable across
+    // components without tight coupling.
+    const target =
+      canvas ??
+      document.querySelector<HTMLCanvasElement>(
+        '[data-testid="spectrogram-canvas"]',
+      );
+    if (!target) {
+      throw new Error("Spectrogram canvas not found");
+    }
+
+    // Export the canvas to a PNG data URL. toDataURL performs the encoding
+    // in-place without creating intermediate canvas copies, keeping memory
+    // usage minimal.
+    const dataUrl = target.toDataURL("image/png");
+
+    if (triggerDownload) {
+      // Create a temporary link to prompt the browser to download the image.
+      const link = document.createElement("a");
+      link.href = dataUrl;
+      link.download = fileName;
+      // Using click() avoids adding the element to the DOM, keeping the
+      // operation lightweight.
+      link.click();
+    }
+
+    return dataUrl;
+  } catch (err) {
+    // Normalise unknown errors into Error instances to aid caller handling.
+    const error = err instanceof Error ? err : new Error(String(err));
+    throw error;
+  }
+};


### PR DESCRIPTION
## Summary
- add reusable `takeSnapshot` utility for spectrogram canvas
- wire header and keyboard shortcut to use snapshot helper with toasts
- add unit tests for snapshot success, failure, and keyboard shortcut

## Testing
- `npx vitest run src/shared/utils/__tests__/takeSnapshot.test.ts src/components/__tests__/SnapshotShortcut.test.tsx --environment jsdom`
- `cargo test`
- `npm test` *(fails: transform errors and missing DOM APIs in existing suite)*

------
https://chatgpt.com/codex/tasks/task_e_68a7213b8d50832b911afe0b33fc476d