### PR TITLE
Precompute pattern lengths in fuzzy scoring

### DIFF
--- a/src/fuzzy.rs
+++ b/src/fuzzy.rs
@@ -1,8 +1,22 @@
 use alloc::{string::String, vec, vec::Vec};
 
-/// Compute the Levenshtein distance between two strings.
-/// Lower scores indicate closer matches.
-pub fn fuzzy_score(pattern: &str, text: &str) -> usize {
+/// Divisor controlling the maximum allowed edit distance for a fuzzy match.
+/// A candidate matches when its Levenshtein score is less than or equal to
+/// `pattern_len / MAX_DISTANCE_DIVISOR`.
+const MAX_DISTANCE_DIVISOR: usize = 2;
+
+/// Compute the Levenshtein distance between two strings and return both the
+/// distance score and the length of the pattern. Returning the length avoids
+/// recomputing it in callers that also need it for threshold calculations.
+pub fn fuzzy_score_with_len(pattern: &str, text: &str) -> (usize, usize) {
+    if pattern.is_empty() {
+        return (text.chars().count(), 0);
+    }
+    if text.is_empty() {
+        let len = pattern.chars().count();
+        return (len, len);
+    }
+
     let pattern_chars: Vec<char> = pattern.chars().collect();
     let text_chars: Vec<char> = text.chars().collect();
     let text_len = text_chars.len();
@@ -13,7 +27,7 @@ pub fn fuzzy_score(pattern: &str, text: &str) -> usize {
     for (i, &pc) in pattern_chars.iter().enumerate() {
         curr[0] = i + 1;
         for (j, &tc) in text_chars.iter().enumerate() {
-            let cost = if pc == tc { 0 } else { 1 };
+            let cost = usize::from(pc != tc);
             let insertion = curr[j] + 1;
             let deletion = prev[j + 1] + 1;
             let substitution = prev[j] + cost;
@@ -22,12 +36,20 @@ pub fn fuzzy_score(pattern: &str, text: &str) -> usize {
         core::mem::swap(&mut prev, &mut curr);
     }
 
-    prev[text_len]
+    (prev[text_len], pattern_chars.len())
 }
 
-/// Determine if two strings match within half the pattern length.
+/// Compute only the Levenshtein distance between two strings.
+/// Lower scores indicate closer matches.
+pub fn fuzzy_score(pattern: &str, text: &str) -> usize {
+    fuzzy_score_with_len(pattern, text).0
+}
+
+/// Determine if two strings match within the permitted edit distance.
+/// Uses a precomputed pattern length to avoid repeated scanning.
 pub fn fuzzy_match(pattern: &str, text: &str) -> bool {
-    fuzzy_score(pattern, text) <= pattern.chars().count() / 2
+    let (score, pattern_len) = fuzzy_score_with_len(pattern, text);
+    score <= pattern_len / MAX_DISTANCE_DIVISOR
 }
 
 /// Compute fuzzy scores for a batch of candidate strings.
@@ -59,5 +81,20 @@ mod tests {
         let scores = fuzzy_scores("abc", &candidates);
         assert_eq!(scores[0], 0);
         assert_eq!(scores.len(), 100);
+    }
+
+    #[test]
+    fn score_with_len_matches() {
+        let (score, len) = fuzzy_score_with_len("kitten", "sitting");
+        assert_eq!(score, fuzzy_score("kitten", "sitting"));
+        assert_eq!(len, "kitten".chars().count());
+    }
+
+    #[test]
+    fn very_long_pattern() {
+        let long_pattern = "a".repeat(10_000);
+        // Text deliberately short to keep runtime reasonable while exercising
+        // the long-pattern code path.
+        assert!(!fuzzy_match(&long_pattern, "b"));
     }
 }


### PR DESCRIPTION
## Summary
- add helper returning both Levenshtein score and pattern length
- use constant MAX_DISTANCE_DIVISOR and avoid repeated length scans
- add long-pattern tests to prevent performance regressions

## Testing
- `cargo clippy --all-targets -- -D warnings -A clippy::items_after_test_module`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68a738319bb0832b8c9f0874e434a073