### PR TITLE
Refactor fuzzy scoring for iterator-based processing and input limits

### DIFF
--- a/src/fuzzy.rs
+++ b/src/fuzzy.rs
@@ -1,18 +1,44 @@
 use alloc::{string::String, vec, vec::Vec};
 
+/// Maximum allowed length for either the pattern or text.
+///
+/// The Levenshtein algorithm is quadratic in the worst case.  Restricting the
+/// inputs guards against excessive allocations and runaway runtimes that could
+/// otherwise be triggered by untrusted data.
+pub const MAX_INPUT_LENGTH: usize = 1024;
+
+/// Divisor for determining the matching threshold.
+///
+/// A candidate is considered a match when the edit distance is less than or
+/// equal to half the pattern length.  Exposing this divisor as a constant avoids
+/// sprinkling the literal `2` throughout the code base.
+pub const MATCH_THRESHOLD_DIVISOR: usize = 2;
+
 /// Compute the Levenshtein distance between two strings.
-/// Lower scores indicate closer matches.
-pub fn fuzzy_score(pattern: &str, text: &str) -> usize {
-    let pattern_chars: Vec<char> = pattern.chars().collect();
-    let text_chars: Vec<char> = text.chars().collect();
-    let text_len = text_chars.len();
+///
+/// `pattern_len` must be the number of UTF-8 code points in `pattern`.  The
+/// function iterates directly over the input strings without collecting them
+/// into intermediate `Vec<char>` buffers, reducing memory overhead.
+///
+/// # Panics
+///
+/// Panics if either input exceeds [`MAX_INPUT_LENGTH`].
+pub fn fuzzy_score(pattern: &str, text: &str, pattern_len: usize) -> usize {
+    let text_len = text.chars().count();
+
+    if pattern_len > MAX_INPUT_LENGTH || text_len > MAX_INPUT_LENGTH {
+        panic!(
+            "input too long; maximum supported length is {}",
+            MAX_INPUT_LENGTH
+        );
+    }
 
     let mut prev: Vec<usize> = (0..=text_len).collect();
     let mut curr = vec![0; text_len + 1];
 
-    for (i, &pc) in pattern_chars.iter().enumerate() {
+    for (i, pc) in pattern.chars().enumerate().take(pattern_len) {
         curr[0] = i + 1;
-        for (j, &tc) in text_chars.iter().enumerate() {
+        for (j, tc) in text.chars().enumerate() {
             let cost = if pc == tc { 0 } else { 1 };
             let insertion = curr[j] + 1;
             let deletion = prev[j + 1] + 1;
@@ -26,38 +52,108 @@ pub fn fuzzy_score(pattern: &str, text: &str) -> usize {
 }
 
 /// Determine if two strings match within half the pattern length.
-pub fn fuzzy_match(pattern: &str, text: &str) -> bool {
-    fuzzy_score(pattern, text) <= pattern.chars().count() / 2
+///
+/// The caller must supply the pre-computed `pattern_len` to avoid rescanning
+/// the pattern on repeated calls.
+pub fn fuzzy_match(pattern: &str, pattern_len: usize, text: &str) -> bool {
+    if pattern_len > MAX_INPUT_LENGTH {
+        panic!(
+            "pattern too long; maximum supported length is {}",
+            MAX_INPUT_LENGTH
+        );
+    }
+
+    fuzzy_score(pattern, text, pattern_len) <= pattern_len / MATCH_THRESHOLD_DIVISOR
 }
 
 /// Compute fuzzy scores for a batch of candidate strings.
-pub fn fuzzy_scores(pattern: &str, candidates: &[String]) -> Vec<usize> {
-    candidates.iter().map(|c| fuzzy_score(pattern, c)).collect()
+///
+/// `pattern_len` should be the length of `pattern` in UTF-8 code points,
+/// pre-computed by the caller to avoid redundant work when scoring multiple
+/// candidates.
+pub fn fuzzy_scores(pattern: &str, pattern_len: usize, candidates: &[String]) -> Vec<usize> {
+    candidates
+        .iter()
+        .map(|c| fuzzy_score(pattern, c, pattern_len))
+        .collect()
 }
 
 #[cfg(test)]
+/// Tests for the fuzzy matching utilities.
 mod tests {
     use super::*;
     use alloc::format;
 
+    /// Verify basic distance calculations with simple ASCII inputs.
     #[test]
     fn distance_basic() {
-        assert_eq!(fuzzy_score("abc", "a-b-c"), 2);
-        assert_eq!(fuzzy_score("abc", "abc"), 0);
+        let pattern = "abc";
+        let pattern_len = pattern.chars().count();
+        assert_eq!(fuzzy_score(pattern, "a-b-c", pattern_len), 2);
+        assert_eq!(fuzzy_score(pattern, "abc", pattern_len), 0);
     }
 
+    /// Ensure the match threshold uses the pre-computed pattern length.
     #[test]
     fn match_threshold() {
-        assert!(fuzzy_match("abc", "ac"));
-        assert!(!fuzzy_match("abc", "xyz"));
+        let pattern = "abc";
+        let pattern_len = pattern.chars().count();
+        assert!(fuzzy_match(pattern, pattern_len, "ac"));
+        assert!(!fuzzy_match(pattern, pattern_len, "xyz"));
     }
 
+    /// Confirm batch scoring reuses the cached pattern length.
     #[test]
     fn batch_scores() {
+        let pattern = "abc";
+        let pattern_len = pattern.chars().count();
         let mut candidates: Vec<String> = (1..100).map(|i| format!("abc{0}", i)).collect();
         candidates.insert(0, String::from("abc"));
-        let scores = fuzzy_scores("abc", &candidates);
+        let scores = fuzzy_scores(pattern, pattern_len, &candidates);
         assert_eq!(scores[0], 0);
         assert_eq!(scores.len(), 100);
+    }
+
+    /// Distances involving empty strings should reflect the other input's length.
+    #[test]
+    fn empty_strings() {
+        let pattern = "";
+        let pattern_len = pattern.chars().count();
+        assert_eq!(fuzzy_score(pattern, "", pattern_len), 0);
+        assert_eq!(fuzzy_score(pattern, "test", pattern_len), 4);
+    }
+
+    /// Unicode characters must be handled as full code points rather than bytes.
+    #[test]
+    fn unicode_handling() {
+        let pattern = "naïve"; // contains an umlaut
+        let pattern_len = pattern.chars().count();
+        assert_eq!(fuzzy_score(pattern, "naive", pattern_len), 1);
+    }
+
+    /// Inputs exceeding the configured limit should trigger a panic.
+    #[test]
+    #[should_panic]
+    fn long_input_panics() {
+        let pattern = "a".repeat(MAX_INPUT_LENGTH + 1);
+        let pattern_len = pattern.chars().count();
+        let _ = fuzzy_score(&pattern, "", pattern_len);
+    }
+
+    /// Very long but permitted inputs should still compute a score.
+    #[test]
+    fn long_input_valid() {
+        let pattern = "a".repeat(MAX_INPUT_LENGTH);
+        let pattern_len = pattern.chars().count();
+        assert_eq!(fuzzy_score(&pattern, &pattern, pattern_len), 0);
+    }
+
+    /// `fuzzy_match` must reject patterns that exceed the length limit.
+    #[test]
+    #[should_panic]
+    fn fuzzy_match_panics_on_long_pattern() {
+        let pattern = "a".repeat(MAX_INPUT_LENGTH + 1);
+        let pattern_len = pattern.chars().count();
+        let _ = fuzzy_match(&pattern, pattern_len, "");
     }
 }


### PR DESCRIPTION
## Summary
- Stream chars directly in `fuzzy_score` and avoid `Vec<char>` allocations
- Cache pattern length, expose constants, and enforce maximum lengths
- Expand unit tests for edge cases including empty, Unicode, and long inputs

## Testing
- `cargo clippy --all-targets`
- `cargo test`
- `cargo tarpaulin --quiet` *(fails: no such command)*

------
https://chatgpt.com/codex/tasks/task_e_68a7381ec720832b953ad89d91d52bfc