### PR TITLE
feat: add explicit fuzzy matching errors

### DIFF
--- a/src/fuzzy.rs
+++ b/src/fuzzy.rs
@@ -1,5 +1,37 @@
 use alloc::{string::String, vec, vec::Vec};
 
+/// Errors that can occur during fuzzy matching operations.
+///
+/// The functions in this module perform strict validation of their inputs and
+/// return these errors rather than panicking, allowing callers to handle
+/// invalid conditions gracefully.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum FuzzyError {
+    /// The supplied length for `pattern` does not match its UTF-8 code point
+    /// count.  Callers must pre-compute the pattern length and pass it
+    /// consistently to avoid redundant scans; mismatches are treated as usage
+    /// errors and reported with this variant.
+    InvalidLength,
+    /// Either `pattern` or `text` exceeds [`MAX_INPUT_LENGTH`].  Limiting input
+    /// size prevents excessive allocations from quadratic-time Levenshtein
+    /// computations.
+    InputTooLong,
+}
+
+#[cfg(feature = "std")]
+impl std::error::Error for FuzzyError {}
+
+impl core::fmt::Display for FuzzyError {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            FuzzyError::InvalidLength => f.write_str("pattern length mismatch"),
+            FuzzyError::InputTooLong => {
+                write!(f, "input exceeds MAX_INPUT_LENGTH ({})", MAX_INPUT_LENGTH)
+            }
+        }
+    }
+}
+
 /// Maximum allowed length for either the pattern or text.
 ///
 /// The Levenshtein algorithm has quadratic complexity in the lengths of the
@@ -27,36 +59,30 @@ pub const MATCH_THRESHOLD_DIVISOR: usize = 2;
 /// repeatedly traversing the UTF-8 data.  Early returns handle empty inputs
 /// without performing any allocations.
 ///
-/// # Panics
+/// # Errors
 ///
-/// * If `pattern_len` does not equal the number of UTF-8 code points in
-///   `pattern`.
-/// * If either input exceeds [`MAX_INPUT_LENGTH`].
-pub fn fuzzy_score(pattern: &str, text: &str, pattern_len: usize) -> usize {
+/// Returns [`FuzzyError::InvalidLength`] if `pattern_len` does not equal the
+/// number of UTF-8 code points in `pattern`, or [`FuzzyError::InputTooLong`] if
+/// either input exceeds [`MAX_INPUT_LENGTH`].
+pub fn fuzzy_score(pattern: &str, text: &str, pattern_len: usize) -> Result<usize, FuzzyError> {
     let pattern_chars: Vec<char> = pattern.chars().collect();
     let actual_pattern_len = pattern_chars.len();
-    
+
     if actual_pattern_len != pattern_len {
-        panic!(
-            "pattern_len {} does not match pattern's code point count {}",
-            pattern_len, actual_pattern_len
-        );
+        return Err(FuzzyError::InvalidLength);
     }
-    
+
     // Count characters without allocating to keep memory usage minimal.
     let text_len = text.chars().count();
-    
+
     if actual_pattern_len > MAX_INPUT_LENGTH || text_len > MAX_INPUT_LENGTH {
-        panic!(
-            "input too long; maximum supported length is {}",
-            MAX_INPUT_LENGTH
-        );
+        return Err(FuzzyError::InputTooLong);
     }
     if pattern_len == 0 {
-        return text_len;
+        return Ok(text_len);
     }
     if text_len == 0 {
-        return pattern_len;
+        return Ok(pattern_len);
     }
 
     let text_chars: Vec<char> = text.chars().collect();
@@ -76,7 +102,7 @@ pub fn fuzzy_score(pattern: &str, text: &str, pattern_len: usize) -> usize {
         core::mem::swap(&mut prev, &mut curr);
     }
 
-    prev[text_len]
+    Ok(prev[text_len])
 }
 
 /// Determine if two strings match within half the pattern length.
@@ -85,15 +111,9 @@ pub fn fuzzy_score(pattern: &str, text: &str, pattern_len: usize) -> usize {
 /// the pattern on repeated calls.  This function delegates to [`fuzzy_score`]
 /// for the heavy lifting and simply compares the resulting distance against the
 /// threshold defined by [`MATCH_THRESHOLD_DIVISOR`].
-pub fn fuzzy_match(pattern: &str, pattern_len: usize, text: &str) -> bool {
-    if pattern_len > MAX_INPUT_LENGTH {
-        panic!(
-            "pattern too long; maximum supported length is {}",
-            MAX_INPUT_LENGTH
-        );
-    }
-
-    fuzzy_score(pattern, text, pattern_len) <= pattern_len / MATCH_THRESHOLD_DIVISOR
+pub fn fuzzy_match(pattern: &str, pattern_len: usize, text: &str) -> Result<bool, FuzzyError> {
+    let score = fuzzy_score(pattern, text, pattern_len)?;
+    Ok(score <= pattern_len / MATCH_THRESHOLD_DIVISOR)
 }
 
 /// Compute fuzzy scores for a batch of candidate strings.
@@ -101,8 +121,13 @@ pub fn fuzzy_match(pattern: &str, pattern_len: usize, text: &str) -> bool {
 /// `pattern_len` should be the length of `pattern` in UTF-8 code points,
 /// pre-computed by the caller to avoid redundant work when scoring multiple
 /// candidates.  The function simply maps [`fuzzy_score`] over the supplied
-/// candidates.
-pub fn fuzzy_scores(pattern: &str, pattern_len: usize, candidates: &[String]) -> Vec<usize> {
+/// candidates and aggregates the results.  If any candidate fails validation,
+/// the first error is returned immediately.
+pub fn fuzzy_scores(
+    pattern: &str,
+    pattern_len: usize,
+    candidates: &[String],
+) -> Result<Vec<usize>, FuzzyError> {
     candidates
         .iter()
         .map(|c| fuzzy_score(pattern, c, pattern_len))
@@ -120,8 +145,8 @@ mod tests {
     fn distance_basic() {
         let pattern = "abc";
         let pattern_len = pattern.chars().count();
-        assert_eq!(fuzzy_score(pattern, "a-b-c", pattern_len), 2);
-        assert_eq!(fuzzy_score(pattern, "abc", pattern_len), 0);
+        assert_eq!(fuzzy_score(pattern, "a-b-c", pattern_len).unwrap(), 2);
+        assert_eq!(fuzzy_score(pattern, "abc", pattern_len).unwrap(), 0);
     }
 
     /// Ensure the match threshold uses the pre-computed pattern length.
@@ -129,8 +154,8 @@ mod tests {
     fn match_threshold() {
         let pattern = "abc";
         let pattern_len = pattern.chars().count();
-        assert!(fuzzy_match(pattern, pattern_len, "ac"));
-        assert!(!fuzzy_match(pattern, pattern_len, "xyz"));
+        assert!(fuzzy_match(pattern, pattern_len, "ac").unwrap());
+        assert!(!fuzzy_match(pattern, pattern_len, "xyz").unwrap());
     }
 
     /// Confirm batch scoring reuses the cached pattern length.
@@ -140,7 +165,7 @@ mod tests {
         let pattern_len = pattern.chars().count();
         let mut candidates: Vec<String> = (1..100).map(|i| format!("abc{0}", i)).collect();
         candidates.insert(0, String::from("abc"));
-        let scores = fuzzy_scores(pattern, pattern_len, &candidates);
+        let scores = fuzzy_scores(pattern, pattern_len, &candidates).unwrap();
         assert_eq!(scores[0], 0);
         assert_eq!(scores.len(), 100);
     }
@@ -150,8 +175,8 @@ mod tests {
     fn empty_strings() {
         let pattern = "";
         let pattern_len = pattern.chars().count();
-        assert_eq!(fuzzy_score(pattern, "", pattern_len), 0);
-        assert_eq!(fuzzy_score(pattern, "test", pattern_len), 4);
+        assert_eq!(fuzzy_score(pattern, "", pattern_len).unwrap(), 0);
+        assert_eq!(fuzzy_score(pattern, "test", pattern_len).unwrap(), 4);
     }
 
     /// Unicode characters must be handled as full code points rather than bytes.
@@ -159,16 +184,26 @@ mod tests {
     fn unicode_handling() {
         let pattern = "naïve"; // contains an umlaut
         let pattern_len = pattern.chars().count();
-        assert_eq!(fuzzy_score(pattern, "naive", pattern_len), 1);
+        assert_eq!(fuzzy_score(pattern, "naive", pattern_len).unwrap(), 1);
     }
 
-    /// Inputs exceeding the configured limit should trigger a panic.
+    /// Inputs exceeding the configured limit should return an error rather than panic.
     #[test]
-    #[should_panic]
-    fn long_input_panics() {
+    fn long_input_error() {
         let pattern = "a".repeat(MAX_INPUT_LENGTH + 1);
         let pattern_len = pattern.chars().count();
-        let _ = fuzzy_score(&pattern, "", pattern_len);
+        let err = fuzzy_score(&pattern, "", pattern_len).unwrap_err();
+        assert_eq!(err, FuzzyError::InputTooLong);
+    }
+
+    /// Inputs with overly long text should also return an error.
+    #[test]
+    fn long_text_error() {
+        let text = "a".repeat(MAX_INPUT_LENGTH + 1);
+        let pattern = "a";
+        let pattern_len = pattern.chars().count();
+        let err = fuzzy_score(pattern, &text, pattern_len).unwrap_err();
+        assert_eq!(err, FuzzyError::InputTooLong);
     }
 
     /// Very long but permitted inputs should still compute a score.
@@ -176,15 +211,45 @@ mod tests {
     fn long_input_valid() {
         let pattern = "a".repeat(MAX_INPUT_LENGTH);
         let pattern_len = pattern.chars().count();
-        assert_eq!(fuzzy_score(&pattern, &pattern, pattern_len), 0);
+        assert_eq!(fuzzy_score(&pattern, &pattern, pattern_len).unwrap(), 0);
     }
 
     /// `fuzzy_match` must reject patterns that exceed the length limit.
     #[test]
-    #[should_panic]
-    fn fuzzy_match_panics_on_long_pattern() {
+    fn fuzzy_match_long_pattern_error() {
         let pattern = "a".repeat(MAX_INPUT_LENGTH + 1);
         let pattern_len = pattern.chars().count();
-        let _ = fuzzy_match(&pattern, pattern_len, "");
+        let err = fuzzy_match(&pattern, pattern_len, "").unwrap_err();
+        assert_eq!(err, FuzzyError::InputTooLong);
+    }
+
+    /// Supplying an incorrect pre-computed length should yield an error.
+    #[test]
+    fn invalid_length_error() {
+        let pattern = "abc";
+        let pattern_len = pattern.chars().count() + 1;
+        let err = fuzzy_score(pattern, "abc", pattern_len).unwrap_err();
+        assert_eq!(err, FuzzyError::InvalidLength);
+    }
+
+    /// `fuzzy_match` should propagate length mismatches from `fuzzy_score`.
+    #[test]
+    fn fuzzy_match_invalid_length_error() {
+        let pattern = "abc";
+        let pattern_len = pattern.chars().count() + 1;
+        let err = fuzzy_match(pattern, pattern_len, "abc").unwrap_err();
+        assert_eq!(err, FuzzyError::InvalidLength);
+    }
+
+    /// `fuzzy_scores` must return the first error encountered.
+    #[test]
+    fn fuzzy_scores_error_propagation() {
+        let pattern = "abc";
+        let pattern_len = pattern.chars().count();
+        // Include an invalid candidate exceeding the maximum length.
+        let mut candidates: Vec<String> = vec!["a".repeat(MAX_INPUT_LENGTH + 1)];
+        candidates.push(String::from("abc"));
+        let err = fuzzy_scores(pattern, pattern_len, &candidates).unwrap_err();
+        assert_eq!(err, FuzzyError::InputTooLong);
     }
 }

--- a/src/num.rs
+++ b/src/num.rs
@@ -458,9 +458,10 @@ impl From<Vec<Complex32>> for ComplexVec {
 
 impl From<ComplexVec> for Vec<Complex32> {
     fn from(cv: ComplexVec) -> Self {
-        cv.re
-            .into_iter()
-            .zip(cv.im.into_iter())
+        // Destructure to move the internal vectors without redundant `into_iter` calls.
+        let ComplexVec { re, im } = cv;
+        re.into_iter()
+            .zip(im)
             .map(|(r, i)| Complex32::new(r, i))
             .collect()
     }

--- a/src/stft.rs
+++ b/src/stft.rs
@@ -66,8 +66,6 @@ compile_error!("stft requires `wasm` and `simd` features to be enabled");
 extern crate alloc;
 #[cfg(all(feature = "parallel", feature = "std"))]
 use crate::fft::rayon_pool;
-#[cfg(test)]
-use crate::fft::FftStrategy;
 use crate::fft::{Complex32, FftError, FftImpl};
 use alloc::vec;
 #[cfg(feature = "parallel")]

--- a/src/wavelet.rs
+++ b/src/wavelet.rs
@@ -9,9 +9,11 @@ use alloc::vec;
 use alloc::vec::Vec;
 
 /// Convenience alias for a two-dimensional `Vec`.
+#[allow(dead_code)] // Retained for future expansion and documentation.
 type Vec2<T> = Vec<Vec<T>>;
 
 /// Convenience alias for a three-dimensional `Vec`.
+#[allow(dead_code)] // Retained for future expansion and documentation.
 type Vec3<T> = Vec<Vec<Vec<T>>>;
 use core::fmt;
 
@@ -24,6 +26,7 @@ pub const HAAR_SCALE: f32 = 0.5;
 pub type BatchOutput = (Vec<Vec<f32>>, Vec<Vec<f32>>);
 /// Output of [`multi_level_forward_batch`]: per-input averages and per-level
 /// detail coefficients.
+#[allow(dead_code)] // Currently unused but documented for potential future APIs.
 pub type MultiLevelBatchOutput = (Vec<Vec<f32>>, Vec<Vec<Vec<f32>>>);
 /// Daubechies-4 low-pass decomposition filter coefficients.
 /// Each value represents a tap of the scaling filter used during the forward transform.
@@ -89,10 +92,10 @@ pub const DB2_ANALYSIS_LOW: [f32; 4] = [
 /// Daubechies-2 (db2) high-pass analysis filter coefficients.
 /// These coefficients are used during the forward transform to compute detail components.
 pub const DB2_ANALYSIS_HIGH: [f32; 4] = [
-    0.019787513117910776,  // g0: first detail coefficient
-    0.4463951772316719,    // g1: second detail coefficient
-    -0.5054728575456481,   // g2: third detail coefficient
-    0.16290171400361862,   // g3: fourth detail coefficient
+    0.019787513117910776, // g0: first detail coefficient
+    0.4463951772316719,   // g1: second detail coefficient
+    -0.5054728575456481,  // g2: third detail coefficient
+    0.16290171400361862,  // g3: fourth detail coefficient
 ];
 
 /// Daubechies-2 (db2) low-pass synthesis filter coefficients.
@@ -107,10 +110,10 @@ pub const DB2_SYNTHESIS_LOW: [f32; 4] = [
 /// Daubechies-2 (db2) high-pass synthesis filter coefficients.
 /// These coefficients are used during the inverse transform to reconstruct detail components.
 pub const DB2_SYNTHESIS_HIGH: [f32; 4] = [
-    0.019787513117910776,  // g0: first reconstruction detail coefficient
-    0.4463951772316719,    // g1: second reconstruction detail coefficient
-    -0.5054728575456481,   // g2: third reconstruction detail coefficient
-    0.16290171400361862,   // g3: fourth reconstruction detail coefficient
+    0.019787513117910776, // g0: first reconstruction detail coefficient
+    0.4463951772316719,   // g1: second reconstruction detail coefficient
+    -0.5054728575456481,  // g2: third reconstruction detail coefficient
+    0.16290171400361862,  // g3: fourth reconstruction detail coefficient
 ];
 
 /// Errors produced by wavelet operations.
@@ -144,10 +147,12 @@ impl std::error::Error for WaveletError {}
 
 /// Output of a batch forward transform: averages and detail coefficients for
 /// each input signal.
+#[allow(dead_code)] // Alias kept for symmetry with `MultiLevelForwardOutput`.
 type BatchForwardOutput = (Vec<Vec<f32>>, Vec<Vec<f32>>);
 
 /// Output of a batch multi-level forward transform: final approximations and
 /// per-level detail coefficients for each input signal.
+#[allow(dead_code)] // Alias kept for potential reuse in API revisions.
 type MultiLevelForwardOutput = (Vec<Vec<f32>>, Vec<Vec<Vec<f32>>>);
 
 /// Forward Haar wavelet transform (single level)
@@ -193,7 +198,7 @@ pub fn haar_inverse(avg: &[f32], diff: &[f32]) -> Result<Vec<f32>, WaveletError>
 /// # Errors
 /// Propagates any error returned by [`haar_forward`].
 pub fn batch_forward(inputs: &[Vec<f32>]) -> Result<BatchOutput, WaveletError> {
-#[allow(clippy::type_complexity)]
+    #[allow(clippy::type_complexity)]
     let mut avgs = Vec::with_capacity(inputs.len());
     let mut diffs = Vec::with_capacity(inputs.len());
     for input in inputs {

--- a/tests/fuzzy_alloc.rs
+++ b/tests/fuzzy_alloc.rs
@@ -31,10 +31,11 @@ static A: CountingAlloc = CountingAlloc;
 fn fuzzy_match_allocations() {
     let pattern = "abc";
     ALLOC_COUNT.store(0, Ordering::SeqCst);
-    let len = pattern.len();
-    fuzzy_score(pattern, pattern, len);
+    let len = pattern.chars().count();
+    fuzzy_score(pattern, pattern, len).unwrap();
     let score_allocs = ALLOC_COUNT.load(Ordering::SeqCst);
-    fuzzy_match(pattern, len, pattern);
+    ALLOC_COUNT.store(0, Ordering::SeqCst);
+    fuzzy_match(pattern, len, pattern).unwrap();
     let match_allocs = ALLOC_COUNT.load(Ordering::SeqCst);
 
     assert_eq!(

--- a/tests/fuzzy_match.rs
+++ b/tests/fuzzy_match.rs
@@ -5,8 +5,8 @@ use kofft::fuzzy::{fuzzy_match, fuzzy_score};
 fn close_match_succeeds() {
     let pattern = "kitten";
     let pattern_len = pattern.chars().count();
-    assert!(fuzzy_match(pattern, pattern_len, "kittin")); // distance 1
-    assert_eq!(fuzzy_score(pattern, "kittin", pattern_len), 1);
+    assert!(fuzzy_match(pattern, pattern_len, "kittin").unwrap()); // distance 1
+    assert_eq!(fuzzy_score(pattern, "kittin", pattern_len).unwrap(), 1);
 }
 
 /// Candidates beyond the threshold must be rejected.
@@ -14,8 +14,8 @@ fn close_match_succeeds() {
 fn distant_match_fails() {
     let pattern = "kitten";
     let pattern_len = pattern.chars().count();
-    assert!(!fuzzy_match(pattern, pattern_len, "puppy"));
-    assert!(fuzzy_score(pattern, "puppy", pattern_len) > pattern_len / 2);
+    assert!(!fuzzy_match(pattern, pattern_len, "puppy").unwrap());
+    assert!(fuzzy_score(pattern, "puppy", pattern_len).unwrap() > pattern_len / 2);
 }
 
 /// Non-ASCII characters should be handled as full code points.
@@ -23,6 +23,6 @@ fn distant_match_fails() {
 fn unicode_strings() {
     let pattern = "naïve";
     let pattern_len = pattern.chars().count();
-    assert!(fuzzy_match(pattern, pattern_len, "naive"));
-    assert_eq!(fuzzy_score(pattern, "naive", pattern_len), 1);
+    assert!(fuzzy_match(pattern, pattern_len, "naive").unwrap());
+    assert_eq!(fuzzy_score(pattern, "naive", pattern_len).unwrap(), 1);
 }

--- a/tests/num.rs
+++ b/tests/num.rs
@@ -1,5 +1,5 @@
 use kofft::num::{
-    copy_from_complex, copy_to_complex, Complex, Complex32, Complex64, ComplexVec, SplitComplex,
+    copy_from_complex, copy_to_complex, Complex32, Complex64, ComplexVec, SplitComplex,
 };
 
 /// Acceptable tolerance for floating-point comparisons in tests.

--- a/tests/resample.rs
+++ b/tests/resample.rs
@@ -6,8 +6,7 @@ use std::time::Instant;
 /// This intentionally slow implementation helps verify that the linear
 /// interpolator performs at least as well in terms of error while providing a
 /// simple reference for boundary behaviour.
-
-
+///
 /// Source rate used for extreme upsampling tests.
 const EXTREME_LOW_RATE: f32 = 1.0;
 /// Destination rate used for extreme upsampling tests.


### PR DESCRIPTION
## Summary
- add `FuzzyError` for invalid length and overlong inputs
- return `Result` from fuzzy matching APIs instead of panicking
- expand tests for fuzzy failure cases and fix minor clippy lints

## Testing
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --features "parallel waveform-cache"` *(fails: complex_mul_large_magnitude)*


------
https://chatgpt.com/codex/tasks/task_e_68a7880c1c24832ba3f955d285e5689a