### PR TITLE
Require Sync FFT for parallel STFT and add thread-safe tests

### DIFF
--- a/examples/stft_usage.rs
+++ b/examples/stft_usage.rs
@@ -4,18 +4,84 @@
 //!
 //! When built with `--features parallel`, also showcases the parallel STFT helper.
 
-use kofft::fft::{FftError, ScalarFftImpl};
+use kofft::fft::{FftError, FftImpl, FftStrategy, ScalarFftImpl};
 #[cfg(feature = "parallel")]
 use kofft::stft::parallel;
 use kofft::stft::{istft, stft};
 use kofft::window::hann;
+use std::sync::Mutex;
+
+/// Thread-safe wrapper enabling shared access to [`ScalarFftImpl`].
+struct SyncFft(Mutex<ScalarFftImpl<f32>>);
+
+impl Default for SyncFft {
+    fn default() -> Self {
+        Self(Mutex::new(ScalarFftImpl::<f32>::default()))
+    }
+}
+
+impl FftImpl<f32> for SyncFft {
+    fn fft(&self, input: &mut [kofft::Complex32]) -> Result<(), FftError> {
+        self.0.lock().unwrap().fft(input)
+    }
+    fn ifft(&self, input: &mut [kofft::Complex32]) -> Result<(), FftError> {
+        self.0.lock().unwrap().ifft(input)
+    }
+    fn fft_strided(
+        &self,
+        input: &mut [kofft::Complex32],
+        stride: usize,
+        scratch: &mut [kofft::Complex32],
+    ) -> Result<(), FftError> {
+        self.0.lock().unwrap().fft_strided(input, stride, scratch)
+    }
+    fn ifft_strided(
+        &self,
+        input: &mut [kofft::Complex32],
+        stride: usize,
+        scratch: &mut [kofft::Complex32],
+    ) -> Result<(), FftError> {
+        self.0.lock().unwrap().ifft_strided(input, stride, scratch)
+    }
+    fn fft_out_of_place_strided(
+        &self,
+        input: &[kofft::Complex32],
+        in_stride: usize,
+        output: &mut [kofft::Complex32],
+        out_stride: usize,
+    ) -> Result<(), FftError> {
+        self.0
+            .lock()
+            .unwrap()
+            .fft_out_of_place_strided(input, in_stride, output, out_stride)
+    }
+    fn ifft_out_of_place_strided(
+        &self,
+        input: &[kofft::Complex32],
+        in_stride: usize,
+        output: &mut [kofft::Complex32],
+        out_stride: usize,
+    ) -> Result<(), FftError> {
+        self.0
+            .lock()
+            .unwrap()
+            .ifft_out_of_place_strided(input, in_stride, output, out_stride)
+    }
+    fn fft_with_strategy(
+        &self,
+        input: &mut [kofft::Complex32],
+        strategy: FftStrategy,
+    ) -> Result<(), FftError> {
+        self.0.lock().unwrap().fft_with_strategy(input, strategy)
+    }
+}
 
 fn main() -> Result<(), FftError> {
     let signal = vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0];
     let window = hann(4);
     let hop = 2;
 
-    let fft = ScalarFftImpl::<f32>::default();
+    let fft = SyncFft::default();
     let mut frames = vec![vec![]; signal.len().div_ceil(hop)];
     stft(&signal, &window, hop, &mut frames, &fft)?;
     println!("STFT frames: {:?}", frames);

--- a/src/stft.rs
+++ b/src/stft.rs
@@ -114,6 +114,159 @@ pub fn stft<Fft: FftImpl<f32>>(
     Ok(())
 }
 
+#[cfg(all(feature = "parallel", test))]
+/// Tests covering the parallel STFT implementation and its thread-safety
+/// guarantees.
+mod parallel_tests {
+    use super::*;
+    use crate::fft::{Complex32, FftError, FftImpl, FftStrategy, ScalarFftImpl};
+    use alloc::vec::Vec;
+    use std::sync::{
+        atomic::{AtomicUsize, Ordering},
+        Mutex,
+    };
+
+    /// Length of the synthetic test signal.
+    const SIG_LEN: usize = 8;
+    /// Length of the analysis window applied in tests.
+    const WIN_LEN: usize = 4;
+    /// Hop size between adjacent frames used in tests.
+    const HOP: usize = 2;
+
+    /// FFT wrapper counting the number of calls to detect data races.
+    #[derive(Default)]
+    struct CountingFft {
+        /// Underlying scalar FFT implementation reused across frames.
+        inner: Mutex<ScalarFftImpl<f32>>,
+        /// Atomic counter incremented on each FFT invocation.
+        calls: AtomicUsize,
+    }
+
+    impl FftImpl<f32> for CountingFft {
+        /// Perform an FFT while atomically incrementing the call counter.
+        fn fft(&self, input: &mut [Complex32]) -> Result<(), FftError> {
+            // Increment atomically to ensure thread-safe mutation.
+            self.calls.fetch_add(1, Ordering::SeqCst);
+            self.inner.lock().unwrap().fft(input)
+        }
+        /// Delegate to the inner implementation for inverse FFT.
+        fn ifft(&self, input: &mut [Complex32]) -> Result<(), FftError> {
+            self.inner.lock().unwrap().ifft(input)
+        }
+        /// Delegate strided FFT to the inner implementation.
+        fn fft_strided(
+            &self,
+            input: &mut [Complex32],
+            stride: usize,
+            scratch: &mut [Complex32],
+        ) -> Result<(), FftError> {
+            self.inner
+                .lock()
+                .unwrap()
+                .fft_strided(input, stride, scratch)
+        }
+        /// Delegate strided inverse FFT to the inner implementation.
+        fn ifft_strided(
+            &self,
+            input: &mut [Complex32],
+            stride: usize,
+            scratch: &mut [Complex32],
+        ) -> Result<(), FftError> {
+            self.inner
+                .lock()
+                .unwrap()
+                .ifft_strided(input, stride, scratch)
+        }
+        /// Delegate out-of-place strided FFT to the inner implementation.
+        fn fft_out_of_place_strided(
+            &self,
+            input: &[Complex32],
+            in_stride: usize,
+            output: &mut [Complex32],
+            out_stride: usize,
+        ) -> Result<(), FftError> {
+            self.inner
+                .lock()
+                .unwrap()
+                .fft_out_of_place_strided(input, in_stride, output, out_stride)
+        }
+        /// Delegate out-of-place strided IFFT to the inner implementation.
+        fn ifft_out_of_place_strided(
+            &self,
+            input: &[Complex32],
+            in_stride: usize,
+            output: &mut [Complex32],
+            out_stride: usize,
+        ) -> Result<(), FftError> {
+            self.inner
+                .lock()
+                .unwrap()
+                .ifft_out_of_place_strided(input, in_stride, output, out_stride)
+        }
+        /// Delegate strategy-based FFT to the inner implementation.
+        fn fft_with_strategy(
+            &self,
+            input: &mut [Complex32],
+            strategy: FftStrategy,
+        ) -> Result<(), FftError> {
+            self.inner
+                .lock()
+                .unwrap()
+                .fft_with_strategy(input, strategy)
+        }
+    }
+
+    /// Ensure parallel STFT matches sequential STFT output.
+    #[test]
+    fn parallel_matches_sequential() {
+        let signal: [f32; SIG_LEN] = [1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0];
+        let window: [f32; WIN_LEN] = [1.0; WIN_LEN];
+        let frames_needed = SIG_LEN.div_ceil(HOP);
+        let mut seq_frames = vec![vec![Complex32::zero(); WIN_LEN]; frames_needed];
+        let mut par_frames = vec![vec![Complex32::zero(); WIN_LEN]; frames_needed];
+        let fft = CountingFft::default();
+        // Sequential reference implementation.
+        stft(&signal, &window, HOP, &mut seq_frames, &fft).unwrap();
+        // Parallel computation under test.
+        parallel(&signal, &window, HOP, &mut par_frames, &fft).unwrap();
+        assert_eq!(seq_frames, par_frames);
+    }
+
+    /// Verify that insufficient output frames return an error.
+    #[test]
+    fn parallel_mismatched_output_len() {
+        let signal: [f32; SIG_LEN] = [0.0; SIG_LEN];
+        let window: [f32; WIN_LEN] = [0.0; WIN_LEN];
+        let mut frames: Vec<Vec<Complex32>> = vec![]; // Too short on purpose.
+        let fft = CountingFft::default();
+        let res = parallel(&signal, &window, HOP, &mut frames, &fft);
+        assert!(matches!(res, Err(FftError::MismatchedLengths)));
+    }
+
+    /// Verify that zero hop size fails fast.
+    #[test]
+    fn parallel_invalid_hop() {
+        let signal: [f32; SIG_LEN] = [0.0; SIG_LEN];
+        let window: [f32; WIN_LEN] = [0.0; WIN_LEN];
+        let mut frames = vec![vec![Complex32::zero(); WIN_LEN]; 1];
+        let fft = CountingFft::default();
+        let res = parallel(&signal, &window, 0, &mut frames, &fft);
+        assert!(matches!(res, Err(FftError::InvalidHopSize)));
+    }
+
+    /// Ensure each frame triggers exactly one FFT call with no data races.
+    #[test]
+    fn parallel_counts_calls() {
+        let signal: [f32; SIG_LEN] = [0.0; SIG_LEN];
+        let window: [f32; WIN_LEN] = [1.0; WIN_LEN];
+        let frames_needed = SIG_LEN.div_ceil(HOP);
+        let mut frames = vec![vec![Complex32::zero(); WIN_LEN]; frames_needed];
+        let fft = CountingFft::default();
+        parallel(&signal, &window, HOP, &mut frames, &fft).unwrap();
+        assert_eq!(fft.calls.load(Ordering::SeqCst), frames_needed);
+    }
+}
+
 /// Compute the inverse STFT of frequency-domain frames in-place.
 ///
 /// - `frames`: mutable frequency-domain frames (each of length `window.len()`)
@@ -215,17 +368,29 @@ impl<'a, Fft: crate::fft::FftImpl<f32>> StftStream<'a, Fft> {
 }
 
 #[cfg(feature = "parallel")]
-/// Compute the Short-Time Fourier Transform (STFT) of `signal` using Rayon for parallelism.
+/// Parallel Short-Time Fourier Transform (STFT).
 ///
-/// Requires the `parallel` feature, which enables the [`rayon`](https://crates.io/crates/rayon) dependency.
+/// # Why parallel?
+/// Computing large numbers of FFT frames can be expensive.  This variant uses
+/// [`rayon`](https://crates.io/crates/rayon) to distribute the work across
+/// threads for improved throughput.
 ///
-/// * `signal` - input real-valued signal
-/// * `window` - analysis window
-/// * `hop_size` - hop size between adjacent frames
-/// * `output` - pre-allocated buffer for FFT frames
-/// * `fft` - FFT implementation to reuse cached plans
+/// # Safety and thread guarantees
+/// The FFT instance is borrowed immutably by each worker thread.  The type
+/// parameter therefore requires [`Sync`] so that sharing a reference across
+/// threads is sound.  No mutable access occurs and the closure captures only
+/// shared references, preventing data races.
 ///
-/// Returns [`FftError::InvalidHopSize`] if `hop_size` is zero.
+/// # Parameters
+/// - `signal`: input real-valued samples
+/// - `window`: analysis window applied per frame
+/// - `hop_size`: hop size between adjacent frames
+/// - `output`: pre-allocated buffer for FFT frames
+/// - `fft`: FFT implementation reused across frames
+///
+/// Returns [`FftError::InvalidHopSize`] if `hop_size` is zero or
+/// [`FftError::MismatchedLengths`] when `output` does not contain enough
+/// frames.
 ///
 /// # Examples
 /// ```ignore
@@ -238,7 +403,7 @@ impl<'a, Fft: crate::fft::FftImpl<f32>> StftStream<'a, Fft> {
 /// let fft = ScalarFftImpl::<f32>::default();
 /// parallel(&signal, &window, 2, &mut frames, &fft).unwrap();
 /// ```ignore
-pub fn parallel<Fft: FftImpl<f32>>(
+pub fn parallel<Fft: FftImpl<f32> + Sync>(
     signal: &[f32],
     window: &[f32],
     hop_size: usize,
@@ -249,12 +414,15 @@ pub fn parallel<Fft: FftImpl<f32>>(
     if hop_size == 0 {
         return Err(FftError::InvalidHopSize);
     }
+    let required = signal.len().div_ceil(hop_size);
+    if output.len() < required {
+        return Err(FftError::MismatchedLengths);
+    }
     let win_len = window.len();
     // Pre-size frames to avoid repeated allocations in the parallel loop
     for frame in output.iter_mut() {
         frame.resize(win_len, Complex32::zero());
     }
-    let fft_ptr = fft as *const Fft as usize;
     output
         .par_iter_mut()
         .enumerate()
@@ -268,18 +436,9 @@ pub fn parallel<Fft: FftImpl<f32>>(
                 };
                 frame[i] = Complex32::new(x, 0.0);
             }
-            // SAFETY: `fft_ptr` is shared across threads. Callers must ensure
-            // SAFETY: We cast the shared reference `fft` to a raw pointer (`fft_ptr`) outside the parallel loop,
-            // and reconstruct a shared reference inside each thread. This is safe because:
-            // - The original `fft` reference is valid for the entire duration of the parallel operation,
-            //   and is not mutably aliased elsewhere.
-            // - The pointer is only ever used to create shared (`&`) references, never mutable ones.
-            // - The FFT implementation (`Fft`) must be both `Send` and `Sync`, so it is safe to share
-            //   references to it across threads and to call its methods concurrently.
-            // - It is the caller's responsibility to ensure that the provided `fft` instance upholds these
-            //   thread safety guarantees for the duration of this function.
-            let fft_ref = unsafe { &*(fft_ptr as *const Fft) };
-            fft_ref.fft(frame)
+            // `fft` is an immutable reference shared between threads.  The
+            // `Sync` bound on `Fft` guarantees that concurrent calls are safe.
+            fft.fft(frame)
         })
 }
 
@@ -351,7 +510,6 @@ pub fn inverse_parallel<Fft: FftImpl<f32> + Sync>(
                 let acc_frame = take(acc);
                 let norm_frame = take(norm);
                 Ok((start, acc_frame, norm_frame))
-
             },
         )
         .collect();

--- a/tests/stft_parallel.rs
+++ b/tests/stft_parallel.rs
@@ -1,37 +1,49 @@
 #![cfg(feature = "parallel")]
 
-use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::{
+    atomic::{AtomicUsize, Ordering},
+    Mutex,
+};
 
 use kofft::fft::{Complex32, FftError, FftImpl, FftStrategy, ScalarFftImpl};
 use kofft::stft::parallel;
 use kofft::window::hann;
 
+/// Thread-safe FFT counting calls to ensure parallel execution uses the provided
+/// instance exactly once per frame.
 struct CountingFft {
-    inner: ScalarFftImpl<f32>,
+    /// Inner FFT implementation protected by a mutex to provide `Sync`.
+    inner: Mutex<ScalarFftImpl<f32>>,
+    /// Total number of FFT operations performed.
     calls: AtomicUsize,
 }
 
 impl CountingFft {
+    /// Create a new counting FFT wrapper.
     fn new() -> Self {
         Self {
-            inner: ScalarFftImpl::<f32>::default(),
+            inner: Mutex::new(ScalarFftImpl::<f32>::default()),
             calls: AtomicUsize::new(0),
         }
     }
+    /// Retrieve the number of FFT invocations.
     fn count(&self) -> usize {
         self.calls.load(Ordering::SeqCst)
     }
 }
 
 impl FftImpl<f32> for CountingFft {
+    /// Forward FFT while incrementing the call counter.
     fn fft(&self, input: &mut [Complex32]) -> Result<(), FftError> {
         self.calls.fetch_add(1, Ordering::SeqCst);
-        self.inner.fft(input)
+        self.inner.lock().unwrap().fft(input)
     }
+    /// Inverse FFT while incrementing the call counter.
     fn ifft(&self, input: &mut [Complex32]) -> Result<(), FftError> {
         self.calls.fetch_add(1, Ordering::SeqCst);
-        self.inner.ifft(input)
+        self.inner.lock().unwrap().ifft(input)
     }
+    /// Delegate strided FFT and count the call.
     fn fft_strided(
         &self,
         input: &mut [Complex32],
@@ -39,8 +51,12 @@ impl FftImpl<f32> for CountingFft {
         scratch: &mut [Complex32],
     ) -> Result<(), FftError> {
         self.calls.fetch_add(1, Ordering::SeqCst);
-        self.inner.fft_strided(input, stride, scratch)
+        self.inner
+            .lock()
+            .unwrap()
+            .fft_strided(input, stride, scratch)
     }
+    /// Delegate strided inverse FFT and count the call.
     fn ifft_strided(
         &self,
         input: &mut [Complex32],
@@ -48,8 +64,12 @@ impl FftImpl<f32> for CountingFft {
         scratch: &mut [Complex32],
     ) -> Result<(), FftError> {
         self.calls.fetch_add(1, Ordering::SeqCst);
-        self.inner.ifft_strided(input, stride, scratch)
+        self.inner
+            .lock()
+            .unwrap()
+            .ifft_strided(input, stride, scratch)
     }
+    /// Delegate out-of-place strided FFT and count the call.
     fn fft_out_of_place_strided(
         &self,
         input: &[Complex32],
@@ -59,8 +79,11 @@ impl FftImpl<f32> for CountingFft {
     ) -> Result<(), FftError> {
         self.calls.fetch_add(1, Ordering::SeqCst);
         self.inner
+            .lock()
+            .unwrap()
             .fft_out_of_place_strided(input, in_stride, output, out_stride)
     }
+    /// Delegate out-of-place strided inverse FFT and count the call.
     fn ifft_out_of_place_strided(
         &self,
         input: &[Complex32],
@@ -70,29 +93,38 @@ impl FftImpl<f32> for CountingFft {
     ) -> Result<(), FftError> {
         self.calls.fetch_add(1, Ordering::SeqCst);
         self.inner
+            .lock()
+            .unwrap()
             .ifft_out_of_place_strided(input, in_stride, output, out_stride)
     }
+    /// Delegate FFT with strategy and count the call.
     fn fft_with_strategy(
         &self,
         input: &mut [Complex32],
         strategy: FftStrategy,
     ) -> Result<(), FftError> {
         self.calls.fetch_add(1, Ordering::SeqCst);
-        self.inner.fft_with_strategy(input, strategy)
+        self.inner
+            .lock()
+            .unwrap()
+            .fft_with_strategy(input, strategy)
     }
 }
 
+/// Ensure the parallel STFT uses the supplied FFT implementation exactly once per frame.
 #[test]
 fn parallel_uses_supplied_fft() {
-    let signal = vec![0.0f32; 8];
-    let window = hann(4);
-    let hop = 2;
-    let frame_count = signal.len().div_ceil(hop);
-    let mut frames = vec![vec![Complex32::zero(); window.len()]; frame_count];
+    const SIGNAL_LEN: usize = 8;
+    const WIN_LEN: usize = 4;
+    const HOP: usize = 2;
+    let signal = vec![0.0f32; SIGNAL_LEN];
+    let window = hann(WIN_LEN);
+    let frame_count = SIGNAL_LEN.div_ceil(HOP);
+    let mut frames = vec![vec![Complex32::zero(); WIN_LEN]; frame_count];
     let fft = CountingFft::new();
-    parallel(&signal, &window, hop, &mut frames, &fft).unwrap();
+    parallel(&signal, &window, HOP, &mut frames, &fft).unwrap();
     assert_eq!(fft.count(), frame_count);
     for frame in frames {
-        assert_eq!(frame.len(), window.len());
+        assert_eq!(frame.len(), WIN_LEN);
     }
 }


### PR DESCRIPTION
## Summary
- require `Fft: FftImpl<f32> + Sync` for the parallel STFT and borrow the FFT directly
- add length validation, thorough thread-safety docs, and parallel unit tests
- wrap non-sync FFT implementations in mutexes in helpers, examples, and tests

## Testing
- `cargo fmt`
- `cargo clippy --all-targets --features parallel`
- `cargo test --features parallel`
- `cargo tarpaulin --features parallel --tests` *(fails: no such command)*

------
https://chatgpt.com/codex/tasks/task_e_68a7382225ac832baaabe7460327ed97