### PR TITLE
Validate worker metadata messages and surface errors

### DIFF
--- a/web/apps/mfe-spectrogram/src/shared/stores/uiStore.ts
+++ b/web/apps/mfe-spectrogram/src/shared/stores/uiStore.ts
@@ -11,6 +11,8 @@ interface UIStore extends UIState {
   setFullscreen: (fullscreen: boolean) => void
   setMobile: (mobile: boolean) => void
   setTablet: (tablet: boolean) => void
+  /** Store a fatal error message to surface to the user. */
+  setError: (message: string | null) => void
   toggleMetadataPanel: () => void
   togglePlaylistPanel: () => void
   toggleSettingsPanel: () => void
@@ -27,6 +29,7 @@ const initialState: UIState = {
   isFullscreen: false,
   isMobile: false,
   isTablet: false,
+  error: null, // Last error message shown to the user
 }
 
 export const useUIStore = create<UIStore>()(
@@ -40,6 +43,7 @@ export const useUIStore = create<UIStore>()(
     setFullscreen: (fullscreen) => set({ isFullscreen: fullscreen }),
     setMobile: (mobile) => set({ isMobile: mobile }),
     setTablet: (tablet) => set({ isTablet: tablet }),
+    setError: (message) => set({ error: message }),
 
     toggleMetadataPanel: () => {
       const { metadataPanelOpen } = get()

--- a/web/apps/mfe-spectrogram/src/shared/types/index.ts
+++ b/web/apps/mfe-spectrogram/src/shared/types/index.ts
@@ -211,6 +211,8 @@ export interface UIState {
   isFullscreen: boolean;
   isMobile: boolean;
   isTablet: boolean;
+  /** Last fatal error surfaced to the user interface. */
+  error: string | null;
 }
 
 // Audio State types

--- a/web/apps/mfe-spectrogram/src/shared/utils/__tests__/metadataStore.worker.test.ts
+++ b/web/apps/mfe-spectrogram/src/shared/utils/__tests__/metadataStore.worker.test.ts
@@ -1,0 +1,32 @@
+import { validateWorkerMetadata, metadataStore } from '../metadataStore'
+import { useUIStore } from '../../stores/uiStore'
+
+// Ensure isolation by resetting UI error state after each test.
+afterEach(() => {
+  useUIStore.getState().setError(null)
+})
+
+describe('validateWorkerMetadata', () => {
+  it('accepts valid metadata objects', () => {
+    const msg = { title: 't', artist: 'a' }
+    expect(validateWorkerMetadata(msg)).toEqual(msg)
+  })
+
+  it('rejects unexpected fields', () => {
+    expect(() => validateWorkerMetadata({ foo: 'bar' } as any)).toThrow('Unexpected field: foo')
+  })
+
+  it('rejects invalid field types', () => {
+    expect(() => validateWorkerMetadata({ duration: 'oops' } as any)).toThrow('Invalid type for duration')
+  })
+})
+
+describe('metadataStore.storeMetadata', () => {
+  it('propagates validation errors to the UI store', async () => {
+    const file = new File([new Uint8Array()], 'test.mp3')
+    await expect(
+      metadataStore.storeMetadata(file, { foo: 'bar' } as any, new ArrayBuffer(8))
+    ).rejects.toThrow('Unexpected field: foo')
+    expect(useUIStore.getState().error).toContain('Unexpected field: foo')
+  })
+})

--- a/web/apps/mfe-spectrogram/src/types/index.ts
+++ b/web/apps/mfe-spectrogram/src/types/index.ts
@@ -203,6 +203,8 @@ export interface UIState {
   isFullscreen: boolean;
   isMobile: boolean;
   isTablet: boolean;
+  /** Last fatal error surfaced to the user interface. */
+  error: string | null;
 }
 
 // Audio State types


### PR DESCRIPTION
## Summary
- validate and sanitise metadata messages from worker, rejecting unknown fields
- surface store and validation errors through UI store
- test malformed worker messages and error propagation

## Testing
- `npm test` *(fails: cargo: no such command `hack`; feature_powerset_builds test failed)*
- `npm run lint` *(fails: Missing script "lint")*


------
https://chatgpt.com/codex/tasks/task_e_68a788435b10832bba28c0c31f7c576f