### PR TITLE
feat(web-shell): centralize spacing and animation constants

### DIFF
--- a/web/apps/shell/src/themes/bauhaus/BauhausLayout.test.tsx
+++ b/web/apps/shell/src/themes/bauhaus/BauhausLayout.test.tsx
@@ -1,12 +1,8 @@
 import React from "react";
 import { describe, it, expect } from "vitest";
 import { render } from "@testing-library/react";
-import {
-  BauhausLayout,
-  Block,
-  GRID_COLUMNS,
-  GRID_GAP_REM,
-} from "./BauhausLayout";
+import { BauhausLayout, Block, GRID_COLUMNS } from "./BauhausLayout";
+import { GRID_GAP_REM } from "../../ui/Spacing";
 import { RED } from "./palette";
 
 /** Convert hex colour strings to rgb() format for style comparisons. */

--- a/web/apps/shell/src/themes/bauhaus/BauhausLayout.tsx
+++ b/web/apps/shell/src/themes/bauhaus/BauhausLayout.tsx
@@ -1,12 +1,10 @@
 import React, { CSSProperties, ReactNode, useMemo } from "react";
 import { useGridTransitions } from "./useGridTransitions";
 import { WHITE, BLACK, RED, BAUHAUS_BLUE, BAUHAUS_YELLOW } from "./palette";
+import { GRID_GAP_REM, LINE_THICKNESS_REM } from "../../ui/Spacing";
 
 /** Number of columns used in the Bauhaus grid. */
 export const GRID_COLUMNS = 12 as const;
-
-/** Gap between grid cells expressed in rem units. */
-export const GRID_GAP_REM = 0.5 as const;
 
 /** Full viewport height ensuring the layout fills the screen. */
 const FULL_HEIGHT = "100vh" as const;
@@ -78,9 +76,6 @@ export interface LineProps {
   readonly orientation: "horizontal" | "vertical";
   readonly index: number;
 }
-
-/** Thickness of rendered lines in rem units. */
-export const LINE_THICKNESS_REM = 0.25 as const;
 
 /**
  * Render a thin line spanning the grid in a single direction.

--- a/web/apps/shell/src/themes/bauhaus/useGridTransitions.test.ts
+++ b/web/apps/shell/src/themes/bauhaus/useGridTransitions.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from "vitest";
 import { renderHook } from "@testing-library/react";
-import { useGridTransitions, SLIDE_DURATION_MS } from "./useGridTransitions";
+import { useGridTransitions } from "./useGridTransitions";
+import { SLIDE_DURATION_MS } from "../../ui/AnimationDurations";
 
 /** Validate behaviour of the sliding transition hook. */
 describe("useGridTransitions", () => {

--- a/web/apps/shell/src/themes/bauhaus/useGridTransitions.ts
+++ b/web/apps/shell/src/themes/bauhaus/useGridTransitions.ts
@@ -1,12 +1,11 @@
 import { CSSProperties, useMemo } from "react";
-
-/** Duration in milliseconds for slide transitions. */
-export const SLIDE_DURATION_MS = 250 as const;
+import { SLIDE_DURATION_MS } from "../../ui/AnimationDurations";
 
 /**
  * Memoised style object enabling sliding grid reveals.
- * Using `transform` avoids expensive reflow operations and `willChange`
- * hints the browser to optimise for upcoming animations.
+ * Pulling the duration from {@link SLIDE_DURATION_MS} ensures consistent
+ * motion, while using `transform` avoids reflow and `willChange` hints the
+ * browser to optimise for upcoming animations.
  */
 export function useGridTransitions(): { readonly style: CSSProperties } {
   const style = useMemo<CSSProperties>(

--- a/web/apps/shell/src/themes/japanese/JapaneseLayout.test.tsx
+++ b/web/apps/shell/src/themes/japanese/JapaneseLayout.test.tsx
@@ -1,7 +1,8 @@
 import React from "react";
 import { describe, it, expect } from "vitest";
 import { render } from "@testing-library/react";
-import { JapaneseLayout, LAYOUT_GAP_REM } from "./JapaneseLayout";
+import { JapaneseLayout } from "./JapaneseLayout";
+import { LAYOUT_GAP_REM } from "../../ui/Spacing";
 
 /** Validate JapaneseLayout behaviour and structure. */
 describe("JapaneseLayout", () => {
@@ -22,17 +23,23 @@ describe("JapaneseLayout", () => {
   it("throws on missing required props", () => {
     expect(() =>
       render(
-        <JapaneseLayout header={null as any} footer={<div />}>text</JapaneseLayout>,
+        <JapaneseLayout header={null as any} footer={<div />}>
+          text
+        </JapaneseLayout>,
       ),
     ).toThrow();
     expect(() =>
       render(
-        <JapaneseLayout header={<div />} footer={null as any}>text</JapaneseLayout>,
+        <JapaneseLayout header={<div />} footer={null as any}>
+          text
+        </JapaneseLayout>,
       ),
     ).toThrow();
     expect(() =>
       render(
-        <JapaneseLayout header={<div />} footer={<div />}>{null}</JapaneseLayout>,
+        <JapaneseLayout header={<div />} footer={<div />}>
+          {null}
+        </JapaneseLayout>,
       ),
     ).toThrow();
   });

--- a/web/apps/shell/src/themes/japanese/JapaneseLayout.tsx
+++ b/web/apps/shell/src/themes/japanese/JapaneseLayout.tsx
@@ -1,8 +1,6 @@
 import React, { CSSProperties, ReactNode, useMemo } from "react";
 import { useMinimalFades } from "./useMinimalFades";
-
-/** Vertical spacing between layout sections expressed in rem units. */
-export const LAYOUT_GAP_REM = 1 as const;
+import { LAYOUT_GAP_REM } from "../../ui/Spacing";
 
 /** Height of the layout viewport ensuring full-screen coverage. */
 const FULL_HEIGHT = "100vh" as const;
@@ -44,7 +42,10 @@ export function JapaneseLayout({
     [],
   );
 
-  const mainStyle = useMemo<CSSProperties>(() => ({ flex: 1, display: "grid", placeItems: "center" }), []);
+  const mainStyle = useMemo<CSSProperties>(
+    () => ({ flex: 1, display: "grid", placeItems: "center" }),
+    [],
+  );
 
   return (
     <div style={containerStyle}>

--- a/web/apps/shell/src/themes/japanese/useMinimalFades.test.ts
+++ b/web/apps/shell/src/themes/japanese/useMinimalFades.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from "vitest";
 import { renderHook } from "@testing-library/react";
-import { useMinimalFades, FADE_DURATION_MS } from "./useMinimalFades";
+import { useMinimalFades } from "./useMinimalFades";
+import { FADE_DURATION_MS } from "../../ui/AnimationDurations";
 
 /** Validate behaviour of the fade hook. */
 describe("useMinimalFades", () => {

--- a/web/apps/shell/src/themes/japanese/useMinimalFades.ts
+++ b/web/apps/shell/src/themes/japanese/useMinimalFades.ts
@@ -1,12 +1,11 @@
 import { useMemo } from "react";
 import { CSSProperties } from "react";
-
-/** Duration in milliseconds for fade transitions ensuring subtlety. */
-export const FADE_DURATION_MS = 200 as const;
+import { FADE_DURATION_MS } from "../../ui/AnimationDurations";
 
 /**
  * Hook producing memoised style props for minimal fade transitions.
- * The memoisation avoids repeatedly allocating style objects, reducing
+ * Leveraging the shared {@link FADE_DURATION_MS} constant keeps timings
+ * consistent while memoisation avoids repeated allocations, reducing
  * garbage collection pressure during re-renders.
  */
 export function useMinimalFades(): { readonly style: CSSProperties } {

--- a/web/apps/shell/src/ui/AnimationDurations.test.ts
+++ b/web/apps/shell/src/ui/AnimationDurations.test.ts
@@ -1,0 +1,13 @@
+import { describe, it, expect } from "vitest";
+import { FADE_DURATION_MS, SLIDE_DURATION_MS } from "./AnimationDurations";
+
+/** Ensure animation duration constants remain stable for predictable motion. */
+describe("Animation duration constants", () => {
+  it("exposes the fade duration", () => {
+    expect(FADE_DURATION_MS).toBe(200);
+  });
+
+  it("exposes the slide duration", () => {
+    expect(SLIDE_DURATION_MS).toBe(250);
+  });
+});

--- a/web/apps/shell/src/ui/AnimationDurations.ts
+++ b/web/apps/shell/src/ui/AnimationDurations.ts
@@ -1,0 +1,11 @@
+/**
+ * Animation timing constants used across shell UI components.
+ * Consolidating durations encourages consistent motion design and
+ * simplifies future tuning for performance.
+ */
+
+/** Fade transition duration in milliseconds providing subtlety without lag. */
+export const FADE_DURATION_MS = 200 as const;
+
+/** Slide transition duration in milliseconds balancing speed and clarity. */
+export const SLIDE_DURATION_MS = 250 as const;

--- a/web/apps/shell/src/ui/Spacing.test.ts
+++ b/web/apps/shell/src/ui/Spacing.test.ts
@@ -1,0 +1,17 @@
+import { describe, it, expect } from "vitest";
+import { LAYOUT_GAP_REM, GRID_GAP_REM, LINE_THICKNESS_REM } from "./Spacing";
+
+/** Verify that shared spacing constants expose stable numeric values. */
+describe("Spacing constants", () => {
+  it("yields the expected layout gap", () => {
+    expect(LAYOUT_GAP_REM).toBe(1);
+  });
+
+  it("yields the expected grid gap", () => {
+    expect(GRID_GAP_REM).toBe(0.5);
+  });
+
+  it("yields the expected line thickness", () => {
+    expect(LINE_THICKNESS_REM).toBe(0.25);
+  });
+});

--- a/web/apps/shell/src/ui/Spacing.ts
+++ b/web/apps/shell/src/ui/Spacing.ts
@@ -1,0 +1,14 @@
+/**
+ * Spacing constants shared across shell UI components.
+ * Centralising these values avoids scattered magic numbers and ensures
+ * consistent rhythm throughout the interface.
+ */
+
+/** Vertical gap between stacked layout sections measured in rem units. */
+export const LAYOUT_GAP_REM = 1 as const;
+
+/** Gap between grid cells used by Bauhaus layouts in rem units. */
+export const GRID_GAP_REM = 0.5 as const;
+
+/** Thickness of Bauhaus lines expressed in rem units. */
+export const LINE_THICKNESS_REM = 0.25 as const;


### PR DESCRIPTION
## Summary
- add shared Spacing and AnimationDurations utilities
- refactor Japanese and Bauhaus layouts to use shared constants
- cover new utilities with unit tests and update existing tests

## Testing
- `npx eslint .`
- `npm test`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68a73588b0a0832b979fa7cd2c2fc3e0