### PR TITLE
Add deterministic dev build script

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,16 @@ High-performance, `no_std`, MCU-friendly DSP library featuring FFT, DCT, DST, Ha
 
 See [benchmarks](benchmarks/README.md) for detailed benchmark results and data.
 
+## Development
+
+To rebuild everything from a clean state and serve the web demo locally:
+
+```bash
+npm run dev
+```
+
+This command clears caches, rebuilds the Rust WebAssembly crate, compiles the React workspace, and serves the bundled application.
+
 ## Waveform Caching
 
 The optional `waveform-cache` feature stores per-track waveform snapshots in a
@@ -43,6 +53,7 @@ CREATE TABLE waveform_samples (
 Because caching increases storage requirements, the feature is **not enabled by
 default**. Opt in by enabling the `waveform-cache` Cargo feature when compiling
 `kofft` if faster startups are worth the space trade-off.
+
 ## Song Identification
 
 `kofft` includes an optional `media::index` module for lightweight song lookup.
@@ -523,16 +534,15 @@ fn main() -> ! {
 
 ## Platform Support
 
-| Platform | SIMD Support | Enable via |
-|----------|-------------|-----------|
-| x86_64   | AVX2/FMA    | `x86_64` feature or `-C target-feature=+avx2` |
-| x86_64 (SSE) | SSE2 | `sse` feature or default `sse2` target |
-| AArch64  | NEON        | `aarch64` feature or `-C target-feature=+neon` |
-| WebAssembly | SIMD128   | `wasm` feature or `-C target-feature=+simd128` |
-| Generic  | Scalar      | Default fallback |
+| Platform     | SIMD Support | Enable via                                     |
+| ------------ | ------------ | ---------------------------------------------- |
+| x86_64       | AVX2/FMA     | `x86_64` feature or `-C target-feature=+avx2`  |
+| x86_64 (SSE) | SSE2         | `sse` feature or default `sse2` target         |
+| AArch64      | NEON         | `aarch64` feature or `-C target-feature=+neon` |
+| WebAssembly  | SIMD128      | `wasm` feature or `-C target-feature=+simd128` |
+| Generic      | Scalar       | Default fallback                               |
 
 Feature selection precedence: `x86_64` (AVX2) → `sse` → scalar fallback.
-
 
 ## License
 
@@ -569,5 +579,3 @@ cargo xtask sanity -- <path-to-flac>  # Run the sanity check example
 - [Repository](https://github.com/kianostad/kofft)
 - [Crates.io](https://crates.io/crates/kofft)
 - [React Spectrogram Demo](react-spectrogram/README.md)
-
-

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "test": "tests"
   },
   "scripts": {
-    "test": "cargo test"
+    "test": "cargo test",
+    "dev": "node scripts/dev.js"
   },
   "keywords": [],
   "author": "",

--- a/scripts/dev.js
+++ b/scripts/dev.js
@@ -1,0 +1,87 @@
+#!/usr/bin/env node
+"use strict";
+
+// Directory where the WebAssembly crate resides.
+const WASM_CRATE_DIR = require("path").join(
+  __dirname,
+  "..",
+  "web",
+  "apps",
+  "mfe-spectrogram",
+  "src",
+  "wasm",
+);
+// Directory containing the React workspace.
+const WEB_DIR = require("path").join(__dirname, "..", "web");
+// Synchronous process execution to invoke shell commands deterministically.
+const { execSync } = require("child_process");
+
+/**
+ * Ensure a required CLI tool exists in the PATH.
+ * Exits early with a clear error message if the tool is missing.
+ * @param {string} tool - Executable name to check for.
+ */
+function ensureTool(tool) {
+  try {
+    execSync(`command -v ${tool}`, { stdio: "ignore" });
+  } catch {
+    console.error(`Missing required tool: ${tool}`);
+    process.exit(1);
+  }
+}
+
+/**
+ * Run a shell command, streaming output and failing fast on errors.
+ * @param {string} cmd - Command line to execute.
+ */
+function run(cmd) {
+  execSync(cmd, { stdio: "inherit" });
+}
+
+/**
+ * Remove build artifacts and caches to ensure reproducible builds.
+ */
+function clean() {
+  run("npm cache clean --force");
+  run("cargo clean");
+  const pkgDir = require("path").join(WASM_CRATE_DIR, "pkg");
+  require("fs").rmSync(pkgDir, { recursive: true, force: true });
+}
+
+/**
+ * Compile the Rust WebAssembly crate using wasm-pack.
+ */
+function buildWasm() {
+  run(`wasm-pack build ${WASM_CRATE_DIR} --release --target web`);
+}
+
+/**
+ * Build the React workspace that consumes the generated WebAssembly package.
+ */
+function buildWeb() {
+  run(`npm --prefix ${WEB_DIR} install`);
+  run(`npm --prefix ${WEB_DIR} run build`);
+}
+
+/**
+ * Serve the compiled web assets for local development.
+ */
+function serve() {
+  run(`npx --yes serve ${require("path").join(WEB_DIR, "dist")}`);
+}
+
+/**
+ * Orchestrate the clean build and serve workflow.
+ */
+function main() {
+  ensureTool("cargo");
+  ensureTool("wasm-pack");
+  ensureTool("npm");
+  ensureTool("npx");
+  clean();
+  buildWasm();
+  buildWeb();
+  serve();
+}
+
+main();


### PR DESCRIPTION
## Summary
- add `npm run dev` script that cleans caches, rebuilds Rust/wasm and React, and serves output
- document dev workflow in README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a738d6e4c4832b88b193c16fb5a3cb