### PR TITLE
fix palette cleanup for theme switching and add design toggle tests

### DIFF
--- a/web/apps/shell/src/DesignContext.tsx
+++ b/web/apps/shell/src/DesignContext.tsx
@@ -25,16 +25,37 @@ const MODE_ATTR = "data-mode";
 /** Prefix shared by Japanese design identifiers. */
 const JAPANESE_PREFIX = "japanese" as const;
 
-/** Apply a palette to the document root. */
+/** Name of the CSS variable for page background colour. */
+const VAR_BG = "--color-bg" as const;
+/** Name of the CSS variable for default text colour. */
+const VAR_TEXT = "--color-text" as const;
+/** Name of the CSS variable for primary accent colour. */
+const VAR_ACCENT = "--color-accent" as const;
+/** Name of the CSS variable for secondary accent colour. */
+const VAR_SECONDARY = "--color-secondary" as const;
+/** Name of the CSS variable for tertiary accent colour. */
+const VAR_TERTIARY = "--color-tertiary" as const;
+
+/**
+ * Apply a palette to the document root.
+ * Secondary and tertiary colours are explicitly removed when absent to
+ * prevent stale values from previous designs leaking into the current theme.
+ */
 function applyPalette(palette: Palette): void {
   const root = document.documentElement;
-  root.style.setProperty("--color-bg", palette.background);
-  root.style.setProperty("--color-text", palette.text);
-  root.style.setProperty("--color-accent", palette.accent);
-  if (palette.secondary)
-    root.style.setProperty("--color-secondary", palette.secondary);
-  if (palette.tertiary)
-    root.style.setProperty("--color-tertiary", palette.tertiary);
+  root.style.setProperty(VAR_BG, palette.background);
+  root.style.setProperty(VAR_TEXT, palette.text);
+  root.style.setProperty(VAR_ACCENT, palette.accent);
+  if (palette.secondary) {
+    root.style.setProperty(VAR_SECONDARY, palette.secondary);
+  } else {
+    root.style.removeProperty(VAR_SECONDARY);
+  }
+  if (palette.tertiary) {
+    root.style.setProperty(VAR_TERTIARY, palette.tertiary);
+  } else {
+    root.style.removeProperty(VAR_TERTIARY);
+  }
 }
 
 /**

--- a/web/apps/shell/src/DesignToggle.test.tsx
+++ b/web/apps/shell/src/DesignToggle.test.tsx
@@ -1,0 +1,72 @@
+import React from "react";
+import { describe, it, expect, afterEach } from "vitest";
+import { render, fireEvent, cleanup } from "@testing-library/react";
+import { DesignProvider } from "./DesignContext";
+import { DesignToggle } from "./DesignToggle";
+import { PALETTES } from "./designs";
+
+/**
+ * Convenience helper rendering the toggle within its provider. The wrapper
+ * mirrors real-world usage and allows tests to interact with context state
+ * exactly as the application does.
+ */
+function renderWithProvider() {
+  return render(
+    <DesignProvider>
+      <DesignToggle />
+    </DesignProvider>,
+  );
+}
+
+/**
+ * Retrieve computed styles for the document root. Named function keeps tests
+ * concise while ensuring the call site is obvious.
+ */
+function rootStyles(): CSSStyleDeclaration {
+  return getComputedStyle(document.documentElement);
+}
+
+/** Validate that selecting each design updates the DOM attribute. */
+describe("DesignToggle", () => {
+  afterEach(cleanup);
+  it.each(["japanese-a", "japanese-b", "bauhaus"] as const)(
+    "switches to %s",
+    (design) => {
+      const { getByTestId } = renderWithProvider();
+      fireEvent.change(getByTestId("design-select"), {
+        target: { value: design },
+      });
+      expect(document.documentElement.getAttribute("data-design")).toBe(design);
+    },
+  );
+
+  /** Ensure colour mode changes propagate to the root element. */
+  it("switches mode", () => {
+    const { getByTestId } = renderWithProvider();
+    fireEvent.change(getByTestId("mode-select"), { target: { value: "dark" } });
+    expect(document.documentElement.getAttribute("data-mode")).toBe("dark");
+  });
+
+  /**
+   * Switching away from Bauhaus should remove secondary and tertiary colour
+   * variables so that minimalist designs remain free of unused values.
+   */
+  it("clears Bauhaus-only variables when switching to Japanese", () => {
+    const { getByTestId } = renderWithProvider();
+    fireEvent.change(getByTestId("design-select"), {
+      target: { value: "bauhaus" },
+    });
+    const palette = PALETTES.bauhaus.light;
+    expect(rootStyles().getPropertyValue("--color-secondary").trim()).toBe(
+      palette.secondary,
+    );
+    expect(rootStyles().getPropertyValue("--color-tertiary").trim()).toBe(
+      palette.tertiary,
+    );
+    fireEvent.change(getByTestId("design-select"), {
+      target: { value: "japanese-a" },
+    });
+    expect(rootStyles().getPropertyValue("--color-secondary")).toBe("");
+    expect(rootStyles().getPropertyValue("--color-tertiary")).toBe("");
+  });
+});


### PR DESCRIPTION
## Summary
- clear unused CSS palette variables when switching designs to prevent stale accents
- test design toggle controls and verify Bauhaus variables are removed when switching to Japanese

## Testing
- `npm test`
- `cargo test` *(fails: required_features_enabled -> parallel feature not enabled)*

------
https://chatgpt.com/codex/tasks/task_e_68a787248868832bbd7348fd31981c81