### PR TITLE
Use SeqCst for parallel FFT overrides

### DIFF
--- a/tests/parallel_override_visibility.rs
+++ b/tests/parallel_override_visibility.rs
@@ -1,0 +1,24 @@
+#![cfg(all(feature = "parallel", feature = "std", feature = "internal-tests"))]
+// Test intent: ensures that parallel FFT override setters publish values across
+// threads so subsequent FFT computations see consistent configuration.
+
+use std::sync::{Arc, Barrier};
+use std::thread;
+
+use kofft::fft::{__test_parallel_pool_thread_count, set_parallel_fft_threads};
+
+#[test]
+fn overrides_visible_across_threads() {
+    // Validate thread-count override visibility.
+    const THREADS: usize = 2;
+    let barrier = Arc::new(Barrier::new(2));
+    let b = barrier.clone();
+    let setter = thread::spawn(move || {
+        set_parallel_fft_threads(THREADS);
+        b.wait();
+    });
+    barrier.wait();
+    let count = __test_parallel_pool_thread_count();
+    setter.join().expect("setter thread panicked");
+    assert_eq!(count, THREADS, "thread override not visible across threads");
+}


### PR DESCRIPTION
## Summary
- use `SeqCst` ordering for parallel FFT override atomics so updates are visible across threads
- test that a thread count override made in one thread is observed by another before creating the Rayon pool

## Testing
- `cargo fmt --all`
- `cargo clippy --all-targets --all-features -p kofft`
- `cargo test --all-features -p kofft -- --test-threads=1` *(fails: `fuzzy_match_allocations`)*
- `cargo test -p kofft --features "parallel internal-tests waveform-cache" --test parallel_override_visibility -- --test-threads=1`


------
https://chatgpt.com/codex/tasks/task_e_68a787f86d78832bac98382ed377534d