### PR TITLE
feat(shell): generate shared animation duration

### DIFF
--- a/web/apps/shell/package.json
+++ b/web/apps/shell/package.json
@@ -5,8 +5,10 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
-    "build": "vite build",
+    "generate:css": "node ./scripts/build-anim-durations.mjs",
+    "build": "npm run generate:css && vite build",
     "preview": "vite preview --port 5173",
+    "pretest": "npm run generate:css",
     "test": "vitest run --coverage"
   },
   "dependencies": {

--- a/web/apps/shell/scripts/build-anim-durations.mjs
+++ b/web/apps/shell/scripts/build-anim-durations.mjs
@@ -1,0 +1,46 @@
+import { readFile, writeFile } from "fs/promises";
+import { fileURLToPath } from "url";
+import { dirname, resolve } from "path";
+
+/** Path to the TypeScript source defining animation duration constants. */
+const tsPath = resolve(
+  dirname(fileURLToPath(import.meta.url)),
+  "../src/ui/AnimationDurations.ts",
+);
+/** Destination path for the generated CSS variables file. */
+const cssPath = resolve(
+  dirname(fileURLToPath(import.meta.url)),
+  "../src/ui/animation-durations.css",
+);
+
+/**
+ * Generate a CSS file exposing theme animation variables from TypeScript
+ * constants. Reading the source file rather than duplicating values keeps
+ * styles and logic in lockstep.
+ */
+async function main() {
+  const src = await readFile(tsPath, "utf8");
+  const match = src.match(/THEME_ANIMATION_MS\s*=\s*(\d+)/);
+  if (!match) {
+    throw new Error(
+      "Failed to extract THEME_ANIMATION_MS from AnimationDurations.ts",
+    );
+  }
+  const ms = Number(match[1]);
+  if (!Number.isFinite(ms)) {
+    throw new Error("Parsed THEME_ANIMATION_MS is not a finite number");
+  }
+  const css = [
+    "/* Auto-generated from AnimationDurations.ts. Do not edit manually. */",
+    ":root {",
+    `  --anim-duration: ${ms}ms;`,
+    "}",
+    "",
+  ].join("\n");
+  await writeFile(cssPath, css);
+}
+
+main().catch((err) => {
+  console.error("Failed to build animation duration CSS", err);
+  process.exitCode = 1;
+});

--- a/web/apps/shell/src/DesignContext.test.tsx
+++ b/web/apps/shell/src/DesignContext.test.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect } from "react";
 import { describe, it, expect } from "vitest";
 import { render, waitFor } from "@testing-library/react";
-import { DesignProvider, useDesign } from "./DesignContext";
+import { DesignProvider, useDesign, applyPalette } from "./DesignContext";
 import { PALETTES, Design, Mode } from "./designs";
 
 /**
@@ -88,5 +88,12 @@ describe("DesignProvider", () => {
       expect(styles.getPropertyValue(VAR_SECONDARY)).toBe("");
       expect(styles.getPropertyValue(VAR_TERTIARY)).toBe("");
     });
+  });
+
+  it("throws on invalid palette", () => {
+    expect(() => applyPalette(undefined as unknown as any)).toThrow(
+      /valid palette/,
+    );
+    expect(() => applyPalette({} as any)).toThrow(/valid palette/);
   });
 });

--- a/web/apps/shell/src/DesignContext.tsx
+++ b/web/apps/shell/src/DesignContext.tsx
@@ -42,8 +42,7 @@ const VAR_TERTIARY = "--color-tertiary" as const;
  * absent. Explicit removal prevents stale values from previous designs from
  * leaking into the current theme.
  */
-function applyPalette(palette: Palette): void {
-  if (!palette)
+export function applyPalette(palette: Palette): void {
   if (
     !palette ||
     typeof palette !== "object" ||
@@ -51,7 +50,9 @@ function applyPalette(palette: Palette): void {
     !("text" in palette) ||
     !("accent" in palette)
   ) {
-    throw new Error("applyPalette requires a valid palette with background, text, and accent properties");
+    throw new Error(
+      "applyPalette requires a valid palette with background, text, and accent properties",
+    );
   }
   const root = document.documentElement;
   root.style.setProperty(VAR_BG, palette.background);

--- a/web/apps/shell/src/main.tsx
+++ b/web/apps/shell/src/main.tsx
@@ -3,6 +3,7 @@ import ReactDOM from "react-dom/client";
 import { DesignProvider } from "./DesignContext";
 import { DesignToggle } from "./DesignToggle";
 import { DesignLayout } from "./DesignLayout";
+import "./ui/animation-durations.css"; // sets --anim-duration
 
 /** Text displayed in the header for all themes. */
 const HEADER_TEXT = "Kofft" as const;

--- a/web/apps/shell/src/themes/bauhaus.css
+++ b/web/apps/shell/src/themes/bauhaus.css
@@ -6,25 +6,24 @@
 */
 
 /* Common Bauhaus properties applied regardless of mode. */
-:root[data-design='bauhaus'] {
-  --anim-duration: 300ms;
-  font-family: 'Futura', sans-serif;
+:root[data-design="bauhaus"] {
+  font-family: "Futura", sans-serif;
   text-transform: none;
 }
 
 /* Light mode styles for Bauhaus design. */
-:root[data-design='bauhaus'][data-mode='light'] {
+:root[data-design="bauhaus"][data-mode="light"] {
   background-color: var(--color-bg);
   color: var(--color-text);
 }
 
 /* Dark mode styles for Bauhaus design. */
-:root[data-design='bauhaus'][data-mode='dark'] {
+:root[data-design="bauhaus"][data-mode="dark"] {
   background-color: var(--color-bg);
   color: var(--color-text);
 }
 
 /* Transition behaviour emphasising motion. */
-:root[data-design='bauhaus'] * {
+:root[data-design="bauhaus"] * {
   transition: transform var(--anim-duration) ease-in-out;
 }

--- a/web/apps/shell/src/themes/japanese.css
+++ b/web/apps/shell/src/themes/japanese.css
@@ -6,29 +6,29 @@
 */
 
 /* Common properties for Japanese designs. */
-:root[data-design='japanese-a'],
-:root[data-design='japanese-b'] {
-  --anim-duration: 300ms;
-  font-family: 'Noto Sans', sans-serif;
+:root[data-design="japanese-a"],
+:root[data-design="japanese-b"] {
+  font-family: "Noto Sans", sans-serif;
 }
 
 /* Light mode styles for Japanese designs. */
-:root[data-design='japanese-a'][data-mode='light'],
-:root[data-design='japanese-b'][data-mode='light'] {
+:root[data-design="japanese-a"][data-mode="light"],
+:root[data-design="japanese-b"][data-mode="light"] {
   background-color: var(--color-bg);
   color: var(--color-text);
 }
 
 /* Dark mode styles for Japanese designs. */
-:root[data-design='japanese-a'][data-mode='dark'],
-:root[data-design='japanese-b'][data-mode='dark'] {
+:root[data-design="japanese-a"][data-mode="dark"],
+:root[data-design="japanese-b"][data-mode="dark"] {
   background-color: var(--color-bg);
   color: var(--color-text);
 }
 
 /* Transition behaviour for minimalist Japanese designs. */
-:root[data-design='japanese-a'] *,
-:root[data-design='japanese-b'] * {
-  transition: background-color var(--anim-duration) ease-in-out,
+:root[data-design="japanese-a"] *,
+:root[data-design="japanese-b"] * {
+  transition:
+    background-color var(--anim-duration) ease-in-out,
     color var(--anim-duration) ease-in-out;
 }

--- a/web/apps/shell/src/ui/AnimationDurations.test.ts
+++ b/web/apps/shell/src/ui/AnimationDurations.test.ts
@@ -1,5 +1,9 @@
 import { describe, it, expect } from "vitest";
-import { FADE_DURATION_MS, SLIDE_DURATION_MS } from "./AnimationDurations";
+import {
+  FADE_DURATION_MS,
+  SLIDE_DURATION_MS,
+  THEME_ANIMATION_MS,
+} from "./AnimationDurations";
 
 /** Ensure animation duration constants remain stable for predictable motion. */
 describe("Animation duration constants", () => {
@@ -9,5 +13,9 @@ describe("Animation duration constants", () => {
 
   it("exposes the slide duration", () => {
     expect(SLIDE_DURATION_MS).toBe(250);
+  });
+
+  it("exposes the theme transition duration", () => {
+    expect(THEME_ANIMATION_MS).toBe(300);
   });
 });

--- a/web/apps/shell/src/ui/AnimationDurations.ts
+++ b/web/apps/shell/src/ui/AnimationDurations.ts
@@ -9,3 +9,10 @@ export const FADE_DURATION_MS = 200 as const;
 
 /** Slide transition duration in milliseconds balancing speed and clarity. */
 export const SLIDE_DURATION_MS = 250 as const;
+
+/**
+ * Base animation duration in milliseconds used by global theme transitions.
+ * Centralising this value prevents magic numbers in CSS and keeps JavaScript
+ * timing in sync with stylesheets.
+ */
+export const THEME_ANIMATION_MS = 300 as const;

--- a/web/apps/shell/src/ui/AnimationDurationsCss.test.ts
+++ b/web/apps/shell/src/ui/AnimationDurationsCss.test.ts
@@ -1,0 +1,23 @@
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "fs";
+import { fileURLToPath } from "url";
+import { dirname, resolve } from "path";
+import { THEME_ANIMATION_MS } from "./AnimationDurations";
+
+/** Resolve path to the generated CSS file relative to this test. */
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+/**
+ * Ensure the CSS variable for animation duration remains in sync with the
+ * TypeScript constant to avoid divergence between JS and styles.
+ */
+describe("animation duration CSS variable", () => {
+  it("matches THEME_ANIMATION_MS", () => {
+    const cssPath = resolve(__dirname, "./animation-durations.css");
+    const css = readFileSync(cssPath, "utf8");
+    const match = css.match(/--anim-duration:\s*(\d+)ms/);
+    if (!match) throw new Error("--anim-duration not found in CSS");
+    expect(Number(match[1])).toBe(THEME_ANIMATION_MS);
+  });
+});

--- a/web/apps/shell/src/ui/animation-durations.css
+++ b/web/apps/shell/src/ui/animation-durations.css
@@ -1,0 +1,4 @@
+/* Auto-generated from AnimationDurations.ts. Do not edit manually. */
+:root {
+  --anim-duration: 300ms;
+}


### PR DESCRIPTION
## Summary
- centralize animation durations via THEME_ANIMATION_MS and generated CSS variable
- remove hard-coded duration from theme styles and import global variable
- export applyPalette with validation and tests

## Testing
- `npm --prefix web/apps/shell run test`
- `npm test` *(fails: test compile_features failed)*

------
https://chatgpt.com/codex/tasks/task_e_68a7902adce0832b8b8fc7f4ef7ebb11