### PR TITLE
Enforce nonzero window lengths and document normalization

### DIFF
--- a/src/window.rs
+++ b/src/window.rs
@@ -56,12 +56,12 @@ fn bessel0(x: f32) -> f32 {
 }
 
 /// Debug-time validation that the maximum value of a window equals one and all
-/// samples are finite. The check is skipped for empty windows to avoid spurious
-/// failures.
+/// samples are finite.
 fn debug_assert_normalized(window: &[f32]) {
-    if window.is_empty() {
-        return;
-    }
+    debug_assert!(
+        !window.is_empty(),
+        "window length must be at least one for normalization checks"
+    );
     debug_assert!(
         window.iter().all(|v| v.is_finite()),
         "window contains non-finite values"
@@ -76,11 +76,12 @@ fn debug_assert_normalized(window: &[f32]) {
 
 /// Generate a Hann window of length `len`.
 ///
-/// The resulting window has a peak amplitude of one.
+/// The window is amplitude-normalized such that its maximum sample equals one.
+///
+/// # Panics
+/// Panics if `len` is zero.
 pub fn hann(len: usize) -> alloc::vec::Vec<f32> {
-    if len == 0 {
-        return alloc::vec![];
-    }
+    assert!(len > 0, "len must be at least 1");
     if len == 1 {
         return alloc::vec![1.0];
     }
@@ -93,11 +94,12 @@ pub fn hann(len: usize) -> alloc::vec::Vec<f32> {
 
 /// Generate a Hamming window of length `len`.
 ///
-/// The resulting window has a peak amplitude of one.
+/// The window is amplitude-normalized such that its maximum sample equals one.
+///
+/// # Panics
+/// Panics if `len` is zero.
 pub fn hamming(len: usize) -> alloc::vec::Vec<f32> {
-    if len == 0 {
-        return alloc::vec![];
-    }
+    assert!(len > 0, "len must be at least 1");
     if len == 1 {
         return alloc::vec![1.0];
     }
@@ -110,11 +112,12 @@ pub fn hamming(len: usize) -> alloc::vec::Vec<f32> {
 
 /// Generate a Blackman window of length `len`.
 ///
-/// The resulting window has a peak amplitude of one.
+/// The window is amplitude-normalized such that its maximum sample equals one.
+///
+/// # Panics
+/// Panics if `len` is zero.
 pub fn blackman(len: usize) -> alloc::vec::Vec<f32> {
-    if len == 0 {
-        return alloc::vec![];
-    }
+    assert!(len > 0, "len must be at least 1");
     if len == 1 {
         return alloc::vec![1.0];
     }
@@ -130,12 +133,12 @@ pub fn blackman(len: usize) -> alloc::vec::Vec<f32> {
 
 /// Generate a Kaiser window of length `len` and shape parameter `beta`.
 ///
-/// The resulting window has a peak amplitude of one.
+/// The window is amplitude-normalized such that its maximum sample equals one.
 ///
 /// # Panics
 /// Panics if `len` is zero or `beta` is negative.
 pub fn kaiser(len: usize, beta: f32) -> alloc::vec::Vec<f32> {
-    assert!(len > 0, "len must be greater than zero");
+    assert!(len > 0, "len must be at least 1");
     assert!(beta >= 0.0, "beta must be non-negative");
     if len == 1 {
         return alloc::vec![1.0];
@@ -165,11 +168,12 @@ pub fn kaiser(len: usize, beta: f32) -> alloc::vec::Vec<f32> {
 
 /// MCU/stack-only, const-generic, in-place Hann window (no heap).
 ///
-/// The buffer is filled with a unity-normalized Hann window.
+/// The buffer is filled with a unity-amplitude Hann window.
+///
+/// # Panics
+/// Panics if `N` is zero.
 pub fn hann_inplace_stack<const N: usize>(out: &mut [f32; N]) {
-    if N == 0 {
-        return;
-    }
+    assert!(N > 0, "N must be at least 1");
     if N == 1 {
         out[0] = 1.0;
         return;
@@ -182,11 +186,12 @@ pub fn hann_inplace_stack<const N: usize>(out: &mut [f32; N]) {
 
 /// MCU/stack-only, const-generic, in-place Hamming window (no heap).
 ///
-/// The buffer is filled with a unity-normalized Hamming window.
+/// The buffer is filled with a unity-amplitude Hamming window.
+///
+/// # Panics
+/// Panics if `N` is zero.
 pub fn hamming_inplace_stack<const N: usize>(out: &mut [f32; N]) {
-    if N == 0 {
-        return;
-    }
+    assert!(N > 0, "N must be at least 1");
     if N == 1 {
         out[0] = 1.0;
         return;
@@ -199,11 +204,12 @@ pub fn hamming_inplace_stack<const N: usize>(out: &mut [f32; N]) {
 
 /// MCU/stack-only, const-generic, in-place Blackman window (no heap).
 ///
-/// The buffer is filled with a unity-normalized Blackman window.
+/// The buffer is filled with a unity-amplitude Blackman window.
+///
+/// # Panics
+/// Panics if `N` is zero.
 pub fn blackman_inplace_stack<const N: usize>(out: &mut [f32; N]) {
-    if N == 0 {
-        return;
-    }
+    assert!(N > 0, "N must be at least 1");
     if N == 1 {
         out[0] = 1.0;
         return;

--- a/tests/window.rs
+++ b/tests/window.rs
@@ -12,27 +12,56 @@ fn max(slice: &[f32]) -> f32 {
 
 /// Allowed floating-point error when verifying normalization.
 const EPSILON: f32 = 1e-5;
+/// Expected sum factor for the Hann window (`sum = HANN_SUM_FACTOR * len`).
+const HANN_SUM_FACTOR: f32 = 0.5;
+/// Expected sum factor for the Hamming window (`sum = HAMMING_SUM_FACTOR * len`).
+const HAMMING_SUM_FACTOR: f32 = 0.54;
+/// Expected sum factor for the Blackman window (`sum = BLACKMAN_SUM_FACTOR * len`).
+const BLACKMAN_SUM_FACTOR: f32 = 0.42;
 
 /// Validates edge cases and normalization for the Hann window.
 #[test]
+#[should_panic]
+fn hann_len_zero_panics() {
+    hann(0);
+}
+
+/// Validates edge cases, normalization, and sum for the Hann window.
+#[test]
 fn hann_edges_and_large() {
-    assert!(hann(0).is_empty());
     assert_eq!(hann(1), vec![1.0]);
     let w = hann(1024);
     assert!((max(&w) - 1.0).abs() < EPSILON);
+    let expected_sum = HANN_SUM_FACTOR * 1024.0;
+    assert!((w.iter().sum::<f32>() - expected_sum).abs() < EPSILON);
 
     let mut buf = [0.0f32; 1];
     hann_inplace_stack(&mut buf);
     assert_eq!(buf, [1.0]);
 }
 
+/// Ensures extreme lengths fail fast without undefined behavior.
+#[test]
+#[should_panic]
+fn hann_large_len_panics() {
+    hann(usize::MAX);
+}
+
 /// Validates edge cases and normalization for the Hamming window.
 #[test]
+#[should_panic]
+fn hamming_len_zero_panics() {
+    hamming(0);
+}
+
+/// Validates edge cases, normalization, and sum for the Hamming window.
+#[test]
 fn hamming_edges_and_large() {
-    assert!(hamming(0).is_empty());
     assert_eq!(hamming(1), vec![1.0]);
     let w = hamming(1024);
     assert!((max(&w) - 1.0).abs() < EPSILON);
+    let expected_sum = HAMMING_SUM_FACTOR * 1024.0;
+    assert!((w.iter().sum::<f32>() - expected_sum).abs() < EPSILON);
 
     let mut buf = [0.0f32; 1];
     hamming_inplace_stack(&mut buf);
@@ -41,11 +70,19 @@ fn hamming_edges_and_large() {
 
 /// Validates edge cases and normalization for the Blackman window.
 #[test]
+#[should_panic]
+fn blackman_len_zero_panics() {
+    blackman(0);
+}
+
+/// Validates edge cases, normalization, and sum for the Blackman window.
+#[test]
 fn blackman_edges_and_large() {
-    assert!(blackman(0).is_empty());
     assert_eq!(blackman(1), vec![1.0]);
     let w = blackman(1024);
     assert!((max(&w) - 1.0).abs() < EPSILON);
+    let expected_sum = BLACKMAN_SUM_FACTOR * 1024.0;
+    assert!((w.iter().sum::<f32>() - expected_sum).abs() < EPSILON);
 
     let mut buf = [0.0f32; 1];
     blackman_inplace_stack(&mut buf);
@@ -65,4 +102,11 @@ fn kaiser_edges_and_large() {
 #[should_panic]
 fn kaiser_negative_beta_panics() {
     kaiser(8, -1.0);
+}
+
+/// Ensures zero length triggers a panic instead of returning an empty window.
+#[test]
+#[should_panic]
+fn kaiser_len_zero_panics() {
+    kaiser(0, 5.0);
 }

--- a/tests/window_more.rs
+++ b/tests/window_more.rs
@@ -1,0 +1,66 @@
+//! Tests for additional window generation functions verifying normalization and edge cases.
+
+use kofft::window_more::{bartlett, bohman, nuttall, tukey};
+
+/// Allowed floating-point error when verifying normalization.
+const EPSILON: f32 = 1e-5;
+
+/// Computes the expected sum of a Bartlett window for a given length.
+///
+/// Formula:
+/// - For even `len`, `sum = len*(len-2)/(2*(len-1))`
+/// - For odd `len`, `sum = (len-1)/2`
+fn expected_bartlett_sum(len: usize) -> f32 {
+    if len % 2 == 0 {
+        (len * (len - 2)) as f32 / (2.0 * (len - 1) as f32)
+    } else {
+        (len - 1) as f32 / 2.0
+    }
+}
+
+/// Helper to find the maximum element in a slice.
+fn max(slice: &[f32]) -> f32 {
+    slice.iter().copied().fold(f32::MIN, f32::max)
+}
+
+/// Ensures zero lengths panic to satisfy input sanitization.
+#[test]
+#[should_panic]
+fn tukey_len_zero_panics() {
+    tukey(0, 0.5);
+}
+
+#[test]
+#[should_panic]
+fn bartlett_len_zero_panics() {
+    bartlett(0);
+}
+
+#[test]
+#[should_panic]
+fn bohman_len_zero_panics() {
+    bohman(0);
+}
+
+#[test]
+#[should_panic]
+fn nuttall_len_zero_panics() {
+    nuttall(0);
+}
+
+/// Validates normalization sums and amplitude for the Bartlett window.
+#[test]
+fn bartlett_sum_and_peak() {
+    let len = 1024;
+    let w = bartlett(len);
+    assert!((max(&w) - 1.0).abs() < EPSILON);
+    let expected = expected_bartlett_sum(len);
+    assert!((w.iter().sum::<f32>() - expected).abs() < EPSILON);
+}
+
+/// Verifies that extremely large lengths fail fast without excessive allocation.
+#[test]
+#[should_panic]
+fn tukey_large_len_panics() {
+    tukey(usize::MAX, 0.5);
+}


### PR DESCRIPTION
## Summary
- require window functions to receive length >= 1 and clarify amplitude normalization
- replace magic numbers with named constants and expose expected normalization sums
- add tests for window normalization, extreme lengths, and additional windows

## Testing
- `cargo clippy --tests`
- `cargo test --all-features` *(fails: fuzzy_match_allocations assertion)*

------
https://chatgpt.com/codex/tasks/task_e_68a7888fd464832b8afa1eafa76c00fe