### PR TITLE
feat(shell): validate design toggle inputs

### DIFF
--- a/web/apps/shell/src/DesignToggle.test.tsx
+++ b/web/apps/shell/src/DesignToggle.test.tsx
@@ -4,6 +4,7 @@ import { render, fireEvent, cleanup } from "@testing-library/react";
 import { DesignProvider } from "./DesignContext";
 import { DesignToggle } from "./DesignToggle";
 import { PALETTES } from "./designs";
+import { parseDesign, parseMode } from "./DesignToggle";
 
 /**
  * Convenience helper rendering the toggle within its provider. The wrapper
@@ -68,5 +69,21 @@ describe("DesignToggle", () => {
     });
     expect(rootStyles().getPropertyValue("--color-secondary")).toBe("");
     expect(rootStyles().getPropertyValue("--color-tertiary")).toBe("");
+  });
+
+  /**
+   * The parser rejects unknown design identifiers, preventing undefined
+   * themes from reaching application state.
+   */
+  it("throws on invalid design", () => {
+    expect(() => parseDesign("invalid" as string)).toThrow(/Unknown design/);
+  });
+
+  /**
+   * The parser rejects unknown colour modes, ensuring the shell only switches
+   * between light and dark configurations.
+   */
+  it("throws on invalid mode", () => {
+    expect(() => parseMode("weird" as string)).toThrow(/Unknown mode/);
   });
 });

--- a/web/apps/shell/src/DesignToggle.tsx
+++ b/web/apps/shell/src/DesignToggle.tsx
@@ -1,25 +1,77 @@
 import React from "react";
 import { useDesign } from "./DesignContext";
 import type { Design, Mode } from "./designs";
+import { PALETTES } from "./designs";
+
+/** Consistent spacing for the toggle container. */
+const CONTROL_SPACING = "0.5rem" as const;
+
+/**
+ * Lookup set of allowed design identifiers. Using a Set provides constant
+ * time membership checks and avoids repeatedly allocating arrays on each
+ * render.
+ */
+const VALID_DESIGNS: ReadonlySet<Design> = new Set(
+  Object.keys(PALETTES) as Design[],
+);
+
+/**
+ * Lookup set of allowed colour modes. Maintained separately so that any
+ * change in supported modes requires updating a single constant.
+ */
+const VALID_MODES: ReadonlySet<Mode> = new Set<Mode>(["light", "dark"]);
+
+/**
+ * Convert an arbitrary string into a validated Design. Rejects unknown values
+ * with a descriptive error to prevent silent fallbacks.
+ */
+export function parseDesign(value: string): Design {
+  if (!VALID_DESIGNS.has(value as Design)) {
+    throw new Error(`Unknown design: ${value}`);
+  }
+  return value as Design;
+}
+
+/**
+ * Convert an arbitrary string into a validated Mode. Rejects unknown values
+ * with a descriptive error to prevent silent fallbacks.
+ */
+export function parseMode(value: string): Mode {
+  if (!VALID_MODES.has(value as Mode)) {
+    throw new Error(`Unknown mode: ${value}`);
+  }
+  return value as Mode;
+}
 
 /**
  * Controlled dropdown allowing users to switch design system and colour mode.
- * The component is intentionally simple to avoid unnecessary re-renders and
- * does not perform any validation beyond the enums enforced by context.
+ * Runtime validation is performed to guard against unknown values originating
+ * from malformed DOM or malicious scripts.
  */
 export function DesignToggle() {
   const { design, mode, setDesign, setMode } = useDesign();
 
+  /**
+   * Handles design changes by verifying the selected value exists in the
+   * predefined set. Throws an error when an unknown design is encountered to
+   * surface issues immediately.
+   */
   const handleDesignChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
-    setDesign(e.target.value as Design);
+    const value = parseDesign(e.target.value);
+    setDesign(value);
   };
 
+  /**
+   * Handles mode changes with the same defensive checks as designs, ensuring
+   * only supported modes reach the context state.
+   */
   const handleModeChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
-    setMode(e.target.value as Mode);
+    const value = parseMode(e.target.value);
+    setMode(value);
   };
 
   return (
-    <div style={{ padding: "0.5rem", display: "flex", gap: "0.5rem" }}>
+    <div style={{ padding: CONTROL_SPACING, display: "flex", gap: CONTROL_SPACING }}>
       <label>
         Design:
         <select


### PR DESCRIPTION
## Summary
- add explicit valid Design/Mode sets and parsing helpers to DesignToggle
- guard dropdown change handlers against unknown values
- cover invalid design and mode parsing with unit tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a7931e9088832bbf33371f59aa1c4e