### PR TITLE
Harden RFFT planner and length handling

### DIFF
--- a/src/fuzzy.rs
+++ b/src/fuzzy.rs
@@ -40,9 +40,9 @@ pub fn fuzzy_score(pattern: &str, text: &str, pattern_len: usize) -> usize {
     let mut prev: Vec<usize> = (0..=text_len).collect();
     let mut curr = vec![0; text_len + 1];
 
-    for (i, pc) in pattern.chars().enumerate().take(pattern_len) {
+    for (i, &pc) in pattern_chars.iter().take(pattern_len).enumerate() {
         curr[0] = i + 1;
-        for (j, tc) in text.chars().enumerate() {
+        for (j, &tc) in text_chars.iter().enumerate() {
             let cost = if pc == tc { 0 } else { 1 };
             let insertion = curr[j] + 1;
             let deletion = prev[j + 1] + 1;
@@ -68,7 +68,6 @@ pub fn fuzzy_match(pattern: &str, pattern_len: usize, text: &str) -> bool {
     }
 
     fuzzy_score(pattern, text, pattern_len) <= pattern_len / MATCH_THRESHOLD_DIVISOR
-
 }
 
 /// Compute fuzzy scores for a batch of candidate strings.
@@ -81,7 +80,6 @@ pub fn fuzzy_scores(pattern: &str, pattern_len: usize, candidates: &[String]) ->
         .iter()
         .map(|c| fuzzy_score(pattern, c, pattern_len))
         .collect()
-
 }
 
 #[cfg(test)]

--- a/src/hilbert.rs
+++ b/src/hilbert.rs
@@ -25,7 +25,6 @@ const POS_FREQ_START: usize = 1;
 /// # Returns
 /// A vector of complex values representing the analytic signal. The real part
 /// matches the original input while the imaginary part is the Hilbert transform.
-
 pub fn hilbert_analytic(input: &[f32]) -> Result<Vec<Complex32>, FftError> {
     if input.is_empty() {
         return Err(FftError::EmptyInput);
@@ -67,6 +66,7 @@ pub fn hilbert_analytic(input: &[f32]) -> Result<Vec<Complex32>, FftError> {
 #[cfg(all(feature = "internal-tests", test))]
 mod tests {
     use super::*;
+    use alloc::vec;
     /// Acceptable tolerance for floating-point comparisons in tests.
     const EPSILON: f32 = 1e-6;
 

--- a/src/stft.rs
+++ b/src/stft.rs
@@ -726,7 +726,7 @@ impl<'a, Fft: crate::fft::FftImpl<f32>> IstftStream<'a, Fft> {
 mod tests {
     use super::*;
     // Only the complex type and scalar FFT implementation are required for tests.
-    use crate::fft::{Complex32, ScalarFftImpl};
+    use crate::fft::{Complex32, FftStrategy, ScalarFftImpl};
 
     #[test]
     fn test_stft_istft_frame_roundtrip() {

--- a/src/wavelet.rs
+++ b/src/wavelet.rs
@@ -7,6 +7,12 @@
 extern crate alloc;
 use alloc::vec;
 use alloc::vec::Vec;
+
+/// Convenience alias for a two-dimensional `Vec`.
+type Vec2<T> = Vec<Vec<T>>;
+
+/// Convenience alias for a three-dimensional `Vec`.
+type Vec3<T> = Vec<Vec<Vec<T>>>;
 use core::fmt;
 
 /// Number of samples processed together in the Haar transform pair.
@@ -85,7 +91,7 @@ pub fn haar_inverse(avg: &[f32], diff: &[f32]) -> Result<Vec<f32>, WaveletError>
 ///
 /// # Errors
 /// Propagates any error returned by [`haar_forward`].
-pub fn batch_forward(inputs: &[Vec<f32>]) -> Result<(Vec<Vec<f32>>, Vec<Vec<f32>>), WaveletError> {
+pub fn batch_forward(inputs: &[Vec<f32>]) -> Result<(Vec2<f32>, Vec2<f32>), WaveletError> {
     let mut avgs = Vec::with_capacity(inputs.len());
     let mut diffs = Vec::with_capacity(inputs.len());
     for input in inputs {
@@ -160,7 +166,7 @@ pub fn multi_level_forward_batch<F>(
     inputs: &[Vec<f32>],
     levels: usize,
     forward: F,
-) -> Result<(Vec<Vec<f32>>, Vec<Vec<Vec<f32>>>), WaveletError>
+) -> Result<(Vec2<f32>, Vec3<f32>), WaveletError>
 where
     F: Fn(&[f32]) -> Result<(Vec<f32>, Vec<f32>), WaveletError>,
 {

--- a/tests/fuzzy_alloc.rs
+++ b/tests/fuzzy_alloc.rs
@@ -29,11 +29,13 @@ static A: CountingAlloc = CountingAlloc;
 #[test]
 fn fuzzy_match_allocations() {
     ALLOC_COUNT.store(0, Ordering::SeqCst);
-    fuzzy_score("abc", "abc");
+    let pattern = "abc";
+    let pattern_len = pattern.chars().count();
+    fuzzy_score(pattern, "abc", pattern_len);
     let score_allocs = ALLOC_COUNT.load(Ordering::SeqCst);
 
     ALLOC_COUNT.store(0, Ordering::SeqCst);
-    fuzzy_match("abc", "abc");
+    fuzzy_match(pattern, pattern_len, "abc");
     let match_allocs = ALLOC_COUNT.load(Ordering::SeqCst);
 
     assert_eq!(

--- a/tests/rfft_validations.rs
+++ b/tests/rfft_validations.rs
@@ -1,0 +1,86 @@
+use kofft::fft::{Complex32, FftError, ScalarFftImpl};
+use kofft::rfft::{rfft_stack, RfftPlanner, MAX_CACHE_ENTRIES, STRIDE};
+
+/// Helper to build a zero-filled complex buffer of length `n`.
+fn zero_complex(len: usize) -> Vec<Complex32> {
+    vec![Complex32::new(0.0, 0.0); len]
+}
+
+#[test]
+fn rejects_odd_length() {
+    let fft = ScalarFftImpl::<f32>::default();
+    let mut planner = RfftPlanner::<f32>::new().unwrap();
+    let mut input = vec![1.0f32; 3];
+    let mut output = zero_complex(input.len() / STRIDE + 1);
+    let mut scratch = zero_complex(input.len() / STRIDE);
+    let err = planner
+        .rfft_with_scratch(&fft, &mut input, &mut output, &mut scratch)
+        .unwrap_err();
+    assert_eq!(err, FftError::InvalidValue);
+}
+
+#[test]
+fn handles_min_length() {
+    let fft = ScalarFftImpl::<f32>::default();
+    let mut planner = RfftPlanner::<f32>::new().unwrap();
+    let mut input = vec![1.0f32, -1.0];
+    let mut output = zero_complex(input.len() / STRIDE + 1);
+    let mut scratch = zero_complex(input.len() / STRIDE);
+    planner
+        .rfft_with_scratch(&fft, &mut input, &mut output, &mut scratch)
+        .unwrap();
+    let mut time = vec![0.0f32; input.len()];
+    planner
+        .irfft_with_scratch(&fft, &mut output, &mut time, &mut scratch)
+        .unwrap();
+    for (a, b) in input.iter().zip(time.iter()) {
+        assert!((a - b).abs() < 1e-5);
+    }
+}
+
+#[test]
+fn handles_large_input() {
+    const N: usize = 1 << 14; // 16384 samples
+    let fft = ScalarFftImpl::<f32>::default();
+    let mut planner = RfftPlanner::<f32>::new().unwrap();
+    let mut input: Vec<f32> = (0..N).map(|i| (i as f32).sin()).collect();
+    let mut output = zero_complex(N / STRIDE + 1);
+    let mut scratch = zero_complex(N / STRIDE);
+    planner
+        .rfft_with_scratch(&fft, &mut input, &mut output, &mut scratch)
+        .unwrap();
+    let mut time = vec![0.0f32; N];
+    planner
+        .irfft_with_scratch(&fft, &mut output, &mut time, &mut scratch)
+        .unwrap();
+    for (a, b) in input.iter().zip(time.iter()) {
+        assert!((a - b).abs() < 1e-3);
+    }
+}
+
+#[test]
+fn planner_cache_eviction() {
+    let fft = ScalarFftImpl::<f32>::default();
+    let mut planner = RfftPlanner::<f32>::new().unwrap();
+    for i in 0..(MAX_CACHE_ENTRIES + 10) {
+        let n = (i + 1) * STRIDE;
+        let mut input = vec![0.0f32; n];
+        let mut output = zero_complex(n / STRIDE + 1);
+        let mut scratch = zero_complex(n / STRIDE);
+        planner
+            .rfft_with_scratch(&fft, &mut input, &mut output, &mut scratch)
+            .unwrap();
+    }
+    assert!(planner.cache_len() <= MAX_CACHE_ENTRIES);
+    assert!(planner.pack_cache_len() <= MAX_CACHE_ENTRIES);
+}
+
+#[test]
+fn rfft_stack_rejects_odd_length() {
+    const N: usize = 3;
+    const M: usize = N / STRIDE + 1;
+    let input = [0.0f32; N];
+    let mut output = [Complex32::new(0.0, 0.0); M];
+    let err = rfft_stack::<N, M>(&input, &mut output).unwrap_err();
+    assert_eq!(err, FftError::InvalidValue);
+}


### PR DESCRIPTION
## Summary
- add STRIDE/HALF/MIN_LEN constants and length validation to RFFT APIs
- cap twiddle caches with LRU eviction to prevent memory bloat
- expand RFFT tests for odd/even lengths, large inputs, and cache eviction

## Testing
- `cargo fmt`
- `cargo clippy --all-targets --all-features`
- `cargo test --all-features`
- `cargo llvm-cov --all-features --summary-only`

------
https://chatgpt.com/codex/tasks/task_e_68a742e21eec832bbf381075c7f355bd