### PR TITLE
Validate STFT/ISTFT boundaries and add robust tests

### DIFF
--- a/src/hilbert.rs
+++ b/src/hilbert.rs
@@ -67,6 +67,7 @@ pub fn hilbert_analytic(input: &[f32]) -> Result<Vec<Complex32>, FftError> {
 #[cfg(all(feature = "internal-tests", test))]
 mod tests {
     use super::*;
+    use alloc::vec;
     /// Acceptable tolerance for floating-point comparisons in tests.
     const EPSILON: f32 = 1e-6;
 

--- a/src/stft.rs
+++ b/src/stft.rs
@@ -74,6 +74,11 @@ use core::mem::take; // for efficiently resetting buffers without reallocations
 /// below this threshold is treated as silence.
 const NORM_EPSILON: f32 = 1e-8;
 
+/// Extra padding multiplier used when allocating internal buffers for streaming
+/// ISTFT. The padding ensures enough headroom for overlap-add operations without
+/// frequent reallocations while keeping memory usage bounded.
+const STREAM_PAD_MULTIPLIER: usize = 2;
+
 /// Compute the STFT of a real-valued signal.
 ///
 /// - `signal`: input signal (real, length N)
@@ -82,7 +87,13 @@ const NORM_EPSILON: f32 = 1e-8;
 /// - `output`: output frames (each frame is Vec<Complex32> of length win_len)
 /// - `fft`: FFT implementation to reuse cached plans
 ///
-/// Returns Ok(()) on success, or FftError on failure.
+/// Returns `Ok(())` on success.
+///
+/// # Errors
+///
+/// - [`FftError::InvalidHopSize`] if `hop_size` is zero or exceeds `window.len()`.
+/// - [`FftError::MismatchedLengths`] if `output` does not contain exactly the
+///   number of frames required or the window is empty.
 pub fn stft<Fft: FftImpl<f32>>(
     signal: &[f32],
     window: &[f32],
@@ -90,14 +101,17 @@ pub fn stft<Fft: FftImpl<f32>>(
     output: &mut [alloc::vec::Vec<Complex32>],
     fft: &Fft,
 ) -> Result<(), FftError> {
-    if hop_size == 0 {
+    if hop_size == 0 || hop_size > window.len() {
         return Err(FftError::InvalidHopSize);
     }
-    let required = signal.len().div_ceil(hop_size);
-    if output.len() < required {
+    let win_len = window.len();
+    if win_len == 0 {
         return Err(FftError::MismatchedLengths);
     }
-    let win_len = window.len();
+    let required = signal.len().div_ceil(hop_size);
+    if output.len() != required {
+        return Err(FftError::MismatchedLengths);
+    }
     for (frame_idx, frame) in output.iter_mut().enumerate() {
         let start = frame_idx * hop_size;
         frame.resize(win_len, Complex32::new(0.0, 0.0));
@@ -276,7 +290,14 @@ mod parallel_tests {
 /// - `scratch`: scratch buffer for overlap-add normalization (length = `output.len()`)
 /// - `fft`: FFT implementation to reuse cached plans
 ///
-/// Returns Ok(()) on success, or [`FftError`] on failure.
+/// Returns `Ok(())` on success.
+///
+/// # Errors
+///
+/// - [`FftError::InvalidHopSize`] if `hop_size` is zero or exceeds
+///   `window.len()`.
+/// - [`FftError::MismatchedLengths`] if frame, window, or buffer sizes are
+///   inconsistent.
 pub fn istft<Fft: FftImpl<f32>>(
     frames: &mut [alloc::vec::Vec<Complex32>],
     window: &[f32],
@@ -285,13 +306,24 @@ pub fn istft<Fft: FftImpl<f32>>(
     scratch: &mut [f32],
     fft: &Fft,
 ) -> Result<(), FftError> {
-    if hop_size == 0 {
+    if hop_size == 0 || hop_size > window.len() {
         return Err(FftError::InvalidHopSize);
     }
     if scratch.len() != output.len() {
         return Err(FftError::MismatchedLengths);
     }
     let win_len = window.len();
+    if win_len == 0 {
+        return Err(FftError::MismatchedLengths);
+    }
+    let required = if frames.is_empty() {
+        0
+    } else {
+        (frames.len() - 1) * hop_size + win_len
+    };
+    if output.len() != required {
+        return Err(FftError::MismatchedLengths);
+    }
     // Clear normalization buffer before accumulating window power.
     scratch.fill(0.0);
     // Overlap-add
@@ -302,10 +334,8 @@ pub fn istft<Fft: FftImpl<f32>>(
         }
         fft.ifft(frame)?;
         for i in 0..win_len {
-            if start + i < output.len() {
-                output[start + i] += frame[i].re * window[i];
-                scratch[start + i] += window[i] * window[i];
-            }
+            output[start + i] += frame[i].re * window[i];
+            scratch[start + i] += window[i] * window[i];
         }
     }
     // Normalize by window sum
@@ -328,14 +358,20 @@ pub struct StftStream<'a, Fft: crate::fft::FftImpl<f32>> {
 }
 
 impl<'a, Fft: crate::fft::FftImpl<f32>> StftStream<'a, Fft> {
+    /// Create a streaming STFT iterator over `signal`.
+    ///
+    /// Validates hop size and window length to prevent misaligned frames.
     pub fn new(
         signal: &'a [f32],
         window: &'a [f32],
         hop_size: usize,
         fft: &'a Fft,
     ) -> Result<Self, FftError> {
-        if hop_size == 0 {
+        if hop_size == 0 || hop_size > window.len() {
             return Err(FftError::InvalidHopSize);
+        }
+        if window.is_empty() {
+            return Err(FftError::MismatchedLengths);
         }
         Ok(Self {
             signal,
@@ -345,6 +381,11 @@ impl<'a, Fft: crate::fft::FftImpl<f32>> StftStream<'a, Fft> {
             fft,
         })
     }
+
+    /// Compute the next FFT frame into `out`.
+    ///
+    /// Returns `Ok(true)` while frames remain or `Ok(false)` when the end of
+    /// the signal is reached. Errors if `out` does not match the window length.
     pub fn next_frame(&mut self, out: &mut [Complex32]) -> Result<bool, FftError> {
         let win_len = self.window.len();
         if out.len() != win_len {
@@ -388,9 +429,11 @@ impl<'a, Fft: crate::fft::FftImpl<f32>> StftStream<'a, Fft> {
 /// - `output`: pre-allocated buffer for FFT frames
 /// - `fft`: FFT implementation reused across frames
 ///
-/// Returns [`FftError::InvalidHopSize`] if `hop_size` is zero or
-/// [`FftError::MismatchedLengths`] when `output` does not contain enough
-/// frames.
+/// # Errors
+///
+/// - [`FftError::InvalidHopSize`] if `hop_size` is zero or exceeds `window.len()`.
+/// - [`FftError::MismatchedLengths`] when `output` does not contain exactly the
+///   required number of frames or the window is empty.
 ///
 /// # Examples
 /// ```ignore
@@ -411,14 +454,17 @@ pub fn parallel<Fft: FftImpl<f32> + Sync>(
     fft: &Fft,
 ) -> Result<(), FftError> {
     use rayon::prelude::*;
-    if hop_size == 0 {
+    if hop_size == 0 || hop_size > window.len() {
         return Err(FftError::InvalidHopSize);
     }
-    let required = signal.len().div_ceil(hop_size);
-    if output.len() < required {
+    let win_len = window.len();
+    if win_len == 0 {
         return Err(FftError::MismatchedLengths);
     }
-    let win_len = window.len();
+    let required = signal.len().div_ceil(hop_size);
+    if output.len() != required {
+        return Err(FftError::MismatchedLengths);
+    }
     // Pre-size frames to avoid repeated allocations in the parallel loop
     for frame in output.iter_mut() {
         frame.resize(win_len, Complex32::zero());
@@ -453,7 +499,11 @@ pub fn parallel<Fft: FftImpl<f32> + Sync>(
 /// * `output` - buffer to receive the reconstructed signal
 /// * `fft` - FFT implementation to reuse cached plans
 ///
-/// Returns [`FftError::InvalidHopSize`] if `hop_size` is zero.
+/// # Errors
+///
+/// - [`FftError::InvalidHopSize`] if `hop_size` is zero or exceeds
+///   `window.len()`.
+/// - [`FftError::MismatchedLengths`] if frame or buffer sizes are inconsistent.
 ///
 /// # Examples
 /// ```ignore
@@ -474,10 +524,21 @@ pub fn inverse_parallel<Fft: FftImpl<f32> + Sync>(
     fft: &Fft,
 ) -> Result<(), FftError> {
     use rayon::prelude::*;
-    if hop_size == 0 {
+    if hop_size == 0 || hop_size > window.len() {
         return Err(FftError::InvalidHopSize);
     }
     let win_len = window.len();
+    if win_len == 0 {
+        return Err(FftError::MismatchedLengths);
+    }
+    let required = if frames.is_empty() {
+        0
+    } else {
+        (frames.len() - 1) * hop_size + win_len
+    };
+    if output.len() != required {
+        return Err(FftError::MismatchedLengths);
+    }
     type Accum = (usize, alloc::vec::Vec<f32>, alloc::vec::Vec<f32>);
     type AccumResult = Result<alloc::vec::Vec<Accum>, FftError>;
     let partials: AccumResult = frames
@@ -492,6 +553,9 @@ pub fn inverse_parallel<Fft: FftImpl<f32> + Sync>(
                 )
             },
             |(time_buf, acc, norm), (frame_idx, frame)| {
+                if frame.len() != win_len {
+                    return Err(FftError::MismatchedLengths);
+                }
                 let start = frame_idx * hop_size;
                 time_buf.copy_from_slice(frame);
                 fft.ifft(time_buf)?;
@@ -519,10 +583,9 @@ pub fn inverse_parallel<Fft: FftImpl<f32> + Sync>(
     norm.resize(output.len(), 0.0);
     for (start, acc_frame, norm_frame) in partials {
         for i in 0..win_len {
-            if start + i < output.len() {
-                output[start + i] += acc_frame[i];
-                norm[start + i] += norm_frame[i];
-            }
+            let idx = start + i;
+            output[idx] += acc_frame[i];
+            norm[idx] += norm_frame[i];
         }
     }
     for i in 0..output.len() {
@@ -611,20 +674,24 @@ pub struct IstftStream<'a, Fft: crate::fft::FftImpl<f32>> {
 }
 
 impl<'a, Fft: crate::fft::FftImpl<f32>> IstftStream<'a, Fft> {
+    /// Create a streaming inverse STFT processor.
+    ///
+    /// Validates hop size and window length to avoid misaligned overlap-add
+    /// during reconstruction.
     pub fn new(
         win_len: usize,
         hop: usize,
         window: &'a [f32],
         fft: &'a Fft,
     ) -> Result<Self, FftError> {
-        if hop == 0 {
+        if hop == 0 || hop > win_len {
             return Err(FftError::InvalidHopSize);
         }
-        if window.len() != win_len {
+        if window.len() != win_len || win_len == 0 {
             return Err(FftError::MismatchedLengths);
         }
-        let buffer = vec![0.0f32; win_len + hop * 2];
-        let norm_buf = vec![0.0f32; win_len + hop * 2];
+        let buffer = vec![0.0f32; win_len + hop * STREAM_PAD_MULTIPLIER];
+        let norm_buf = vec![0.0f32; win_len + hop * STREAM_PAD_MULTIPLIER];
         Ok(Self {
             win_len,
             hop,
@@ -642,7 +709,8 @@ impl<'a, Fft: crate::fft::FftImpl<f32>> IstftStream<'a, Fft> {
     ///
     /// Returns a slice of length `hop` containing the next chunk of time-domain
     /// signal. Remaining samples after all frames have been pushed can be
-    /// retrieved via [`flush`].
+    /// retrieved via [`flush`]. Errors if the provided frame length does not
+    /// match `win_len`.
     pub fn push_frame(&mut self, frame: &mut [crate::fft::Complex32]) -> Result<&[f32], FftError> {
         if frame.len() != self.win_len {
             return Err(FftError::MismatchedLengths);
@@ -725,8 +793,8 @@ impl<'a, Fft: crate::fft::FftImpl<f32>> IstftStream<'a, Fft> {
 #[cfg(all(feature = "internal-tests", test))]
 mod tests {
     use super::*;
-    // Only the complex type and scalar FFT implementation are required for tests.
-    use crate::fft::{Complex32, ScalarFftImpl};
+    // Import FFT traits and types for constructing test FFT wrappers.
+    use crate::fft::{Complex32, FftError, FftImpl, FftStrategy, ScalarFftImpl};
 
     #[test]
     fn test_stft_istft_frame_roundtrip() {
@@ -775,10 +843,10 @@ mod tests {
         }
         let fft = ScalarFftImpl::<f32>::default();
         stft(&signal, &window, hop, &mut frames, &fft).unwrap();
-        let mut output = vec![0.0f32; n];
-        let mut scratch = vec![0.0f32; n];
+        let mut output = vec![0.0f32; n + win_len - hop];
+        let mut scratch = vec![0.0f32; output.len()];
         istft(&mut frames, &window, hop, &mut output, &mut scratch, &fft).unwrap();
-        for (a, b) in signal.iter().zip(output.iter()) {
+        for (a, b) in signal.iter().zip(output.iter().take(n)) {
             assert!((a - b).abs() < 1e-4, "{} vs {}", a, b);
         }
     }
@@ -862,9 +930,9 @@ mod tests {
         }
         let fft = SyncFft::default();
         parallel(&signal, &window, hop, &mut frames, &fft).unwrap();
-        let mut output = vec![0.0f32; n];
+        let mut output = vec![0.0f32; n + win_len - hop];
         inverse_parallel(&frames, &window, hop, &mut output, &fft).unwrap();
-        for (a, b) in signal.iter().zip(output.iter()) {
+        for (a, b) in signal.iter().zip(output.iter().take(n)) {
             assert!((a - b).abs() < 1e-4, "{} vs {}", a, b);
         }
     }
@@ -889,10 +957,11 @@ mod streaming_tests {
         while stft_stream.next_frame(&mut frame).unwrap() {
             frames.push(frame.clone());
         }
-        let mut output = vec![0.0f32; signal.len()];
+        let win_len = window.len();
+        let mut output = vec![0.0f32; signal.len() + win_len - hop];
         let mut scratch = vec![0.0f32; output.len()];
         istft(&mut frames, &window, hop, &mut output, &mut scratch, &fft).unwrap();
-        for (a, b) in signal.iter().zip(output.iter()) {
+        for (a, b) in signal.iter().zip(output.iter().take(signal.len())) {
             assert!((a - b).abs() < 1e-4, "{} vs {}", a, b);
         }
     }
@@ -908,12 +977,12 @@ mod edge_case_tests {
     fn test_empty_signal_batch() {
         let signal: [f32; 0] = [];
         let window = [1.0, 1.0, 1.0, 1.0];
-        let mut frames = vec![vec![Complex32::new(0.0, 0.0); 4]];
+        let mut frames: Vec<Vec<Complex32>> = Vec::new();
         let fft = ScalarFftImpl::<f32>::default();
         let res = stft(&signal, &window, 2, &mut frames, &fft);
         assert!(res.is_ok());
-        let mut output = vec![0.0f32; 0];
-        let mut scratch = vec![0.0f32; 0];
+        let mut output = vec![];
+        let mut scratch = vec![];
         let res = istft(&mut frames, &window, 2, &mut output, &mut scratch, &fft);
         assert!(res.is_ok());
     }
@@ -927,7 +996,7 @@ mod edge_case_tests {
         let mut scratch = vec![0.0f32; output.len()];
         let fft = ScalarFftImpl::<f32>::default();
         let res = istft(&mut frames, &window, 2, &mut output, &mut scratch, &fft);
-        assert!(res.is_ok()); // Should not panic, just not fill all output
+        assert!(matches!(res, Err(FftError::MismatchedLengths)));
     }
 
     #[test]
@@ -979,10 +1048,11 @@ mod edge_case_tests {
                 assert_eq!(c.im, 0.0);
             }
         }
-        let mut output = vec![0.0f32; signal.len()];
+        let win_len = window.len();
+        let mut output = vec![0.0f32; signal.len() + win_len - hop];
         let mut scratch = vec![0.0f32; output.len()];
         istft(&mut frames, &window, hop, &mut output, &mut scratch, &fft).unwrap();
-        for &x in &output {
+        for &x in &output[..signal.len()] {
             assert_eq!(x, 0.0);
         }
     }
@@ -1003,11 +1073,11 @@ mod edge_case_tests {
         }
         let fft = ScalarFftImpl::<f32>::default();
         stft(&signal, &window, hop, &mut frames, &fft).unwrap();
-        let mut output = vec![0.0f32; n];
+        let mut output = vec![0.0f32; n + win_len - hop];
         let mut scratch = vec![0.0f32; output.len()];
         istft(&mut frames, &window, hop, &mut output, &mut scratch, &fft).unwrap();
         // Should roughly reconstruct signal (Hann window has edge attenuation)
-        for (a, b) in signal.iter().zip(output.iter()) {
+        for (a, b) in signal.iter().zip(output.iter().take(n)) {
             assert!((a - b).abs() < 1.1, "{} vs {}", a, b);
         }
     }
@@ -1043,7 +1113,7 @@ mod edge_case_tests {
         let mut frames = vec![vec![Complex32::new(0.0, 0.0); window.len()]; required];
         let fft = ScalarFftImpl::<f32>::default();
         stft(&signal, &window, 1, &mut frames, &fft).unwrap();
-        let mut output = vec![0.0f32; signal.len()];
+        let mut output = vec![0.0f32; signal.len() + window.len() - 1];
         let mut scratch = vec![0.0f32; output.len()];
         istft(&mut frames, &window, 1, &mut output, &mut scratch, &fft).unwrap();
         // With such a tiny window, normalization should treat the output as silence
@@ -1057,14 +1127,14 @@ mod edge_case_tests {
 mod coverage_tests {
     use super::*;
     use crate::fft::{Complex32, ScalarFftImpl};
-    use alloc::format;
+    use alloc::{format, vec::Vec};
     use proptest::prelude::*;
 
     #[test]
     fn test_stft_empty() {
         let signal: [f32; 0] = [];
         let window = [1.0, 1.0, 1.0, 1.0];
-        let mut frames = vec![vec![Complex32::new(0.0, 0.0); 4]];
+        let mut frames: Vec<Vec<Complex32>> = Vec::new();
         let fft = ScalarFftImpl::<f32>::default();
         let res = stft(&signal, &window, 2, &mut frames, &fft);
         assert!(res.is_ok());
@@ -1178,10 +1248,11 @@ mod coverage_tests {
                 assert_eq!(c.im, 0.0);
             }
         }
-        let mut output = vec![0.0f32; signal.len()];
+        let win_len = window.len();
+        let mut output = vec![0.0f32; signal.len() + win_len - hop];
         let mut scratch = vec![0.0f32; output.len()];
         istft(&mut frames, &window, hop, &mut output, &mut scratch, &fft).unwrap();
-        for &x in &output {
+        for &x in &output[..signal.len()] {
             assert_eq!(x, 0.0);
         }
     }
@@ -1200,10 +1271,11 @@ mod coverage_tests {
             }
             let fft = ScalarFftImpl::<f32>::default();
             stft(signal, &window, hop, &mut frames, &fft).unwrap();
-            let mut output = vec![0.0f32; len];
+            let expected = (num_frames - 1) * hop + win_len;
+            let mut output = vec![0.0f32; expected];
             let mut scratch = vec![0.0f32; output.len()];
             istft(&mut frames, &window, hop, &mut output, &mut scratch, &fft).unwrap();
-            for (a, b) in signal.iter().zip(output.iter()) {
+            for (a, b) in signal.iter().zip(output.iter().take(len)) {
                 prop_assert!((a - b).abs() < 1e-2);
             }
         }

--- a/tests/fuzzy_alloc.rs
+++ b/tests/fuzzy_alloc.rs
@@ -29,11 +29,13 @@ static A: CountingAlloc = CountingAlloc;
 #[test]
 fn fuzzy_match_allocations() {
     ALLOC_COUNT.store(0, Ordering::SeqCst);
-    fuzzy_score("abc", "abc");
+    let pattern = "abc";
+    let len = pattern.len();
+    fuzzy_score(pattern, "abc", len);
     let score_allocs = ALLOC_COUNT.load(Ordering::SeqCst);
 
     ALLOC_COUNT.store(0, Ordering::SeqCst);
-    fuzzy_match("abc", "abc");
+    fuzzy_match(pattern, len, "abc");
     let match_allocs = ALLOC_COUNT.load(Ordering::SeqCst);
 
     assert_eq!(

--- a/tests/inverse_parallel.rs
+++ b/tests/inverse_parallel.rs
@@ -103,8 +103,9 @@ fn inverse_parallel_matches_istft() {
     let fft = SyncFft::default();
     let mut frames = vec![vec![]; signal.len().div_ceil(hop)];
     stft(&signal, &window, hop, &mut frames, &fft).unwrap();
-    let mut out_seq = vec![0.0; signal.len()];
-    let mut scratch = vec![0.0; signal.len()];
+    let expected = (frames.len() - 1) * hop + win_len;
+    let mut out_seq = vec![0.0; expected];
+    let mut scratch = vec![0.0; expected];
     istft(
         &mut frames.clone(),
         &window,
@@ -114,7 +115,7 @@ fn inverse_parallel_matches_istft() {
         &fft,
     )
     .unwrap();
-    let mut out_par = vec![0.0; signal.len()];
+    let mut out_par = vec![0.0; expected];
     inverse_parallel(&frames, &window, hop, &mut out_par, &fft).unwrap();
     for (a, b) in out_seq.iter().zip(out_par.iter()) {
         assert!((a - b).abs() < 1e-5);

--- a/tests/stft_boundaries.rs
+++ b/tests/stft_boundaries.rs
@@ -1,0 +1,213 @@
+#![cfg(all(feature = "simd", feature = "wasm"))]
+
+use kofft::fft::{Complex32, FftError, ScalarFftImpl};
+use kofft::stft::{istft, stft, IstftStream, StftStream};
+use kofft::window::hann;
+
+#[cfg(feature = "parallel")]
+mod sync_fft {
+    use super::*;
+    use kofft::fft::{FftImpl, FftStrategy};
+    use std::sync::Mutex;
+
+    #[derive(Default)]
+    pub struct SyncFft(Mutex<ScalarFftImpl<f32>>);
+
+    impl FftImpl<f32> for SyncFft {
+        fn fft(&self, input: &mut [Complex32]) -> Result<(), FftError> {
+            self.0.lock().unwrap().fft(input)
+        }
+        fn ifft(&self, input: &mut [Complex32]) -> Result<(), FftError> {
+            self.0.lock().unwrap().ifft(input)
+        }
+        fn fft_strided(
+            &self,
+            input: &mut [Complex32],
+            stride: usize,
+            scratch: &mut [Complex32],
+        ) -> Result<(), FftError> {
+            self.0.lock().unwrap().fft_strided(input, stride, scratch)
+        }
+        fn ifft_strided(
+            &self,
+            input: &mut [Complex32],
+            stride: usize,
+            scratch: &mut [Complex32],
+        ) -> Result<(), FftError> {
+            self.0.lock().unwrap().ifft_strided(input, stride, scratch)
+        }
+        fn fft_out_of_place_strided(
+            &self,
+            input: &[Complex32],
+            in_stride: usize,
+            output: &mut [Complex32],
+            out_stride: usize,
+        ) -> Result<(), FftError> {
+            self.0
+                .lock()
+                .unwrap()
+                .fft_out_of_place_strided(input, in_stride, output, out_stride)
+        }
+        fn ifft_out_of_place_strided(
+            &self,
+            input: &[Complex32],
+            in_stride: usize,
+            output: &mut [Complex32],
+            out_stride: usize,
+        ) -> Result<(), FftError> {
+            self.0
+                .lock()
+                .unwrap()
+                .ifft_out_of_place_strided(input, in_stride, output, out_stride)
+        }
+        fn fft_with_strategy(
+            &self,
+            input: &mut [Complex32],
+            strategy: FftStrategy,
+        ) -> Result<(), FftError> {
+            self.0.lock().unwrap().fft_with_strategy(input, strategy)
+        }
+    }
+}
+
+/// Ensure hop sizes larger than the window are rejected.
+#[test]
+fn stft_rejects_large_hop() {
+    let signal = [0.0f32; 8];
+    let window = hann(4);
+    let hop = 8; // larger than window
+    let mut frames = vec![vec![Complex32::new(0.0, 0.0); window.len()]; 1];
+    let fft = ScalarFftImpl::<f32>::default();
+    let res = stft(&signal, &window, hop, &mut frames, &fft);
+    assert!(matches!(res, Err(FftError::InvalidHopSize)));
+}
+
+/// STFT rejects a zero hop size.
+#[test]
+fn stft_rejects_zero_hop() {
+    let signal = [0.0f32; 4];
+    let window = hann(4);
+    let hop = 0;
+    let mut frames = vec![vec![Complex32::new(0.0, 0.0); window.len()]; 1];
+    let fft = ScalarFftImpl::<f32>::default();
+    let res = stft(&signal, &window, hop, &mut frames, &fft);
+    assert!(matches!(res, Err(FftError::InvalidHopSize)));
+}
+
+/// ISTFT validates hop against the window length and output size.
+#[test]
+fn istft_rejects_large_hop_and_short_output() {
+    let window = hann(4);
+    let hop = 8; // invalid
+    let mut frames = vec![vec![Complex32::new(0.0, 0.0); window.len()]; 1];
+    let mut out = vec![0.0f32; 4];
+    let mut scratch = vec![0.0f32; 4];
+    let fft = ScalarFftImpl::<f32>::default();
+    let res = istft(&mut frames, &window, hop, &mut out, &mut scratch, &fft);
+    assert!(matches!(res, Err(FftError::InvalidHopSize)));
+
+    // Now test output length mismatch
+    let hop = 2;
+    let mut out_short = vec![0.0f32; 3];
+    let mut scratch_short = vec![0.0f32; 3];
+    let res = istft(
+        &mut frames,
+        &window,
+        hop,
+        &mut out_short,
+        &mut scratch_short,
+        &fft,
+    );
+    assert!(matches!(res, Err(FftError::MismatchedLengths)));
+}
+
+/// ISTFT rejects zero hop size.
+#[test]
+fn istft_rejects_zero_hop() {
+    let window = hann(4);
+    let hop = 0;
+    let mut frames = vec![vec![Complex32::new(0.0, 0.0); window.len()]; 1];
+    let mut out = vec![0.0f32; 4];
+    let mut scratch = vec![0.0f32; 4];
+    let fft = ScalarFftImpl::<f32>::default();
+    let res = istft(&mut frames, &window, hop, &mut out, &mut scratch, &fft);
+    assert!(matches!(res, Err(FftError::InvalidHopSize)));
+}
+
+/// Streaming STFT rejects hop sizes exceeding the window length.
+#[test]
+fn stft_stream_rejects_large_hop() {
+    let signal = [0.0f32; 8];
+    let window = hann(4);
+    let fft = ScalarFftImpl::<f32>::default();
+    let res = StftStream::new(&signal, &window, 8, &fft);
+    assert!(matches!(res, Err(FftError::InvalidHopSize)));
+}
+
+/// STFT stream errors when the output frame size is incorrect.
+#[test]
+fn stft_stream_frame_size_mismatch() {
+    let signal = [0.0f32; 8];
+    let window = hann(4);
+    let hop = 2;
+    let fft = ScalarFftImpl::<f32>::default();
+    let mut stream = StftStream::new(&signal, &window, hop, &fft).unwrap();
+    let mut frame = vec![Complex32::new(0.0, 0.0); window.len() - 1];
+    let res = stream.next_frame(&mut frame);
+    assert!(matches!(res, Err(FftError::MismatchedLengths)));
+}
+
+/// Streaming ISTFT checks hop size and window length during construction.
+#[test]
+fn istft_stream_rejects_large_hop() {
+    let window = hann(4);
+    let fft = ScalarFftImpl::<f32>::default();
+    let res = IstftStream::new(4, 8, &window, &fft);
+    assert!(matches!(res, Err(FftError::InvalidHopSize)));
+}
+
+/// Flushing twice should yield an empty slice on the second call.
+#[test]
+fn istft_stream_double_flush_empty() {
+    let signal = [1.0, 2.0, 3.0, 4.0];
+    let window = hann(4);
+    let hop = 2;
+    let fft = ScalarFftImpl::<f32>::default();
+    let mut stft_stream = StftStream::new(&signal, &window, hop, &fft).unwrap();
+    let mut istft_stream = IstftStream::new(window.len(), hop, &window, &fft).unwrap();
+    let mut frame = vec![Complex32::new(0.0, 0.0); window.len()];
+    while stft_stream.next_frame(&mut frame).unwrap() {
+        let _ = istft_stream.push_frame(&mut frame).unwrap();
+    }
+    let tail = istft_stream.flush();
+    assert!(!tail.is_empty());
+    assert!(istft_stream.flush().is_empty());
+}
+
+#[cfg(feature = "parallel")]
+/// Parallel STFT validates hop size similarly to the sequential version.
+#[test]
+fn parallel_stft_rejects_large_hop() {
+    use kofft::stft::parallel;
+    let signal = [0.0f32; 8];
+    let window = hann(4);
+    let hop = 8; // invalid
+    let mut frames = vec![vec![Complex32::new(0.0, 0.0); window.len()]; 1];
+    let fft = sync_fft::SyncFft::default();
+    let res = parallel(&signal, &window, hop, &mut frames, &fft);
+    assert!(matches!(res, Err(FftError::InvalidHopSize)));
+}
+
+#[cfg(feature = "parallel")]
+/// Parallel inverse STFT validates hop size and output length.
+#[test]
+fn inverse_parallel_rejects_large_hop() {
+    use kofft::stft::inverse_parallel;
+    let window = hann(4);
+    let hop = 8; // invalid
+    let frames = vec![vec![Complex32::new(0.0, 0.0); window.len()]; 1];
+    let mut out = vec![0.0f32; 4];
+    let fft = sync_fft::SyncFft::default();
+    let res = inverse_parallel(&frames, &window, hop, &mut out, &fft);
+    assert!(matches!(res, Err(FftError::InvalidHopSize)));
+}


### PR DESCRIPTION
## Summary
- harden STFT/ISTFT APIs with hop/window/output validation
- document streaming structures and add buffer constants
- test hop-size errors, window mismatches, parallel paths, and flush behavior

## Testing
- `cargo clippy --all-targets --all-features -q`
- `cargo test --all-features`


------
https://chatgpt.com/codex/tasks/task_e_68a742ff5730832b9b9068fcf9c11839