### PR TITLE
Clarify Hilbert transform single-element handling and optimize allocation

### DIFF
--- a/src/hilbert.rs
+++ b/src/hilbert.rs
@@ -5,8 +5,12 @@
 extern crate alloc;
 use crate::fft::FftImpl;
 use crate::fft::{Complex32, FftError, ScalarFftImpl};
-use alloc::vec;
 use alloc::vec::Vec;
+
+/// Multiplier applied to positive-frequency components when constructing the
+/// analytic signal. Doubling these bins preserves the original signal's
+/// amplitude after negative frequencies are nulled.
+const POSITIVE_FREQ_SCALE: f32 = 2.0;
 
 /// Compute the analytic signal (Hilbert transform) of a real input
 /// Returns a Vec<Complex32> of the analytic signal
@@ -18,27 +22,25 @@ pub fn hilbert_analytic(input: &[f32]) -> Result<Vec<Complex32>, FftError> {
         return Err(FftError::NonPowerOfTwoNoStd);
     }
     let n = input.len();
-    let mut freq = vec![Complex32::zero(); n];
-    for (i, &x) in input.iter().enumerate() {
-        freq[i] = Complex32::new(x, 0.0);
+    // Preallocate without zero-initialization to avoid needless memory
+    // overhead, then push each real sample as a complex value.
+    let mut freq: Vec<Complex32> = Vec::with_capacity(n);
+    for &x in input {
+        freq.push(Complex32::new(x, 0.0));
     }
     let fft = ScalarFftImpl::<f32>::default();
     fft.fft(&mut freq)?;
-    if n.is_multiple_of(2) {
-        for f in freq.iter_mut().take(n / 2).skip(1) {
-            f.re *= 2.0;
-            f.im *= 2.0;
-        }
-        for f in freq.iter_mut().take(n).skip(n / 2 + 1) {
-            *f = Complex32::zero();
-        }
+    if n == 1 {
+        // Single-element signals contain only a DC component; no scaling or
+        // zeroing is required.
     } else {
-        for f in freq.iter_mut().take((n - 1) / 2 + 1).skip(1) {
-            f.re *= 2.0;
-            f.im *= 2.0;
+        // For power-of-two lengths greater than one, double positive
+        // frequencies (excluding DC and Nyquist) and zero out negatives.
+        for f in freq.iter_mut().take(n / 2).skip(1) {
+            f.re *= POSITIVE_FREQ_SCALE;
+            f.im *= POSITIVE_FREQ_SCALE;
         }
-        let start = n.div_ceil(2);
-        for f in freq.iter_mut().take(n).skip(start) {
+        for f in freq.iter_mut().skip(n / 2 + 1) {
             *f = Complex32::zero();
         }
     }
@@ -49,15 +51,37 @@ pub fn hilbert_analytic(input: &[f32]) -> Result<Vec<Complex32>, FftError> {
 #[cfg(all(feature = "internal-tests", test))]
 mod tests {
     use super::*;
+    use alloc::vec;
+    /// The transform of a single-sample signal should be that sample with a
+    /// zero imaginary component.
     #[test]
-    fn test_hilbert_analytic() {
-        let x = [1.0, 0.0, -1.0, 0.0];
+    fn hilbert_single_sample() {
+        let x = [42.0];
         let analytic = hilbert_analytic(&x).unwrap();
-        assert_eq!(analytic.len(), x.len());
+        assert_eq!(analytic, vec![Complex32::new(42.0, 0.0)]);
     }
 
+    /// Even-length inputs should preserve the real part and produce the expected
+    /// imaginary response for an impulse.
     #[test]
-    fn test_hilbert_errors() {
+    fn hilbert_even_impulse() {
+        let x = [1.0, 0.0, 0.0, 0.0];
+        let analytic = hilbert_analytic(&x).unwrap();
+        let expected = [
+            Complex32::new(1.0, 0.0),
+            Complex32::new(0.0, 0.5),
+            Complex32::new(0.0, 0.0),
+            Complex32::new(0.0, -0.5),
+        ];
+        for (a, e) in analytic.iter().zip(expected.iter()) {
+            assert!((a.re - e.re).abs() < 1e-6);
+            assert!((a.im - e.im).abs() < 1e-6);
+        }
+    }
+
+    /// Confirm that error conditions are properly reported.
+    #[test]
+    fn hilbert_errors() {
         assert_eq!(hilbert_analytic(&[]).unwrap_err(), FftError::EmptyInput);
         let x = [1.0, 2.0, 3.0];
         assert_eq!(


### PR DESCRIPTION
## Summary
- allocate Hilbert transform buffer with `Vec::with_capacity` and fill manually
- introduce `POSITIVE_FREQ_SCALE` constant and handle `n == 1` explicitly
- add unit tests for single-sample and even-length inputs

## Testing
- `cargo clippy --features internal-tests -- -D warnings`
- `cargo test --features internal-tests`
- `cargo test --features internal-tests hilbert::tests:: -- --nocapture`


------
https://chatgpt.com/codex/tasks/task_e_68a738188480832bb495de6321358a5d