### PR TITLE
Add explicit error handling for Haar wavelet transforms

### DIFF
--- a/examples/basic_usage.rs
+++ b/examples/basic_usage.rs
@@ -132,7 +132,7 @@ fn main() {
     // 5. Haar Wavelet Transform
     println!("5. Haar Wavelet Transform");
     let wavelet_input = vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0];
-    let (avg, diff) = haar_forward(&wavelet_input);
+    let (avg, diff) = haar_forward(&wavelet_input).unwrap();
 
     println!("   Input: {:?}", wavelet_input);
     println!(

--- a/examples/wavelet_usage.rs
+++ b/examples/wavelet_usage.rs
@@ -4,13 +4,13 @@ use kofft::wavelet::{
 
 fn main() {
     let signal = vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0];
-    let (approx, details) = haar_forward_multi(&signal, 2);
+    let (approx, details) = haar_forward_multi(&signal, 2).unwrap();
     println!("Haar approx: {:?}\nHaar details: {:?}", approx, details);
-    let recon = haar_inverse_multi(&approx, &details);
+    let recon = haar_inverse_multi(&approx, &details).unwrap();
     println!("Haar recon: {:?}", recon);
 
-    let (approx2, details2) = db4_forward_multi(&signal, 2);
+    let (approx2, details2) = db4_forward_multi(&signal, 2).unwrap();
     println!("Db4 approx: {:?}\nDb4 details: {:?}", approx2, details2);
-    let recon2 = db4_inverse_multi(&approx2, &details2);
+    let recon2 = db4_inverse_multi(&approx2, &details2).unwrap();
     println!("Db4 recon: {:?}", recon2);
 }


### PR DESCRIPTION
## Summary
- add `WaveletError` and constants for Haar pair size & scaling
- return `Result` from `haar_forward`/`haar_inverse` and propagate errors across batch and multi-level APIs
- test odd-length inputs and buffer mismatches; update examples and in-place implementations

## Testing
- `cargo clippy --tests --all-features -q`
- `cargo test --all-features -q`


------
https://chatgpt.com/codex/tasks/task_e_68a73819f090832b9d1f1f8ac0762dc2