### PR TITLE
refactor fuzzy_match length reuse

### DIFF
--- a/src/fuzzy.rs
+++ b/src/fuzzy.rs
@@ -1,7 +1,17 @@
 use alloc::{string::String, vec, vec::Vec};
 
+/// Divisor used to determine the maximum allowed edit distance as a fraction
+/// of the pattern length. A value of `2` restricts matches to an edit distance
+/// of at most half the pattern length.
+const MATCH_THRESHOLD_DIVISOR: usize = 2;
+
 /// Compute the Levenshtein distance between two strings.
+///
 /// Lower scores indicate closer matches.
+///
+/// # Complexity
+/// - Time: `O(p * t)` where `p` is the pattern length and `t` is the text length.
+/// - Space: `O(t)` for the dynamic programming rows.
 pub fn fuzzy_score(pattern: &str, text: &str) -> usize {
     let pattern_chars: Vec<char> = pattern.chars().collect();
     let text_chars: Vec<char> = text.chars().collect();
@@ -25,12 +35,24 @@ pub fn fuzzy_score(pattern: &str, text: &str) -> usize {
     prev[text_len]
 }
 
-/// Determine if two strings match within half the pattern length.
+/// Determine if two strings are similar enough that the edit distance does not
+/// exceed half the pattern length. The pattern length is computed once and
+/// reused to avoid redundant iteration.
+///
+/// # Complexity
+/// - Time: `O(p * t)` delegated to [`fuzzy_score`].
+/// - Space: `O(t)` delegated to [`fuzzy_score`].
 pub fn fuzzy_match(pattern: &str, text: &str) -> bool {
-    fuzzy_score(pattern, text) <= pattern.chars().count() / 2
+    let len = pattern.chars().count();
+    fuzzy_score(pattern, text) <= len / MATCH_THRESHOLD_DIVISOR
 }
 
 /// Compute fuzzy scores for a batch of candidate strings.
+///
+/// # Complexity
+/// - Time: `O(n * p * t)` where `n` is the number of candidates.
+/// - Space: `O(n)` for the resulting vector plus `O(t)` per call to
+///   [`fuzzy_score`].
 pub fn fuzzy_scores(pattern: &str, candidates: &[String]) -> Vec<usize> {
     candidates.iter().map(|c| fuzzy_score(pattern, c)).collect()
 }
@@ -40,18 +62,21 @@ mod tests {
     use super::*;
     use alloc::format;
 
+    /// Validate basic Levenshtein distance cases.
     #[test]
     fn distance_basic() {
         assert_eq!(fuzzy_score("abc", "a-b-c"), 2);
         assert_eq!(fuzzy_score("abc", "abc"), 0);
     }
 
+    /// Ensure the matching threshold correctly filters distant strings.
     #[test]
     fn match_threshold() {
         assert!(fuzzy_match("abc", "ac"));
         assert!(!fuzzy_match("abc", "xyz"));
     }
 
+    /// Check batch scoring of multiple candidates.
     #[test]
     fn batch_scores() {
         let mut candidates: Vec<String> = (1..100).map(|i| format!("abc{0}", i)).collect();

--- a/tests/fuzzy_alloc.rs
+++ b/tests/fuzzy_alloc.rs
@@ -1,0 +1,43 @@
+use kofft::fuzzy::{fuzzy_match, fuzzy_score};
+use std::alloc::{GlobalAlloc, Layout, System};
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+/// Allocator used in tests to count allocation operations.
+struct CountingAlloc;
+
+/// Global counter tracking allocation operations.
+static ALLOC_COUNT: AtomicUsize = AtomicUsize::new(0);
+
+unsafe impl GlobalAlloc for CountingAlloc {
+    unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
+        ALLOC_COUNT.fetch_add(1, Ordering::SeqCst);
+        System.alloc(layout)
+    }
+
+    unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout) {
+        System.dealloc(ptr, layout)
+    }
+}
+
+/// Global allocator that increments [`ALLOC_COUNT`] for each allocation.
+#[global_allocator]
+static A: CountingAlloc = CountingAlloc;
+
+/// Ensure that [`fuzzy_match`] performs the same number of allocations as
+/// calling [`fuzzy_score`] directly, guaranteeing that computing the pattern
+/// length outside of [`fuzzy_score`] does not introduce extra allocations.
+#[test]
+fn fuzzy_match_allocations() {
+    ALLOC_COUNT.store(0, Ordering::SeqCst);
+    fuzzy_score("abc", "abc");
+    let score_allocs = ALLOC_COUNT.load(Ordering::SeqCst);
+
+    ALLOC_COUNT.store(0, Ordering::SeqCst);
+    fuzzy_match("abc", "abc");
+    let match_allocs = ALLOC_COUNT.load(Ordering::SeqCst);
+
+    assert_eq!(
+        match_allocs, score_allocs,
+        "fuzzy_match should not allocate more than fuzzy_score"
+    );
+}


### PR DESCRIPTION
## Summary
- avoid redundant pattern length computations in fuzzy_match
- document fuzzy algorithm complexity and define match divisor constant
- verify fuzzy_match allocation behavior matches fuzzy_score

## Testing
- `cargo +nightly clippy --all-targets -Znext-lockfile-bump`
- `cargo +nightly test -Znext-lockfile-bump`


------
https://chatgpt.com/codex/tasks/task_e_68a7381ac324832b8c2968e07d783a8f