### PR TITLE
Refactor CZT power handling with validation and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -470,7 +470,7 @@ let db4_recon = db4_inverse_multi(&db4_a, &db4_d);
 let magnitude = goertzel::goertzel_f32(&input, 44100.0, 1000.0);
 
 // Chirp Z-Transform
-let czt_result = czt::czt_f32(&input, 64, (0.5, 0.0), (1.0, 0.0));
+let czt_result = czt::czt_f32(&input, 64, (0.5, 0.0), (1.0, 0.0)).unwrap();
 
 // Hilbert Transform
 let hilbert_result = hilbert::hilbert_analytic(&input);

--- a/examples/basic_usage.rs
+++ b/examples/basic_usage.rs
@@ -204,7 +204,7 @@ fn main() {
     // 10. Chirp Z-Transform
     println!("10. Chirp Z-Transform");
     let czt_input = vec![1.0, 0.0, 0.0, 0.0];
-    let czt_result = czt_f32(&czt_input, 4, (0.5, 0.0), (1.0, 0.0));
+    let czt_result = czt_f32(&czt_input, 4, (0.5, 0.0), (1.0, 0.0)).unwrap();
     println!(
         "   CZT: {:?}",
         czt_result

--- a/src/czt.rs
+++ b/src/czt.rs
@@ -6,77 +6,112 @@ extern crate alloc;
 use alloc::vec;
 use alloc::vec::Vec;
 
-// no additional libm functions needed
+/// Unit complex number `(1 + 0j)` used as a neutral element for
+/// iterative complex multiplication.
+const UNIT_COMPLEX: (f32, f32) = (1.0, 0.0);
+/// Zero complex number `(0 + 0j)` used to initialize output buffers.
+const ZERO_COMPLEX: (f32, f32) = (0.0, 0.0);
 
-/// Compute the CZT of a real signal at M output bins
-/// - `input`: real-valued signal
-/// - `m`: number of output bins
-/// - `w`: complex ratio between bins (e.g., exp(-j*2pi/M))
-/// - `a`: complex starting point (e.g., 1.0)
-pub fn czt_f32(input: &[f32], m: usize, w: (f32, f32), a: (f32, f32)) -> Vec<(f32, f32)> {
-    let (wr, wi) = w;
+/// Errors that can occur during CZT computation.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CztError {
+    /// The `a` parameter has zero magnitude which would cause a division by zero.
+    InvalidParameter,
+}
+
+/// Display implementation for [`CztError`] providing human-readable messages.
+impl core::fmt::Display for CztError {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            CztError::InvalidParameter => write!(f, "parameter causes division by zero"),
+        }
+    }
+}
+
+/// Implement the standard error trait when the `std` feature is enabled so
+/// errors can seamlessly integrate with typical Rust error handling.
+#[cfg(feature = "std")]
+impl std::error::Error for CztError {}
+
+/// Compute the Chirp Z-Transform (CZT) of a real-valued input signal.
+///
+/// # Parameters
+/// - `input`: slice containing the real-valued samples to transform.
+/// - `m`: number of frequency bins to compute.
+/// - `w`: complex ratio between successive frequency bins (typically `exp(-j*2π/M)`).
+/// - `a`: complex starting point for the transform (typically `1 + 0j`).
+///
+/// # Returns
+/// `Ok` with a vector of complex tuples representing the transform output or
+/// `Err` if parameters are invalid.
+///
+/// # Algorithm
+/// The implementation iteratively updates powers of `w` and `a` to avoid
+/// expensive nested exponentiation loops. For each output bin, we reuse the
+/// previously computed power of `w` and update it in constant time.
+pub fn czt_f32(
+    input: &[f32],
+    m: usize,
+    w: (f32, f32),
+    a: (f32, f32),
+) -> Result<Vec<(f32, f32)>, CztError> {
+    // Extract and validate `a` by computing its reciprocal. Fail fast if the
+    // magnitude is zero to prevent division by zero and undefined behaviour.
     let (ar, ai) = a;
     let denom = ar * ar + ai * ai;
-    let a_inv_r = if denom == 0.0 { 0.0 } else { ar / denom };
-    let a_inv_i = if denom == 0.0 { 0.0 } else { -ai / denom };
-    let mut output = vec![(0.0, 0.0); m];
-    for (k, out) in output.iter_mut().enumerate() {
-        // compute w^k
-        let mut w_k_r = 1.0;
-        let mut w_k_i = 0.0;
-        for _ in 0..k {
-            let tr = w_k_r * wr - w_k_i * wi;
-            let ti = w_k_r * wi + w_k_i * wr;
-            w_k_r = tr;
-            w_k_i = ti;
-        }
-        let mut wnk_r = 1.0;
-        let mut wnk_i = 0.0;
-        let mut a_pow_r = 1.0;
-        let mut a_pow_i = 0.0;
+    if denom == 0.0 {
+        return Err(CztError::InvalidParameter);
+    }
+    let a_inv_r = ar / denom;
+    let a_inv_i = -ai / denom;
+
+    // Prepare output buffer initialised to zero.
+    let mut output = vec![ZERO_COMPLEX; m];
+
+    // Precompute successive powers of `w` iteratively. `w_k` holds `w^k` for the
+    // current bin and is updated in-place for the next bin.
+    let (wr, wi) = w;
+    let mut w_k_r = UNIT_COMPLEX.0;
+    let mut w_k_i = UNIT_COMPLEX.1;
+
+    for out in output.iter_mut() {
+        // `wnk` tracks the incremental power `w^{k*n}` for each input sample,
+        // starting at `1` and multiplying by `w^k` each iteration.
+        let mut wnk_r = UNIT_COMPLEX.0;
+        let mut wnk_i = UNIT_COMPLEX.1;
+        // `a_pow` tracks `a^{-n}` via repeated multiplication by `a^{-1}`.
+        let mut a_pow_r = UNIT_COMPLEX.0;
+        let mut a_pow_i = UNIT_COMPLEX.1;
+
+        // Process every input sample, accumulating its contribution to the
+        // current frequency bin.
         for &x in input {
+            // Multiply current powers to obtain `a^{-n} * w^{k*n}`.
             let tr = a_pow_r * wnk_r - a_pow_i * wnk_i;
             let ti = a_pow_r * wnk_i + a_pow_i * wnk_r;
+            // Accumulate the contribution scaled by the real sample `x`.
             out.0 += x * tr;
             out.1 += x * ti;
-            // update powers
+
+            // Update `w^{k*n}` by multiplying once by `w^k`.
             let wtr = wnk_r * w_k_r - wnk_i * w_k_i;
             let wti = wnk_r * w_k_i + wnk_i * w_k_r;
             wnk_r = wtr;
             wnk_i = wti;
+
+            // Update `a^{-n}` by multiplying once by `a^{-1}`.
             let atr = a_pow_r * a_inv_r - a_pow_i * a_inv_i;
             let ati = a_pow_r * a_inv_i + a_pow_i * a_inv_r;
             a_pow_r = atr;
             a_pow_i = ati;
         }
-    }
-    output
-}
 
-#[cfg(all(feature = "internal-tests", test))]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn test_czt_basic() {
-        let x = [1.0, 0.0, 0.0, 0.0];
-        // DFT via CZT: w = exp(-j*2pi/4), a = 1
-        let w = (
-            (-2.0 * core::f32::consts::PI / 4.0).cos(),
-            (-2.0 * core::f32::consts::PI / 4.0).sin(),
-        );
-        let a = (1.0, 0.0);
-        let y = czt_f32(&x, 4, w, a);
-        assert!((y[0].0 - 1.0).abs() < 1e-5);
+        // Update `w^k` for the next bin using a single multiplication.
+        let wkr = w_k_r * wr - w_k_i * wi;
+        let wki = w_k_r * wi + w_k_i * wr;
+        w_k_r = wkr;
+        w_k_i = wki;
     }
 
-    #[test]
-    fn test_czt_non_unit_params() {
-        let x = [0.0, 1.0];
-        let w = (0.0, 1.0); // j
-        let a = (0.5, 0.0);
-        let y = czt_f32(&x, 2, w, a);
-        assert!((y[0].0 - 2.0).abs() < 1e-5 && y[0].1.abs() < 1e-5);
-        assert!((y[1].0).abs() < 1e-5 && (y[1].1 - 2.0).abs() < 1e-5);
-    }
+    Ok(output)
 }

--- a/tests/czt.rs
+++ b/tests/czt.rs
@@ -1,0 +1,56 @@
+//! Tests for the Chirp Z-Transform implementation
+
+use kofft::czt::{czt_f32, CztError};
+use kofft::fft::fft_complex_vec;
+use kofft::num::ComplexVec;
+
+/// Tolerance for comparing floating-point results.
+const EPSILON: f32 = 1e-4;
+
+/// Verify that providing a zero `a` parameter results in an error.
+#[test]
+fn invalid_a_returns_error() {
+    let input = [1.0_f32, 0.0];
+    let w = (0.0_f32, 1.0_f32);
+    let result = czt_f32(&input, 2, w, (0.0, 0.0));
+    assert!(matches!(result, Err(CztError::InvalidParameter)));
+}
+
+/// Ensure the transform handles large numbers of output bins without panicking.
+#[test]
+fn large_m_produces_correct_length() {
+    let input = vec![1.0_f32; 8];
+    let m = 256;
+    let w = (
+        (-2.0 * core::f32::consts::PI / m as f32).cos(),
+        (-2.0 * core::f32::consts::PI / m as f32).sin(),
+    );
+    let a = (1.0, 0.0);
+    let result = czt_f32(&input, m, w, a).unwrap();
+    assert_eq!(result.len(), m);
+}
+
+/// Compare CZT output against the standard FFT for numerical accuracy.
+#[test]
+fn czt_matches_fft() {
+    let input = [1.0_f32, 2.0, 3.0, 4.0];
+    let n = input.len();
+
+    // FFT reference result
+    let mut cv = ComplexVec::new(input.to_vec(), vec![0.0; n]);
+    fft_complex_vec(&mut cv).unwrap();
+    let fft_out = cv.to_complex_vec();
+
+    // CZT with parameters equivalent to an N-point DFT
+    let w = (
+        (-2.0 * core::f32::consts::PI / n as f32).cos(),
+        (-2.0 * core::f32::consts::PI / n as f32).sin(),
+    );
+    let a = (1.0, 0.0);
+    let czt_out = czt_f32(&input, n, w, a).unwrap();
+
+    for k in 0..n {
+        assert!((czt_out[k].0 - fft_out[k].re).abs() < EPSILON);
+        assert!((czt_out[k].1 - fft_out[k].im).abs() < EPSILON);
+    }
+}


### PR DESCRIPTION
## Summary
- compute `w` powers iteratively to avoid nested loops
- validate `a` and surface `CztError::InvalidParameter`
- document and expose tests for invalid parameters, large `m`, and FFT accuracy

## Testing
- `cargo fmt`
- `cargo clippy --all-targets -q`
- `cargo test -q`
- `cargo tarpaulin --all-features --out Xml --timeout 300`

------
https://chatgpt.com/codex/tasks/task_e_68a73821202c832b91918cd881d0856c