### PR TITLE
Validate RFFT twiddle lengths

### DIFF
--- a/examples/rfft_usage.rs
+++ b/examples/rfft_usage.rs
@@ -5,7 +5,7 @@ use kofft::Complex32;
 fn main() {
     // Planner-based real FFT
     let fft = ScalarFftImpl::<f32>::default();
-    let mut planner = RfftPlanner::new();
+    let mut planner = RfftPlanner::new().expect("planner creation");
     let mut input = vec![1.0f32, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0];
     let mut spectrum = vec![Complex32::new(0.0, 0.0); input.len() / 2 + 1];
     let mut scratch = vec![Complex32::new(0.0, 0.0); input.len() / 2];

--- a/kofft-bench/benches/bench_fft.rs
+++ b/kofft-bench/benches/bench_fft.rs
@@ -353,7 +353,7 @@ fn bench_real(c: &mut Criterion, size: usize) {
             let mut total = Duration::ZERO;
             let mut alloc_total = 0;
             let mut peak = 0;
-            let mut planner = RfftPlanner::<f32>::new();
+            let mut planner = RfftPlanner::<f32>::new().unwrap();
             for _ in 0..iters {
                 input.copy_from_slice(&input_template);
                 reset_alloc();

--- a/src/dct.rs
+++ b/src/dct.rs
@@ -40,7 +40,7 @@ impl DctPlanner {
     pub fn new() -> Self {
         Self {
             cache: HashMap::new(),
-            rfft: RfftPlanner::new(),
+            rfft: RfftPlanner::new().expect("planner creation"),
             buf: Vec::new(),
             spectrum: Vec::new(),
         }

--- a/src/num.rs
+++ b/src/num.rs
@@ -18,6 +18,9 @@ pub trait Float:
     fn zero() -> Self;
     fn one() -> Self;
     fn from_f32(x: f32) -> Self;
+    /// Attempt to convert a `usize` into the floating-point type.
+    /// Returns `None` if the value cannot be represented exactly.
+    fn from_usize(x: usize) -> Option<Self>;
     fn cos(self) -> Self;
     fn sin(self) -> Self;
     fn sin_cos(self) -> (Self, Self);
@@ -46,6 +49,14 @@ impl Float for f32 {
     }
     fn from_f32(x: f32) -> Self {
         x
+    }
+    fn from_usize(x: usize) -> Option<Self> {
+        const MAX_EXACT: usize = 1usize << 24;
+        if x < MAX_EXACT {
+            Some(x as f32)
+        } else {
+            None
+        }
     }
     fn cos(self) -> Self {
         f32::cos(self)
@@ -83,6 +94,14 @@ impl Float for f64 {
     }
     fn from_f32(x: f32) -> Self {
         x as f64
+    }
+    fn from_usize(x: usize) -> Option<Self> {
+        const MAX_EXACT: usize = 1usize << 53;
+        if x < MAX_EXACT {
+            Some(x as f64)
+        } else {
+            None
+        }
     }
     fn cos(self) -> Self {
         f64::cos(self)

--- a/tests/rfft_arch_parity.rs
+++ b/tests/rfft_arch_parity.rs
@@ -15,7 +15,7 @@ fn rfft_matches_scalar() {
     let mut simd_out = vec![Complex32::new(0.0, 0.0); size / 2 + 1];
     let mut scratch = vec![Complex32::new(0.0, 0.0); size / 2];
     let fft_scalar = ScalarFftImpl::<f32>::default();
-    let mut planner = RfftPlanner::<f32>::new();
+    let mut planner = RfftPlanner::<f32>::new().unwrap();
     planner
         .rfft_with_scratch(
             &fft_scalar,

--- a/tests/rfft_dispatch.rs
+++ b/tests/rfft_dispatch.rs
@@ -5,7 +5,7 @@ use kofft::rfft::RfftPlanner;
 fn rfft_irfft_roundtrip_dispatch() {
     // f32 path
     let fft32 = ScalarFftImpl::<f32>::default();
-    let mut planner32 = RfftPlanner::<f32>::new();
+    let mut planner32 = RfftPlanner::<f32>::new().unwrap();
     let mut input32 = vec![1.0f32, 2.0, 3.0, 4.0];
     let orig32 = input32.clone();
     let mut freq32 = vec![Complex32::new(0.0, 0.0); input32.len() / 2 + 1];
@@ -23,7 +23,7 @@ fn rfft_irfft_roundtrip_dispatch() {
 
     // f64 path
     let fft64 = ScalarFftImpl::<f64>::default();
-    let mut planner64 = RfftPlanner::<f64>::new();
+    let mut planner64 = RfftPlanner::<f64>::new().unwrap();
     let mut input64 = vec![1.0f64, 2.0, 3.0, 4.0];
     let orig64 = input64.clone();
     let mut freq64 = vec![Complex64::new(0.0, 0.0); input64.len() / 2 + 1];

--- a/tests/rfft_twiddles.rs
+++ b/tests/rfft_twiddles.rs
@@ -3,14 +3,14 @@ use kofft::rfft::RfftPlanner;
 
 #[test]
 fn planner_twiddles_rfft_f32() {
-    let mut planner = RfftPlanner::<f32>::new();
-    let tw = planner.get_twiddles(8);
+    let mut planner = RfftPlanner::<f32>::new().unwrap();
+    let tw = planner.get_twiddles(8).unwrap();
     assert_eq!(tw.len(), 8);
     let expected = Complex32::expi(-std::f32::consts::PI / 8.0);
     assert!((tw[1].re - expected.re).abs() < 1e-6);
     assert!((tw[1].im - expected.im).abs() < 1e-6);
     // Ensure cached reference is reused.
     let ptr1 = tw.as_ptr();
-    let ptr2 = planner.get_twiddles(8).as_ptr();
+    let ptr2 = planner.get_twiddles(8).unwrap().as_ptr();
     assert_eq!(ptr1, ptr2);
 }


### PR DESCRIPTION
## Summary
- validate twiddle-table lengths using fallible `from_usize`
- propagate errors through `RfftPlanner` APIs and add tests for invalid lengths
- cover `build_twiddle_table` edge cases to ensure safe generation

## Testing
- `cargo fmt`
- `cargo clippy --all-targets`
- `cargo test`
- `cargo llvm-cov --no-report`


------
https://chatgpt.com/codex/tasks/task_e_68a7381fd570832b8e5cfb8c593762c8