### PR TITLE
refactor: harden playback engine abort and state

### DIFF
--- a/web/apps/mfe-spectrogram/src/shared/utils/__tests__/PlaybackEngine.test.ts
+++ b/web/apps/mfe-spectrogram/src/shared/utils/__tests__/PlaybackEngine.test.ts
@@ -287,7 +287,12 @@ describe("PlaybackEngine", () => {
     } as any;
     const fastTrack2 = {
       file: { arrayBuffer: async () => new ArrayBuffer(8) },
-    } as any;
+  const fastTrack1 = {
+    file: { arrayBuffer: async () => new ArrayBuffer(8) },
+  } as any;
+  const fastTrack2 = {
+    file: { arrayBuffer: async () => new ArrayBuffer(8) },
+  } as any;
 
     const p1 = playbackEngine.load(slowTrack).catch((e) => e);
     const p2 = playbackEngine.load(fastTrack1).catch((e) => e);

--- a/web/apps/mfe-spectrogram/src/shared/utils/__tests__/PlaybackEngine.test.ts
+++ b/web/apps/mfe-spectrogram/src/shared/utils/__tests__/PlaybackEngine.test.ts
@@ -270,7 +270,7 @@ describe("PlaybackEngine", () => {
 
   // Rapid consecutive load calls should abort previous operations and only
   // resolve the last one.
-    it("handles rapid successive load calls", async () => {
+    it("handles rapid consecutive load calls", async () => {
       // Delay long enough to ensure the first load is still pending when the
       // subsequent ones start.
       const LONG_DELAY_MS = 50;

--- a/web/apps/mfe-spectrogram/src/shared/utils/__tests__/PlaybackEngine.test.ts
+++ b/web/apps/mfe-spectrogram/src/shared/utils/__tests__/PlaybackEngine.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { playbackEngine } from "../PlaybackEngine";
 import { useAudioStore } from "@/shared/stores/audioStore";
+import { TIME_UPDATE_INTERVAL_MS } from "../timeUpdater";
 
 declare global {
   interface Window {
@@ -30,6 +31,9 @@ class MockAudioContext {
   }
   createBufferSource() {
     return new MockSource() as any;
+  }
+  createMediaStreamSource(_stream: MediaStream) {
+    return { connect: vi.fn(), disconnect: vi.fn() } as any;
   }
   resume = vi.fn().mockResolvedValue(undefined);
   close = vi.fn().mockResolvedValue(undefined);
@@ -78,11 +82,14 @@ describe("PlaybackEngine", () => {
   });
 
   it("cancels pending decode when loading a new track", async () => {
+    // Delay long enough to ensure the load is still pending when a subsequent
+    // load is triggered.
+    const LONG_DELAY_MS = 50;
     const slowTrack = {
       file: {
         arrayBuffer: () =>
           new Promise<ArrayBuffer>((resolve) =>
-            setTimeout(() => resolve(new ArrayBuffer(8)), 50),
+            setTimeout(() => resolve(new ArrayBuffer(8)), LONG_DELAY_MS),
           ),
       },
     } as any;
@@ -123,6 +130,8 @@ describe("PlaybackEngine", () => {
     expect(playSpy).toHaveBeenCalledWith(1);
   });
 
+  // When no additional tracks exist the engine should stop and update the store
+  // exactly once to avoid intermediate inconsistent states.
   it("stops when there is no next track", () => {
     const track1 = {
       id: "1",
@@ -137,16 +146,20 @@ describe("PlaybackEngine", () => {
     });
 
     const playSpy = vi.spyOn(useAudioStore.getState(), "playTrack");
-    const setPlayingSpy = vi.spyOn(useAudioStore.getState(), "setPlaying");
-    const setPausedSpy = vi.spyOn(useAudioStore.getState(), "setPaused");
-    const setStoppedSpy = vi.spyOn(useAudioStore.getState(), "setStopped");
+    let updates = 0;
+    const unsub = useAudioStore.subscribe(() => {
+      updates++;
+    });
 
     (playbackEngine as any).handleEnded();
 
+    const state = useAudioStore.getState();
     expect(playSpy).not.toHaveBeenCalled();
-    expect(setPlayingSpy).toHaveBeenCalledWith(false);
-    expect(setPausedSpy).toHaveBeenCalledWith(false);
-    expect(setStoppedSpy).toHaveBeenCalledWith(true);
+    expect(state.isPlaying).toBe(false);
+    expect(state.isPaused).toBe(false);
+    expect(state.isStopped).toBe(true);
+    expect(updates).toBe(1);
+    unsub();
   });
 
   it('repeats the same track when loopMode is "one"', () => {
@@ -223,6 +236,8 @@ describe("PlaybackEngine", () => {
     (Math.random as any).mockRestore();
   });
 
+  // When shuffle is enabled with a single track the engine should stop and
+  // update the store only once.
   it("stops when shuffle is enabled but only one track exists", () => {
     const track1 = {
       id: "1",
@@ -237,15 +252,108 @@ describe("PlaybackEngine", () => {
     });
 
     const playSpy = vi.spyOn(useAudioStore.getState(), "playTrack");
-    const setPlayingSpy = vi.spyOn(useAudioStore.getState(), "setPlaying");
-    const setPausedSpy = vi.spyOn(useAudioStore.getState(), "setPaused");
-    const setStoppedSpy = vi.spyOn(useAudioStore.getState(), "setStopped");
+    let updates = 0;
+    const unsub = useAudioStore.subscribe(() => {
+      updates++;
+    });
 
     (playbackEngine as any).handleEnded();
 
+    const state = useAudioStore.getState();
     expect(playSpy).not.toHaveBeenCalled();
-    expect(setPlayingSpy).toHaveBeenCalledWith(false);
-    expect(setPausedSpy).toHaveBeenCalledWith(false);
-    expect(setStoppedSpy).toHaveBeenCalledWith(true);
+    expect(state.isPlaying).toBe(false);
+    expect(state.isPaused).toBe(false);
+    expect(state.isStopped).toBe(true);
+    expect(updates).toBe(1);
+    unsub();
+  });
+
+  // Rapid consecutive load calls should abort previous operations and only
+  // resolve the last one.
+    it("handles rapid successive load calls", async () => {
+      // Delay long enough to ensure the first load is still pending when the
+      // subsequent ones start.
+      const LONG_DELAY_MS = 50;
+      const slowTrack = {
+        file: {
+          arrayBuffer: () =>
+            new Promise<ArrayBuffer>((resolve) =>
+              setTimeout(() => resolve(new ArrayBuffer(8)), LONG_DELAY_MS),
+            ),
+        },
+      } as any;
+    const fastTrack1 = {
+      file: { arrayBuffer: async () => new ArrayBuffer(8) },
+    } as any;
+    const fastTrack2 = {
+      file: { arrayBuffer: async () => new ArrayBuffer(8) },
+    } as any;
+
+    const p1 = playbackEngine.load(slowTrack).catch((e) => e);
+    const p2 = playbackEngine.load(fastTrack1).catch((e) => e);
+    await playbackEngine.load(fastTrack2);
+
+    const r1 = await p1;
+    const r2 = await p2;
+    expect(r1).toBeInstanceOf(DOMException);
+    expect(r1.name).toBe("AbortError");
+    expect(r2).toBeInstanceOf(DOMException);
+    expect(r2.name).toBe("AbortError");
+    expect(playbackEngine.getDuration()).toBe(2);
+  });
+
+  // Microphone streams should connect and disconnect cleanly.
+  it("activates and deactivates microphone", async () => {
+    const stream = {} as any;
+    await playbackEngine.startMicrophone(stream);
+    const mic = (playbackEngine as any).micSource;
+    expect(mic.connect).toHaveBeenCalled();
+    const disconnectSpy = vi.spyOn(mic, "disconnect");
+    playbackEngine.stopMicrophone();
+    expect(disconnectSpy).toHaveBeenCalled();
+  });
+
+  // If the audio context is suspended the engine should resume it before use.
+  it("resumes suspended audio context", async () => {
+    (MockAudioContext as any).prototype.state = "suspended";
+    const ctx = await playbackEngine.initializeAudioContext();
+    expect(ctx.resume).toHaveBeenCalled();
+    (MockAudioContext as any).prototype.state = "running";
+  });
+
+  // The time updater should dispatch updates at the configured interval.
+  it("emits time updates at fixed interval", async () => {
+    vi.useFakeTimers();
+    vi.stubGlobal("requestAnimationFrame", (cb: FrameRequestCallback) =>
+      setTimeout(() => cb(performance.now()), 0),
+    );
+    vi.stubGlobal("cancelAnimationFrame", vi.fn());
+
+    const track = { file: { arrayBuffer: async () => new ArrayBuffer(8) } } as any;
+    await playbackEngine.load(track);
+    const cb = vi.fn();
+    const unsub = playbackEngine.subscribe(cb);
+    playbackEngine.play();
+
+    cb.mockReset();
+    vi.advanceTimersByTime(TIME_UPDATE_INTERVAL_MS * 3 + 5);
+    expect(cb).toHaveBeenCalledTimes(3);
+    unsub();
+    vi.useRealTimers();
+    vi.unstubAllGlobals();
+  });
+
+  // abortable should resolve once and remove attached listeners.
+  it("cleans up abort listeners", async () => {
+    const controller = new AbortController();
+    const addSpy = vi.spyOn(controller.signal, "addEventListener");
+    const removeSpy = vi.spyOn(controller.signal, "removeEventListener");
+
+    const p = (playbackEngine as any).abortable(Promise.resolve(1), controller);
+    await p;
+    controller.abort();
+
+    expect(addSpy).toHaveBeenCalledWith("abort", expect.any(Function));
+    expect(removeSpy).toHaveBeenCalledWith("abort", expect.any(Function));
   });
 });


### PR DESCRIPTION
## Summary
- ensure abortable helper resolves or rejects once, removing listeners to avoid leaks
- update handleEnded to mutate useAudioStore atomically and document playback engine internals
- add regression tests for rapid track loading, microphone activation, context resume, and time-updater scheduling

## Testing
- `npm test` *(fails: requestAnimationFrame is not defined; Playwright configuration issues)*
- `npm run lint` *(fails: Missing script: "lint")*

------
https://chatgpt.com/codex/tasks/task_e_68a7888363f4832bb16df4712e6d4d8a