### PR TITLE
Harden Goertzel input validation and edge-case tests

### DIFF
--- a/src/fuzzy.rs
+++ b/src/fuzzy.rs
@@ -33,7 +33,6 @@ pub fn fuzzy_score(pattern: &str, text: &str, pattern_len: usize) -> usize {
         );
     }
 
-    let pattern_chars: Vec<char> = pattern.chars().collect();
     let text_chars: Vec<char> = text.chars().collect();
     let text_len = text_chars.len();
 
@@ -68,7 +67,6 @@ pub fn fuzzy_match(pattern: &str, pattern_len: usize, text: &str) -> bool {
     }
 
     fuzzy_score(pattern, text, pattern_len) <= pattern_len / MATCH_THRESHOLD_DIVISOR
-
 }
 
 /// Compute fuzzy scores for a batch of candidate strings.
@@ -81,7 +79,6 @@ pub fn fuzzy_scores(pattern: &str, pattern_len: usize, candidates: &[String]) ->
         .iter()
         .map(|c| fuzzy_score(pattern, c, pattern_len))
         .collect()
-
 }
 
 #[cfg(test)]

--- a/src/goertzel.rs
+++ b/src/goertzel.rs
@@ -7,19 +7,41 @@ use libm::{cosf, floorf, sqrtf};
 #[cfg(feature = "std")]
 use libm::{floorf, sqrtf};
 
+/// Minimum acceptable sample rate in hertz.
+const MIN_SAMPLE_RATE_HZ: f32 = 1.0;
+/// Minimum number of samples required for a stable Goertzel computation.
+const MIN_DATA_LEN: usize = 2;
+/// Minimum allowed target frequency in hertz.
+const MIN_TARGET_FREQ_HZ: f32 = 0.0;
+
 /// Compute the magnitude at a single DFT bin using the Goertzel algorithm.
-/// - `input`: real-valued signal
-/// - `bin`: DFT bin index (0..N-1)
-/// - `sample_rate`: sample rate in Hz
-/// - `target_freq`: frequency to detect in Hz
+///
+/// # Parameters
+/// * `input` - Real-valued signal buffer. Must contain at least
+///   [`MIN_DATA_LEN`] samples for numerical stability.
+/// * `sample_rate` - Signal sample rate in hertz. Must be at least
+///   [`MIN_SAMPLE_RATE_HZ`].
+/// * `target_freq` - Frequency to detect in hertz. Valid range is
+///   [`MIN_TARGET_FREQ_HZ`]..=`sample_rate / 2.0` (Nyquist).
+///
+/// # Errors
+/// Returns [`FftError::InvalidValue`] when any parameter is outside its
+/// documented range, or [`FftError::EmptyInput`] when `input` has zero length.
 #[cfg(feature = "std")]
 pub fn goertzel_f32(input: &[f32], sample_rate: f32, target_freq: f32) -> Result<f32, FftError> {
     if input.is_empty() {
         return Err(FftError::EmptyInput);
     }
-    if sample_rate <= 0.0 {
+    if input.len() < MIN_DATA_LEN {
         return Err(FftError::InvalidValue);
     }
+    if sample_rate < MIN_SAMPLE_RATE_HZ {
+        return Err(FftError::InvalidValue);
+    }
+    if target_freq < MIN_TARGET_FREQ_HZ || target_freq > sample_rate * 0.5 {
+        return Err(FftError::InvalidValue);
+    }
+
     let n = input.len() as f32;
     let k = floorf(target_freq * n / sample_rate);
     let omega = 2.0 * core::f32::consts::PI * k / n;
@@ -40,9 +62,16 @@ pub fn goertzel_f32(input: &[f32], sample_rate: f32, target_freq: f32) -> Result
     if input.is_empty() {
         return Err(FftError::EmptyInput);
     }
-    if sample_rate <= 0.0 {
+    if input.len() < MIN_DATA_LEN {
         return Err(FftError::InvalidValue);
     }
+    if sample_rate < MIN_SAMPLE_RATE_HZ {
+        return Err(FftError::InvalidValue);
+    }
+    if target_freq < MIN_TARGET_FREQ_HZ || target_freq > sample_rate * 0.5 {
+        return Err(FftError::InvalidValue);
+    }
+
     let n = input.len() as f32;
     let k = floorf(target_freq * n / sample_rate);
     let omega = 2.0 * core::f32::consts::PI * k / n;
@@ -58,37 +87,77 @@ pub fn goertzel_f32(input: &[f32], sample_rate: f32, target_freq: f32) -> Result
     Ok(sqrtf(power))
 }
 
-#[cfg(all(feature = "internal-tests", test))]
+#[cfg(test)]
 mod tests {
     use super::*;
+    use alloc::vec;
     use alloc::vec::Vec;
+
     #[test]
-    fn test_goertzel_detects_tone() {
-        let sr = 8000.0;
-        let f = 1000.0;
+    fn detects_tone() {
+        let sr = 8_000.0;
+        let f = 1_000.0;
         let n = 100;
         let signal: Vec<f32> = (0..n)
             .map(|i| (2.0 * core::f32::consts::PI * f * i as f32 / sr).sin())
             .collect();
         let mag = goertzel_f32(&signal, sr, f).unwrap();
-        let _mean = signal.iter().map(|&x| x.abs()).sum::<f32>() / signal.len() as f32;
-        assert!(mag > 0.0); // Only robust check with libm
+        assert!(mag > 0.0);
     }
 
     #[test]
-    fn test_goertzel_empty() {
+    fn rejects_short_input() {
+        let data = [1.0f32];
         assert_eq!(
-            goertzel_f32(&[], 1.0, 1.0).unwrap_err(),
-            FftError::EmptyInput
-        );
-    }
-
-    #[test]
-    fn test_goertzel_bad_rate() {
-        let signal = [1.0f32, 2.0];
-        assert_eq!(
-            goertzel_f32(&signal, 0.0, 1.0).unwrap_err(),
+            goertzel_f32(&data, 8_000.0, 1_000.0).unwrap_err(),
             FftError::InvalidValue
         );
+    }
+
+    #[test]
+    fn rejects_bad_rate() {
+        let data = [1.0f32, 2.0];
+        assert_eq!(
+            goertzel_f32(&data, 0.0, 1_000.0).unwrap_err(),
+            FftError::InvalidValue
+        );
+    }
+
+    #[test]
+    fn rejects_bad_freq() {
+        let data = [1.0f32, 2.0];
+        assert_eq!(
+            goertzel_f32(&data, 8_000.0, -1.0).unwrap_err(),
+            FftError::InvalidValue
+        );
+        assert_eq!(
+            goertzel_f32(&data, 8_000.0, 5_000.0).unwrap_err(),
+            FftError::InvalidValue
+        );
+    }
+
+    #[test]
+    fn handles_dc_and_nyquist() {
+        let sr = 8_000.0;
+        let n = 8;
+        let dc = vec![1.0f32; n];
+        let mag_dc = goertzel_f32(&dc, sr, 0.0).unwrap();
+        assert!((mag_dc - n as f32).abs() < 1e-3);
+
+        let nyquist: Vec<f32> = (0..n)
+            .map(|i| if i % 2 == 0 { 1.0 } else { -1.0 })
+            .collect();
+        let mag_nyq = goertzel_f32(&nyquist, sr, sr / 2.0).unwrap();
+        assert!((mag_nyq - n as f32).abs() < 1e-3);
+    }
+
+    #[test]
+    fn handles_large_magnitude() {
+        let sr = 8_000.0;
+        let n = 10;
+        let amp = 1_000_000.0f32;
+        let data = vec![amp; n];
+        let mag = goertzel_f32(&data, sr, 0.0).unwrap();
+        assert!((mag - amp * n as f32).abs() / (amp * n as f32) < 1e-5);
     }
 }

--- a/src/hilbert.rs
+++ b/src/hilbert.rs
@@ -25,7 +25,6 @@ const POS_FREQ_START: usize = 1;
 /// # Returns
 /// A vector of complex values representing the analytic signal. The real part
 /// matches the original input while the imaginary part is the Hilbert transform.
-
 pub fn hilbert_analytic(input: &[f32]) -> Result<Vec<Complex32>, FftError> {
     if input.is_empty() {
         return Err(FftError::EmptyInput);
@@ -67,6 +66,7 @@ pub fn hilbert_analytic(input: &[f32]) -> Result<Vec<Complex32>, FftError> {
 #[cfg(all(feature = "internal-tests", test))]
 mod tests {
     use super::*;
+    use alloc::vec;
     /// Acceptable tolerance for floating-point comparisons in tests.
     const EPSILON: f32 = 1e-6;
 

--- a/src/stft.rs
+++ b/src/stft.rs
@@ -725,8 +725,9 @@ impl<'a, Fft: crate::fft::FftImpl<f32>> IstftStream<'a, Fft> {
 #[cfg(all(feature = "internal-tests", test))]
 mod tests {
     use super::*;
+    use alloc::vec;
     // Only the complex type and scalar FFT implementation are required for tests.
-    use crate::fft::{Complex32, ScalarFftImpl};
+    use crate::fft::{Complex32, FftStrategy, ScalarFftImpl};
 
     #[test]
     fn test_stft_istft_frame_roundtrip() {

--- a/tests/fuzzy_alloc.rs
+++ b/tests/fuzzy_alloc.rs
@@ -29,11 +29,13 @@ static A: CountingAlloc = CountingAlloc;
 #[test]
 fn fuzzy_match_allocations() {
     ALLOC_COUNT.store(0, Ordering::SeqCst);
-    fuzzy_score("abc", "abc");
+    let pattern = "abc";
+    let len = pattern.chars().count();
+    fuzzy_score(pattern, "abc", len);
     let score_allocs = ALLOC_COUNT.load(Ordering::SeqCst);
 
     ALLOC_COUNT.store(0, Ordering::SeqCst);
-    fuzzy_match("abc", "abc");
+    fuzzy_match(pattern, len, "abc");
     let match_allocs = ALLOC_COUNT.load(Ordering::SeqCst);
 
     assert_eq!(


### PR DESCRIPTION
## Summary
- validate Goertzel sample rate, target frequency, and input length with clear constants and error paths
- document Goertzel API parameters and expectations
- extend Goertzel tests for DC, Nyquist, short buffers, and large magnitudes; fix fuzzy allocation test

## Testing
- `cargo clippy --all-targets --all-features`
- `cargo test --all-features`

------
https://chatgpt.com/codex/tasks/task_e_68a742f5c5e8832bbe78faae5ebd00e8