### PR TITLE
Stabilize DHT algorithm and verify against FFT

### DIFF
--- a/src/hartley.rs
+++ b/src/hartley.rs
@@ -7,51 +7,68 @@ use alloc::vec;
 use alloc::vec::Vec;
 use libm::{cosf, sinf};
 
-/// Discrete Hartley Transform (DHT)
-#[cfg(feature = "std")]
+/// Full turn constant `2π` used to map index pairs to angles.
+///
+/// Naming the value clarifies intent and avoids repeating a magic number
+/// throughout the transform implementation.
+const TAU: f32 = core::f32::consts::PI * 2.0;
+
+/// Compute the Discrete Hartley Transform (DHT) of a real-valued signal.
+///
+/// # Arguments
+/// * `input` - Real input samples. An empty slice returns immediately.
+///
+/// # Why
+/// The DHT is a real-to-real transform similar to the FFT but avoids complex
+/// numbers. Implementing it directly keeps dependencies minimal.
+///
+/// # How
+/// Each output bin `k` sums the input samples scaled by `cos(θ) + sin(θ)` where
+/// `θ = 2π·i·k/n`. Kahan summation is used to mitigate floating‑point error.
+/// The function fails fast for empty input to avoid division-by-zero and `NaN`
+/// propagation when computing the angular factor.
 pub fn dht(input: &[f32]) -> Vec<f32> {
     let n = input.len();
+    if n == 0 {
+        // Avoid computing 2π/n which would yield `inf` for `n == 0`.
+        return Vec::new();
+    }
     let mut output = vec![0.0; n];
-    let factor = 2.0 * core::f32::consts::PI / n as f32;
+    let factor = TAU / n as f32;
     for (k, out) in output.iter_mut().enumerate() {
-        let mut sum = 0.0;
+        // Kahan summation compensates for floating-point rounding error.
+        let mut sum = 0.0f32;
+        let mut c = 0.0f32;
         for (i, &x) in input.iter().enumerate() {
             let angle = factor * (i * k) as f32;
             let re = cosf(angle);
             let im = sinf(angle);
-            sum += x * (re + im);
+            let y = x * (re + im) - c;
+            let t = sum + y;
+            c = (t - sum) - y;
+            sum = t;
         }
         *out = sum;
     }
     output
 }
 
-#[cfg(not(feature = "std"))]
-pub fn dht(input: &[f32]) -> Vec<f32> {
-    let n = input.len();
-    let mut output = vec![0.0; n];
-    let factor = 2.0 * core::f32::consts::PI / n as f32;
-    for (k, out) in output.iter_mut().enumerate() {
-        let mut sum = 0.0;
-        for (i, &x) in input.iter().enumerate() {
-            let angle = factor * (i * k) as f32;
-            let re = cosf(angle);
-            let im = sinf(angle);
-            sum += x * (re + im);
-        }
-        *out = sum;
-    }
-    output
-}
-
-/// Batch DHT
+/// Compute the DHT for each batch in-place without extra copying.
+///
+/// # Why
+/// Replacing `copy_from_slice` with a move eliminates an otherwise redundant
+/// memory copy for every batch, improving throughput for large inputs.
 pub fn batch(batches: &mut [Vec<f32>]) {
     for batch in batches.iter_mut() {
-        let out = dht(batch);
-        batch.copy_from_slice(&out);
+        let result = dht(batch);
+        *batch = result;
     }
 }
-/// Multi-channel DHT
+
+/// Apply the DHT independently to multiple channels.
+///
+/// This is a convenience wrapper around [`batch`] for multi-channel audio or
+/// image data.
 pub fn multi_channel(channels: &mut [Vec<f32>]) {
     batch(channels)
 }

--- a/tests/hartley_fft.rs
+++ b/tests/hartley_fft.rs
@@ -1,0 +1,71 @@
+//! Integration tests asserting the Discrete Hartley Transform matches the
+//! equivalent Fast Fourier Transform behaviour.
+
+use kofft::fft::{FftError, FftImpl, ScalarFftImpl};
+use kofft::hartley::dht;
+use kofft::num::Complex32;
+
+/// Allowed floating‑point error tolerance when comparing transform results.
+///
+/// A relatively loose threshold keeps the tests stable across different
+/// architectures while still catching significant numerical regressions.
+const EPSILON: f32 = 1e-4;
+
+/// Verify that the DHT matches `Re(FFT) - Im(FFT)` for even-length inputs.
+///
+/// This ensures the implementation agrees with the FFT-based definition of the
+/// Hartley transform for a simple deterministic vector.
+#[test]
+fn dht_matches_fft_even_length() {
+    let input = [1.0f32, 2.0, 3.0, 4.0];
+    let mut fft_data: Vec<Complex32> = input.iter().map(|&x| Complex32::new(x, 0.0)).collect();
+    let fft = ScalarFftImpl::<f32>::default();
+    fft.fft(&mut fft_data).unwrap();
+    let dht_out = dht(&input);
+    for (k, &val) in dht_out.iter().enumerate() {
+        let c = fft_data[k];
+        let expected = c.re - c.im;
+        assert!(
+            (val - expected).abs() <= EPSILON,
+            "index {k}: {val} vs {expected}"
+        );
+    }
+}
+
+/// Verify that DHT and FFT remain equivalent for odd-length signals.
+///
+/// Odd sizes stress the general FFT path and help maintain ≥50 % test coverage
+/// for the Hartley transform.
+#[test]
+fn dht_matches_fft_odd_length() {
+    let input = [1.0f32, 2.0, 3.0, 4.0, 5.0];
+    let mut fft_data: Vec<Complex32> = input.iter().map(|&x| Complex32::new(x, 0.0)).collect();
+    let fft = ScalarFftImpl::<f32>::default();
+    fft.fft(&mut fft_data).unwrap();
+    let dht_out = dht(&input);
+    for (k, &val) in dht_out.iter().enumerate() {
+        let c = fft_data[k];
+        let expected = c.re - c.im;
+        assert!(
+            (val - expected).abs() <= EPSILON,
+            "index {k}: {val} vs {expected}"
+        );
+    }
+}
+
+/// Ensure zero-length inputs produce an empty DHT and the FFT implementation
+/// rejects them with a clear error.
+///
+/// Handling this edge case prevents `NaN` propagation and division-by-zero
+/// bugs in production usage.
+#[test]
+fn dht_empty_matches_fft_behavior() {
+    let input: [f32; 0] = [];
+    let dht_out = dht(&input);
+    assert!(dht_out.is_empty());
+
+    let mut fft_data: Vec<Complex32> = Vec::new();
+    let fft = ScalarFftImpl::<f32>::default();
+    let fft_result = fft.fft(&mut fft_data);
+    assert!(matches!(fft_result, Err(FftError::EmptyInput)));
+}


### PR DESCRIPTION
## Summary
- remove duplicated DHT implementations and document math
- eliminate redundant copies, add Kahan summation, and expose named `TAU` constant
- add tests confirming DHT equals `Re(FFT)-Im(FFT)` for even, odd, and empty inputs

## Testing
- `cargo +nightly clippy --all-targets --all-features` *(fails: cannot find macro `vec` in hilbert.rs; fuzzy tests missing args)*
- `cargo +nightly test --all-features` *(fails: fuzzy_alloc tests missing required arguments)*

------
https://chatgpt.com/codex/tasks/task_e_68a742f20fa8832baa1a9bba9da7f3ce