### PR TITLE
Harden linear resampler and add edge tests

### DIFF
--- a/web/apps/mfe-spectrogram/src/shared/utils/__tests__/linearResample.test.ts
+++ b/web/apps/mfe-spectrogram/src/shared/utils/__tests__/linearResample.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect, vi } from "vitest";
+// Stub modules with heavy browser dependencies before importing subjects.
+vi.mock("../audioPlayer", () => ({ audioPlayer: {} }));
+vi.mock("../wasm", () => ({
+  computeWaveformPeaksWASM: vi.fn(),
+  linearResample: vi.fn(),
+}));
+
+import { linearResample as linearResampleTS } from "../waveform";
+
+// Negative target length to verify graceful handling of invalid sizes.
+const NEGATIVE_LENGTH = -5;
+// Zero target length should yield an empty array.
+const ZERO_LENGTH = 0;
+// Positive target length used for normal resampling behavior.
+const POSITIVE_LENGTH = 4;
+
+// Implementation under test.
+const RESAMPLERS = [{ label: "TS", fn: linearResampleTS }];
+
+/**
+ * Ensure linearResample gracefully handles edge-case target lengths.
+ */
+for (const { label, fn } of RESAMPLERS) {
+  describe(`linearResample ${label}`, () => {
+    it("returns empty array for negative length", () => {
+      const out = fn(new Float32Array([1, 2, 3]), NEGATIVE_LENGTH);
+      expect(out.length).toBe(0);
+    });
+
+    it("returns empty array for zero length", () => {
+      const out = fn(new Float32Array([1, 2, 3]), ZERO_LENGTH);
+      expect(out.length).toBe(0);
+    });
+
+    it("resamples correctly for positive length", () => {
+      const input = new Float32Array([0, 1, 2, 3]);
+      const out = fn(input, POSITIVE_LENGTH);
+      expect(out.length).toBe(POSITIVE_LENGTH);
+      expect(out[POSITIVE_LENGTH - 1]).toBeCloseTo(input[input.length - 1], 6);
+    });
+
+    it("returns zero-filled output for empty input", () => {
+      const out = fn(new Float32Array(), POSITIVE_LENGTH);
+      expect(out.length).toBe(POSITIVE_LENGTH);
+      for (const v of out) {
+        expect(v).toBe(0);
+      }
+    });
+  });
+}

--- a/web/apps/mfe-spectrogram/src/shared/utils/wasm.ts
+++ b/web/apps/mfe-spectrogram/src/shared/utils/wasm.ts
@@ -258,28 +258,42 @@ function generateAmplitudeEnvelopeJS(
   return envelope;
 }
 
-// Linear resampler used when the WASM helper is unavailable.  Resamples to a
-// specific target length while ensuring the final sample of the output matches
-// the final input sample.
-function linearResample(
+// Minimum allowable output length; prevents negative-length array allocation.
+const MIN_TARGET_LENGTH = 0;
+// Output length representing a single interpolated sample.
+const SINGLE_SAMPLE_LENGTH = 1;
+
+/**
+ * Fallback linear resampler used when WASM helpers are unavailable.
+ * Performs a linear interpolation across `targetLength` samples while ensuring
+ * the final output sample mirrors the final input sample.
+ * Exported for direct unit testing; external callers should prefer WASM APIs.
+ */
+export function linearResample(
   input: Float32Array,
   targetLength: number,
 ): Float32Array {
-  if (targetLength <= 0 || input.length === 0) {
-    return new Float32Array(targetLength);
+  if (targetLength <= MIN_TARGET_LENGTH || input.length === MIN_TARGET_LENGTH) {
+    return new Float32Array(Math.max(MIN_TARGET_LENGTH, targetLength));
   }
   const output = new Float32Array(targetLength);
-  if (targetLength === 1) {
-    output[0] = input[input.length - 1];
+  if (targetLength === SINGLE_SAMPLE_LENGTH) {
+    output[MIN_TARGET_LENGTH] = input[input.length - SINGLE_SAMPLE_LENGTH];
     return output;
   }
-  const ratio = (input.length - 1) / (targetLength - 1);
+  const ratio =
+    (input.length - SINGLE_SAMPLE_LENGTH) /
+    (targetLength - SINGLE_SAMPLE_LENGTH);
   for (let i = 0; i < targetLength; i++) {
     const pos = i * ratio;
     const idx = Math.floor(pos);
     const frac = pos - idx;
     const s0 = input[idx];
-    const s1 = input[idx + 1 < input.length ? idx + 1 : idx];
+    const nextIdx =
+      idx + SINGLE_SAMPLE_LENGTH < input.length
+        ? idx + SINGLE_SAMPLE_LENGTH
+        : idx;
+    const s1 = input[nextIdx];
     output[i] = s0 + (s1 - s0) * frac;
   }
   return output;


### PR DESCRIPTION
## Summary
- prevent negative-length allocations in linearResample and export for testing
- add constants and comments for clarity
- cover negative, zero, and positive resample lengths

## Testing
- `npm test` *(fails: HTMLCanvasElement is not defined)*
- `npx vitest run src/shared/utils/__tests__/linearResample.test.ts --environment jsdom`

------
https://chatgpt.com/codex/tasks/task_e_68a7880ecd40832bb0052d3d388e373d