### PR TITLE
fix: clean up audio file URLs and surface decode errors

### DIFF
--- a/web/apps/mfe-spectrogram/src/hooks/__tests__/useAudioFile.test.ts
+++ b/web/apps/mfe-spectrogram/src/hooks/__tests__/useAudioFile.test.ts
@@ -1,51 +1,59 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { renderHook, act, waitFor } from '@testing-library/react'
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { renderHook, act, waitFor } from "@testing-library/react";
+import { audioPlayer } from "@/shared/utils/audioPlayer";
 
-const {
-  state,
-  addToPlaylist,
-  setCurrentTrack,
-  updateTrack,
-  useAudioStore
-} = vi.hoisted(() => {
-  const state: any = { playlist: [], currentTrack: null }
-  const addToPlaylist = vi.fn((track) => state.playlist.push(track))
-  const setCurrentTrack = vi.fn((track) => { state.currentTrack = track })
-  const updateTrack = vi.fn()
-  const useAudioStore: any = () => ({ addToPlaylist, setCurrentTrack })
-  useAudioStore.getState = () => ({ ...state, updateTrack })
-  return { state, addToPlaylist, setCurrentTrack, updateTrack, useAudioStore }
-})
+const { state, addToPlaylist, setCurrentTrack, updateTrack, useAudioStore } =
+  vi.hoisted(() => {
+    const state: any = { playlist: [], currentTrack: null };
+    const addToPlaylist = vi.fn((track) => state.playlist.push(track));
+    const setCurrentTrack = vi.fn((track) => {
+      state.currentTrack = track;
+    });
+    const updateTrack = vi.fn();
+    const useAudioStore: any = () => ({ addToPlaylist, setCurrentTrack });
+    useAudioStore.getState = () => ({ ...state, updateTrack });
+    return {
+      state,
+      addToPlaylist,
+      setCurrentTrack,
+      updateTrack,
+      useAudioStore,
+    };
+  });
 
-vi.mock('@/shared/stores/audioStore', () => ({ useAudioStore }))
+vi.mock("@/shared/stores/audioStore", () => ({ useAudioStore }));
 
 const { extractMetadata, generateAmplitudeEnvelope } = vi.hoisted(() => {
   return {
     extractMetadata: vi.fn().mockResolvedValue({
-      title: 'meta',
-      artist: 'artist',
-      album: 'album',
+      title: "meta",
+      artist: "artist",
+      album: "album",
       duration: 1,
       sample_rate: 44100,
     }),
-    generateAmplitudeEnvelope: vi.fn().mockResolvedValue(new Float32Array([1, 2, 3]))
-  }
-})
+    generateAmplitudeEnvelope: vi
+      .fn()
+      .mockResolvedValue(new Float32Array([1, 2, 3])),
+  };
+});
 
-vi.mock('@/shared/utils/wasm', () => ({
+vi.mock("@/shared/utils/wasm", () => ({
   extractMetadata,
   generateAmplitudeEnvelope,
-}))
+}));
 
-vi.mock('@/shared/utils/artwork', () => ({
-  extractArtwork: vi.fn().mockResolvedValue({ artwork: null })
-}))
+vi.mock("@/shared/utils/artwork", () => ({
+  extractArtwork: vi.fn().mockResolvedValue({ artwork: null }),
+}));
 
-vi.mock('@/shared/utils/audioPlayer', () => ({
+vi.mock("@/shared/utils/audioPlayer", () => ({
   audioPlayer: {
     subscribe: vi.fn().mockReturnValue(() => {}),
     initAudioContext: vi.fn().mockResolvedValue({
-      decodeAudioData: vi.fn().mockResolvedValue({ getChannelData: () => new Float32Array(0) })
+      decodeAudioData: vi
+        .fn()
+        .mockResolvedValue({ getChannelData: () => new Float32Array(0) }),
     }),
     playTrack: vi.fn(),
     stopPlayback: vi.fn(),
@@ -56,73 +64,162 @@ vi.mock('@/shared/utils/audioPlayer', () => ({
     toggleMute: vi.fn(),
     getFrequencyData: vi.fn(),
     getTimeData: vi.fn(),
-    cleanup: vi.fn()
-  }
-}))
+    cleanup: vi.fn(),
+  },
+}));
 
-vi.mock('@/shared/utils/toast', () => ({
-  conditionalToast: { success: vi.fn(), error: vi.fn() }
-}))
+vi.mock("@/shared/utils/toast", () => ({
+  conditionalToast: { success: vi.fn(), error: vi.fn() },
+}));
 
-import { useAudioFile } from '../useAudioFile'
-describe('useAudioFile', () => {
+import { useAudioFile } from "../useAudioFile";
+describe("useAudioFile", () => {
   beforeEach(() => {
-    state.playlist = []
-    state.currentTrack = null
-    addToPlaylist.mockClear()
-    setCurrentTrack.mockClear()
-    updateTrack.mockClear()
-    extractMetadata.mockClear()
-    ;(localStorage.getItem as any).mockReset()
-    ;(localStorage.setItem as any).mockReset()
-  })
+    state.playlist = [];
+    state.currentTrack = null;
+    addToPlaylist.mockClear();
+    setCurrentTrack.mockClear();
+    updateTrack.mockClear();
+    extractMetadata.mockClear();
+    (localStorage.getItem as any).mockReset();
+    (localStorage.setItem as any).mockReset();
+    (audioPlayer.initAudioContext as any).mockResolvedValue({
+      decodeAudioData: vi.fn().mockResolvedValue({
+        getChannelData: () => new Float32Array(0),
+      }),
+    });
+  });
 
-  it('adds placeholder and updates track asynchronously', async () => {
-    const file = new File(['data'], 'track.mp3', { type: 'audio/mpeg' })
-    ;(file as any).arrayBuffer = vi.fn().mockResolvedValue(new ArrayBuffer(8))
-    const { result } = renderHook(() => useAudioFile())
-    let placeholder: any
-    await act(async () => { placeholder = await result.current.loadAudioFile(file) })
-    expect(addToPlaylist).toHaveBeenCalledWith(expect.objectContaining({ isLoading: true }))
+  it("adds placeholder and updates track asynchronously", async () => {
+    const file = new File(["data"], "track.mp3", { type: "audio/mpeg" });
+    (file as any).arrayBuffer = vi.fn().mockResolvedValue(new ArrayBuffer(8));
+    const { result } = renderHook(() => useAudioFile());
+    let placeholder: any;
+    await act(async () => {
+      placeholder = await result.current.loadAudioFile(file);
+    });
+    expect(addToPlaylist).toHaveBeenCalledWith(
+      expect.objectContaining({ isLoading: true }),
+    );
     await waitFor(() =>
-      expect(updateTrack).toHaveBeenCalledWith(placeholder.id, expect.objectContaining({ isLoading: false }))
-    )
-  })
+      expect(updateTrack).toHaveBeenCalledWith(
+        placeholder.id,
+        expect.objectContaining({ isLoading: false }),
+      ),
+    );
+  });
 
-  it('uses cached metadata and skips extractMetadata', async () => {
-    const encoder = new TextEncoder()
-    const buffer = encoder.encode('data').buffer
-    const hashBuffer = await crypto.subtle.digest('SHA-256', buffer)
+  it("uses cached metadata and skips extractMetadata", async () => {
+    const encoder = new TextEncoder();
+    const buffer = encoder.encode("data").buffer;
+    const hashBuffer = await crypto.subtle.digest("SHA-256", buffer);
     const hash = Array.from(new Uint8Array(hashBuffer))
-      .map(b => b.toString(16).padStart(2, '0'))
-      .join('')
-    const cacheKey = `audio-metadata-${hash}`
+      .map((b) => b.toString(16).padStart(2, "0"))
+      .join("");
+    const cacheKey = `audio-metadata-${hash}`;
     const store: Record<string, string> = {
       [cacheKey]: JSON.stringify({
-        metadata: { title: 'cached', artist: 'artist', album: 'album', duration: 1, sample_rate: 44100 },
+        metadata: {
+          title: "cached",
+          artist: "artist",
+          album: "album",
+          duration: 1,
+          sample_rate: 44100,
+        },
         artwork: null,
       }),
-    }
-    ;(localStorage.getItem as any).mockImplementation(key => store[key] || null)
-    ;(localStorage.setItem as any).mockImplementation((key, val) => {
-      store[key] = val
-    })
+    };
+    (localStorage.getItem as any).mockImplementation(
+      (key) => store[key] || null,
+    );
+    (localStorage.setItem as any).mockImplementation((key, val) => {
+      store[key] = val;
+    });
 
-    const file = new File(['data'], 'track.mp3', { type: 'audio/mpeg' })
-    ;(file as any).arrayBuffer = vi.fn().mockResolvedValue(buffer)
+    const file = new File(["data"], "track.mp3", { type: "audio/mpeg" });
+    (file as any).arrayBuffer = vi.fn().mockResolvedValue(buffer);
 
-    const { result } = renderHook(() => useAudioFile())
+    const { result } = renderHook(() => useAudioFile());
     await act(async () => {
-      await result.current.loadAudioFile(file)
-    })
+      await result.current.loadAudioFile(file);
+    });
 
-    await waitFor(() => expect(updateTrack).toHaveBeenCalled())
+    await waitFor(() => expect(updateTrack).toHaveBeenCalled());
 
-    expect(localStorage.getItem).toHaveBeenCalledWith(cacheKey)
-    expect(extractMetadata).not.toHaveBeenCalled()
+    expect(localStorage.getItem).toHaveBeenCalledWith(cacheKey);
+    expect(extractMetadata).not.toHaveBeenCalled();
     expect(updateTrack).toHaveBeenCalledWith(
       expect.any(String),
-      expect.objectContaining({ metadata: expect.objectContaining({ title: 'cached' }) })
-    )
-  })
-})
+      expect.objectContaining({
+        metadata: expect.objectContaining({ title: "cached" }),
+      }),
+    );
+  });
+
+  // Ensures that any object URLs created for audio playback are revoked
+  // when the hook unmounts, preventing resource leaks.
+  it("revokes object URLs on unmount", async () => {
+    const file = new File(["data"], "track.mp3", { type: "audio/mpeg" });
+    (file as any).arrayBuffer = vi.fn().mockResolvedValue(new ArrayBuffer(8));
+
+    const createObjectURL = vi.fn(() => "blob:test");
+    const revokeObjectURL = vi.fn();
+    global.URL.createObjectURL = createObjectURL as any;
+    global.URL.revokeObjectURL = revokeObjectURL as any;
+
+    const { result, unmount } = renderHook(() => useAudioFile());
+    await act(async () => {
+      await result.current.loadAudioFile(file);
+    });
+    unmount();
+
+    expect(revokeObjectURL).toHaveBeenCalledWith("blob:test");
+  });
+
+  // Verifies that an error while reading the file's binary data
+  // surfaces through the hook's error state.
+  it("reports error when arrayBuffer fails", async () => {
+    const file = new File(["data"], "bad.mp3", { type: "audio/mpeg" });
+    (file as any).arrayBuffer = vi
+      .fn()
+      .mockRejectedValue(new Error("read fail"));
+
+    const { result } = renderHook(() => useAudioFile());
+    await act(async () => {
+      await result.current.loadAudioFile(file);
+    });
+
+    await waitFor(() => expect(result.current.error).toBe("read fail"));
+    await waitFor(() =>
+      expect(updateTrack).toHaveBeenCalledWith(expect.any(String), {
+        isLoading: false,
+      }),
+    );
+  });
+
+  // Confirms that decodeAudioData failures are propagated and exposed
+  // to consumers via the error state.
+  it("reports error when decoding fails", async () => {
+    const file = new File(["data"], "track.mp3", { type: "audio/mpeg" });
+    (file as any).arrayBuffer = vi.fn().mockResolvedValue(new ArrayBuffer(8));
+
+    const decodeAudioData = vi.fn().mockRejectedValue(new Error("boom"));
+    (audioPlayer.initAudioContext as any).mockResolvedValue({
+      decodeAudioData,
+    });
+
+    const { result } = renderHook(() => useAudioFile());
+    await act(async () => {
+      await result.current.loadAudioFile(file);
+    });
+
+    await waitFor(() =>
+      expect(result.current.error).toBe("Failed to decode audio data"),
+    );
+    await waitFor(() =>
+      expect(updateTrack).toHaveBeenCalledWith(expect.any(String), {
+        isLoading: false,
+      }),
+    );
+  });
+});

--- a/web/apps/mfe-spectrogram/src/shared/hooks/useAudioFile.ts
+++ b/web/apps/mfe-spectrogram/src/shared/hooks/useAudioFile.ts
@@ -1,26 +1,59 @@
-import { useState, useCallback, useEffect, useRef } from 'react'
-import { useAudioStore } from '@/shared/stores/audioStore'
-import { audioPlayer, type AudioPlayerState } from '@/shared/utils/audioPlayer'
-import { AudioTrack, AudioMetadata, ArtworkSource } from '@/shared/types'
-import { extractMetadata, generateAmplitudeEnvelope } from '@/shared/utils/wasm'
-import { extractArtwork } from '@/shared/utils/artwork'
-import { conditionalToast } from '@/shared/utils/toast'
-import { metadataStore } from '@/shared/utils/metadataStore'
-import { optimisticMetadataStore, computeOptimisticKey } from '@/shared/utils/optimisticMetadataStore'
-import { metadataVerificationWorker } from '@/shared/utils/metadataVerificationWorker'
+import { useState, useCallback, useEffect, useRef } from "react";
+import { useAudioStore } from "@/shared/stores/audioStore";
+import { audioPlayer, type AudioPlayerState } from "@/shared/utils/audioPlayer";
+import { AudioTrack, AudioMetadata, ArtworkSource } from "@/shared/types";
+import {
+  extractMetadata,
+  generateAmplitudeEnvelope,
+} from "@/shared/utils/wasm";
+import { extractArtwork } from "@/shared/utils/artwork";
+import { conditionalToast } from "@/shared/utils/toast";
+import { metadataStore } from "@/shared/utils/metadataStore";
+import {
+  optimisticMetadataStore,
+  computeOptimisticKey,
+} from "@/shared/utils/optimisticMetadataStore";
+import { metadataVerificationWorker } from "@/shared/utils/metadataVerificationWorker";
 
 // Utility to compute SHA-256 hash for a file buffer
 const hashArrayBuffer = async (buffer: ArrayBuffer): Promise<string> => {
-  const hashBuffer = await crypto.subtle.digest('SHA-256', buffer)
+  const hashBuffer = await crypto.subtle.digest("SHA-256", buffer);
   return Array.from(new Uint8Array(hashBuffer))
-    .map(b => b.toString(16).padStart(2, '0'))
-    .join('')
-}
+    .map((b) => b.toString(16).padStart(2, "0"))
+    .join("");
+};
+
+// Default sampling rate used when metadata lacks explicit information.
+const DEFAULT_SAMPLE_RATE = 44100;
+
+// Error message used when reading a file's binary data fails.
+const FILE_READ_ERROR = "Failed to read file data";
+
+// Error message used when audio decoding encounters a failure.
+const DECODE_ERROR = "Failed to decode audio data";
+
+// Window size in milliseconds used for amplitude envelope generation.
+const ENVELOPE_WINDOW_MS = 1000;
+
+// Step size in milliseconds for envelope sampling.
+const ENVELOPE_STEP_MS = 20;
+
+// Number of smoothing passes applied to the envelope.
+const ENVELOPE_SMOOTHING = 3;
 
 export const useAudioFile = () => {
-  const [isLoading, setIsLoading] = useState(false)
-  const [error, setError] = useState<string | null>(null)
-  const unsubscribeRef = useRef<(() => void) | null>(null)
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const unsubscribeRef = useRef<(() => void) | null>(null);
+
+  // Stores object URLs for all loaded files so they can be revoked on cleanup.
+  const objectUrlsRef = useRef<string[]>([]);
+
+  // Releases all stored object URLs to avoid leaking memory.
+  const revokeAllObjectUrls = useCallback(() => {
+    objectUrlsRef.current.forEach((url) => URL.revokeObjectURL(url));
+    objectUrlsRef.current = [];
+  }, []);
 
   const {
     setPlaying,
@@ -31,27 +64,35 @@ export const useAudioFile = () => {
     setVolume,
     setMuted,
     setCurrentTrack,
-    addToPlaylist
-  } = useAudioStore()
+    addToPlaylist,
+  } = useAudioStore();
 
   // Subscribe to audio player state changes
   useEffect(() => {
     const unsubscribe = audioPlayer.subscribe((state: AudioPlayerState) => {
-      setPlaying(state.isPlaying)
-      setPaused(state.isPaused)
-      setStopped(state.isStopped)
-      setCurrentTime(state.currentTime)
-      setDuration(state.duration)
-      setVolume(state.volume)
-      setMuted(state.isMuted)
-    })
+      setPlaying(state.isPlaying);
+      setPaused(state.isPaused);
+      setStopped(state.isStopped);
+      setCurrentTime(state.currentTime);
+      setDuration(state.duration);
+      setVolume(state.volume);
+      setMuted(state.isMuted);
+    });
 
-    unsubscribeRef.current = unsubscribe
+    unsubscribeRef.current = unsubscribe;
 
     return () => {
-      unsubscribe()
-    }
-  }, [setPlaying, setPaused, setStopped, setCurrentTime, setDuration, setVolume, setMuted])
+      unsubscribe();
+    };
+  }, [
+    setPlaying,
+    setPaused,
+    setStopped,
+    setCurrentTime,
+    setDuration,
+    setVolume,
+    setMuted,
+  ]);
 
   // React to natural track endings by advancing the playlist according to
   // loop/shuffle preferences. This keeps playback continuity entirely within
@@ -68,558 +109,699 @@ export const useAudioFile = () => {
         loopMode,
         shuffle,
         nextTrack,
-      } = useAudioStore.getState()
+      } = useAudioStore.getState();
 
-      const playlistLength = playlist.length
+      const playlistLength = playlist.length;
       if (playlistLength === 0) {
-        setPlaying(false)
-        setPaused(false)
-        setStopped(true)
-        return
+        setPlaying(false);
+        setPaused(false);
+        setStopped(true);
+        return;
       }
 
-      if (loopMode === 'one') {
-        playTrack(currentTrackIndex)
-        return
+      if (loopMode === "one") {
+        playTrack(currentTrackIndex);
+        return;
       }
 
       if (shuffle) {
-        if (playlistLength === 1 && loopMode === 'off') {
-          setPlaying(false)
-          setPaused(false)
-          setStopped(true)
+        if (playlistLength === 1 && loopMode === "off") {
+          setPlaying(false);
+          setPaused(false);
+          setStopped(true);
         } else {
           // Delegate to store's shuffle-aware nextTrack implementation
-          nextTrack()
+          nextTrack();
         }
-        return
+        return;
       }
 
-      const isLastTrack = currentTrackIndex >= playlistLength - 1
+      const isLastTrack = currentTrackIndex >= playlistLength - 1;
       if (!isLastTrack) {
-        playTrack(currentTrackIndex + 1)
-        return
+        playTrack(currentTrackIndex + 1);
+        return;
       }
 
-      if (loopMode === 'all') {
-        playTrack(0)
-        return
+      if (loopMode === "all") {
+        playTrack(0);
+        return;
       }
 
-      setPlaying(false)
-      setPaused(false)
-      setStopped(true)
-    })
+      setPlaying(false);
+      setPaused(false);
+      setStopped(true);
+    });
 
     return () => {
-      unsubscribeEnded()
-    }
-  }, [])
+      unsubscribeEnded();
+    };
+  }, []);
+
+  // Revoke any allocated object URLs when the hook's owner unmounts.
+  useEffect(() => {
+    return () => {
+      revokeAllObjectUrls();
+    };
+  }, [revokeAllObjectUrls]);
 
   // Parse metadata using WASM utility
-  const parseMetadata = useCallback(async (file: File): Promise<AudioMetadata> => {
-    try {
-      return await extractMetadata(file)
-    } catch (error) {
-      return {
-        title: file.name.replace(/\.[^/.]+$/, ''),
-        artist: 'Unknown Artist',
-        album: 'Unknown Album',
-        format: file.type || 'unknown'
+  const parseMetadata = useCallback(
+    async (file: File): Promise<AudioMetadata> => {
+      try {
+        return await extractMetadata(file);
+      } catch (error) {
+        return {
+          title: file.name.replace(/\.[^/.]+$/, ""),
+          artist: "Unknown Artist",
+          album: "Unknown Album",
+          format: file.type || "unknown",
+        };
       }
-    }
-  }, [])
+    },
+    [],
+  );
 
   // Generate amplitude envelope using WASM utility
-  const generateAmplitudeEnvelopeData = useCallback(async (
-    file: File,
-    metadata: AudioMetadata,
-    arrayBuffer?: ArrayBuffer
-  ): Promise<Float32Array> => {
-    try {
-      const sampleRate = metadata.sample_rate || 44100
+  const generateAmplitudeEnvelopeData = useCallback(
+    async (
+      file: File,
+      metadata: AudioMetadata,
+      arrayBuffer?: ArrayBuffer,
+    ): Promise<Float32Array> => {
+      try {
+        const sampleRate = metadata.sample_rate || DEFAULT_SAMPLE_RATE;
 
-      // Use the shared audio context to decode audio data
-      const context = await audioPlayer.initAudioContext()
-      const buffer = arrayBuffer ?? (await file.arrayBuffer())
-      const audioBuffer = await context.decodeAudioData(buffer)
+        // Use the shared audio context to decode audio data
+        const context = await audioPlayer.initAudioContext();
+        const buffer =
+          arrayBuffer ??
+          (await file.arrayBuffer().catch(() => {
+            throw new Error(FILE_READ_ERROR);
+          }));
+        const audioBuffer = await context.decodeAudioData(buffer).catch(() => {
+          throw new Error(DECODE_ERROR);
+        });
 
-      // Get first channel data
-      const channelData = audioBuffer.getChannelData(0)
-      const audioData = new Float32Array(channelData.length)
-      audioData.set(channelData)
+        // Get first channel data
+        const channelData = audioBuffer.getChannelData(0);
+        const audioData = new Float32Array(channelData.length);
+        audioData.set(channelData);
 
-      // Generate envelope
-      const envelope = await generateAmplitudeEnvelope(audioData, sampleRate, 1000, 20, 3)
+        // Generate envelope
+        const envelope = await generateAmplitudeEnvelope(
+          audioData,
+          sampleRate,
+          ENVELOPE_WINDOW_MS,
+          ENVELOPE_STEP_MS,
+          ENVELOPE_SMOOTHING,
+        );
 
-      return envelope
-    } catch (error) {
-      // Return empty array as fallback
-      return new Float32Array(0)
-    }
-  }, [])
+        return envelope;
+      } catch (error) {
+        // Propagate errors so callers can surface them to the user.
+        throw error;
+      }
+    },
+    [],
+  );
 
   // Start background verification for a track
-  const startBackgroundVerification = useCallback(async (file: File, optimisticKey: string, trackId: string) => {
-    try {
-      const arrayBuffer = await file.arrayBuffer()
-      
-      // Add to verification queue with high priority for currently loaded tracks
-      await metadataVerificationWorker.addVerificationTask(
-        file.name,
-        file.size,
-        arrayBuffer,
-        10 // High priority for currently loaded tracks
-      )
-      
-      console.log('🔄 [VERIFICATION] Added to verification queue:', optimisticKey)
-      
-      // Set up a listener for verification completion
-      const checkVerificationStatus = async () => {
-        try {
-          const result = await optimisticMetadataStore.getOptimisticMetadata(file.name, file.size)
-          if (result.metadata?.verified) {
-            console.log('✅ [VERIFICATION] Metadata verified for key:', optimisticKey)
-            
-            // Update track with verified metadata
-            const verifiedMetadata: AudioMetadata = {
-              title: result.metadata.title,
-              artist: result.metadata.artist,
-              album: result.metadata.album,
-              year: result.metadata.year,
-              genre: result.metadata.genre,
-              duration: result.metadata.duration,
-              bitrate: result.metadata.bitrate,
-              sample_rate: result.metadata.sample_rate,
-              channels: result.metadata.channels,
-              bit_depth: result.metadata.bit_depth,
-              format: result.metadata.format,
-              album_art: result.artwork?.data,
-              album_art_mime: result.artwork?.mime_type || result.metadata.album_art_mime
-            }
+  const startBackgroundVerification = useCallback(
+    async (file: File, optimisticKey: string, trackId: string) => {
+      try {
+        const arrayBuffer = await file.arrayBuffer();
 
-            let artwork: ArtworkSource | undefined
-            if (result.artwork) {
-              artwork = {
-                type: 'embedded',
-                data: result.artwork.data,
-                mimeType: result.artwork.mime_type,
-                confidence: 1.0,
-                metadata: {
-                  artist: verifiedMetadata.artist,
-                  album: verifiedMetadata.album,
-                  title: verifiedMetadata.title
-                }
+        // Add to verification queue with high priority for currently loaded tracks
+        await metadataVerificationWorker.addVerificationTask(
+          file.name,
+          file.size,
+          arrayBuffer,
+          10, // High priority for currently loaded tracks
+        );
+
+        console.log(
+          "🔄 [VERIFICATION] Added to verification queue:",
+          optimisticKey,
+        );
+
+        // Set up a listener for verification completion
+        const checkVerificationStatus = async () => {
+          try {
+            const result = await optimisticMetadataStore.getOptimisticMetadata(
+              file.name,
+              file.size,
+            );
+            if (result.metadata?.verified) {
+              console.log(
+                "✅ [VERIFICATION] Metadata verified for key:",
+                optimisticKey,
+              );
+
+              // Update track with verified metadata
+              const verifiedMetadata: AudioMetadata = {
+                title: result.metadata.title,
+                artist: result.metadata.artist,
+                album: result.metadata.album,
+                year: result.metadata.year,
+                genre: result.metadata.genre,
+                duration: result.metadata.duration,
+                bitrate: result.metadata.bitrate,
+                sample_rate: result.metadata.sample_rate,
+                channels: result.metadata.channels,
+                bit_depth: result.metadata.bit_depth,
+                format: result.metadata.format,
+                album_art: result.artwork?.data,
+                album_art_mime:
+                  result.artwork?.mime_type || result.metadata.album_art_mime,
+              };
+
+              let artwork: ArtworkSource | undefined;
+              if (result.artwork) {
+                artwork = {
+                  type: "embedded",
+                  data: result.artwork.data,
+                  mimeType: result.artwork.mime_type,
+                  confidence: 1.0,
+                  metadata: {
+                    artist: verifiedMetadata.artist,
+                    album: verifiedMetadata.album,
+                    title: verifiedMetadata.title,
+                  },
+                };
               }
+
+              useAudioStore.getState().updateTrack(trackId, {
+                metadata: verifiedMetadata,
+                artwork,
+              });
+
+              conditionalToast.success(`Verified: ${verifiedMetadata.title}`);
+              return true;
             }
-
-            useAudioStore.getState().updateTrack(trackId, {
-              metadata: verifiedMetadata,
-              artwork
-            })
-            
-            conditionalToast.success(`Verified: ${verifiedMetadata.title}`)
-            return true
+          } catch (error) {
+            console.warn(
+              "⚠️ [VERIFICATION] Error checking verification status:",
+              error,
+            );
           }
-        } catch (error) {
-          console.warn('⚠️ [VERIFICATION] Error checking verification status:', error)
-        }
-        return false
+          return false;
+        };
+
+        // Check verification status periodically
+        const verificationInterval = setInterval(async () => {
+          const verified = await checkVerificationStatus();
+          if (verified) {
+            clearInterval(verificationInterval);
+          }
+        }, 2000); // Check every 2 seconds
+
+        // Stop checking after 30 seconds
+        setTimeout(() => {
+          clearInterval(verificationInterval);
+        }, 30000);
+      } catch (error) {
+        console.error(
+          "❌ [VERIFICATION] Failed to start background verification:",
+          error,
+        );
       }
-
-      // Check verification status periodically
-      const verificationInterval = setInterval(async () => {
-        const verified = await checkVerificationStatus()
-        if (verified) {
-          clearInterval(verificationInterval)
-        }
-      }, 2000) // Check every 2 seconds
-
-      // Stop checking after 30 seconds
-      setTimeout(() => {
-        clearInterval(verificationInterval)
-      }, 30000)
-      
-    } catch (error) {
-      console.error('❌ [VERIFICATION] Failed to start background verification:', error)
-    }
-  }, [])
+    },
+    [],
+  );
 
   // Validate audio file
   const validateAudioFile = useCallback((file: File): boolean => {
     const validTypes = [
-      'audio/mpeg',
-      'audio/mp3',
-      'audio/wav',
-      'audio/wave',
-      'audio/x-wav',
-      'audio/flac',
-      'audio/x-flac',
-      'audio/ogg',
-      'audio/oga',
-      'audio/m4a',
-      'audio/x-m4a',
-      'audio/aac',
-      'audio/webm',
-      'audio/x-webm'
-    ]
+      "audio/mpeg",
+      "audio/mp3",
+      "audio/wav",
+      "audio/wave",
+      "audio/x-wav",
+      "audio/flac",
+      "audio/x-flac",
+      "audio/ogg",
+      "audio/oga",
+      "audio/m4a",
+      "audio/x-m4a",
+      "audio/aac",
+      "audio/webm",
+      "audio/x-webm",
+    ];
 
-    return validTypes.includes(file.type) || !!file.name.match(/\.(mp3|wav|flac|ogg|m4a|aac|webm)$/i)
-  }, [])
+    return (
+      validTypes.includes(file.type) ||
+      !!file.name.match(/\.(mp3|wav|flac|ogg|m4a|aac|webm)$/i)
+    );
+  }, []);
 
   // Load single audio file with optimistic metadata
-  const loadAudioFile = useCallback(async (file: File): Promise<AudioTrack> => {
-    setIsLoading(true)
-    setError(null)
+  const loadAudioFile = useCallback(
+    async (file: File): Promise<AudioTrack> => {
+      setIsLoading(true);
+      setError(null);
 
-    try {
-      if (!validateAudioFile(file)) {
-        throw new Error('Invalid audio file format')
-      }
-
-      const id = crypto.randomUUID()
-      const startTime = performance.now()
-      
-      // Create placeholder track for immediate UI feedback
-      const placeholder: AudioTrack = {
-        id,
-        file,
-        metadata: {
-          title: file.name.replace(/\.[^/.]+$/, ''),
-          artist: 'Loading...',
-          album: '',
-          duration: 0,
-        },
-        duration: 0,
-        url: URL.createObjectURL(file),
-        isLoading: true,
-      }
-
-      addToPlaylist(placeholder)
-
-      const { playlist } = useAudioStore.getState()
-      if (playlist.length === 1) {
-        setCurrentTrack(placeholder)
-      }
-
-      // Fast path: Try optimistic metadata lookup
-      const optimisticKey = computeOptimisticKey(file.name, file.size)
-      console.log('🚀 [OPTIMISTIC] Checking optimistic cache for key:', optimisticKey)
-      
       try {
-        const optimisticResult = await optimisticMetadataStore.getOptimisticMetadata(file.name, file.size)
-        
-        if (optimisticResult.metadata && optimisticResult.trackIndex) {
-          const cacheHitTime = performance.now() - startTime
-          console.log(`⚡ [OPTIMISTIC] Cache hit in ${cacheHitTime.toFixed(2)}ms for key:`, optimisticKey)
-          
-          // Convert optimistic metadata to AudioMetadata format
-          const optimisticMetadata: AudioMetadata = {
-            title: optimisticResult.metadata.title,
-            artist: optimisticResult.metadata.artist,
-            album: optimisticResult.metadata.album,
-            year: optimisticResult.metadata.year,
-            genre: optimisticResult.metadata.genre,
-            duration: optimisticResult.metadata.duration,
-            bitrate: optimisticResult.metadata.bitrate,
-            sample_rate: optimisticResult.metadata.sample_rate,
-            channels: optimisticResult.metadata.channels,
-            bit_depth: optimisticResult.metadata.bit_depth,
-            format: optimisticResult.metadata.format,
-            album_art: optimisticResult.artwork?.data,
-            album_art_mime: optimisticResult.artwork?.mime_type || optimisticResult.metadata.album_art_mime
-          }
-
-          // Create artwork source if available
-          let artwork: ArtworkSource | undefined
-          if (optimisticResult.artwork) {
-            artwork = {
-              type: 'embedded',
-              data: optimisticResult.artwork.data,
-              mimeType: optimisticResult.artwork.mime_type,
-              confidence: optimisticResult.metadata.verified ? 1.0 : 0.8,
-              metadata: {
-                artist: optimisticMetadata.artist,
-                album: optimisticMetadata.album,
-                title: optimisticMetadata.title
-              }
-            }
-          }
-
-          // Update track with optimistic metadata immediately
-          useAudioStore.getState().updateTrack(id, {
-            metadata: optimisticMetadata,
-            duration: optimisticMetadata.duration || 0,
-            artwork,
-            isLoading: false,
-          })
-
-          // Show verification status if not verified
-          if (!optimisticResult.metadata.verified) {
-            conditionalToast.info(`Loaded: ${optimisticMetadata.title} (verifying...)`)
-          } else {
-            conditionalToast.success(`Loaded: ${optimisticMetadata.title}`)
-          }
-
-          // Start background verification if not already verified
-          if (!optimisticResult.metadata.verified) {
-            startBackgroundVerification(file, optimisticKey, id)
-          }
-
-          return placeholder
+        if (!validateAudioFile(file)) {
+          throw new Error("Invalid audio file format");
         }
-      } catch (optimisticError) {
-        console.warn('⚠️ [OPTIMISTIC] Optimistic lookup failed, falling back to full extraction:', optimisticError)
-      }
 
-      // Fallback: Full metadata extraction
-      console.log('🔍 [METADATA] No optimistic cache hit, performing full extraction...')
-      
-      ;(async () => {
+        const id = crypto.randomUUID();
+        const startTime = performance.now();
+
+        // Create a Blob URL for immediate playback and remember it for cleanup.
+        const objectUrl = URL.createObjectURL(file);
+        objectUrlsRef.current.push(objectUrl);
+
+        // Create placeholder track for immediate UI feedback
+        const placeholder: AudioTrack = {
+          id,
+          file,
+          metadata: {
+            title: file.name.replace(/\.[^/.]+$/, ""),
+            artist: "Loading...",
+            album: "",
+            duration: 0,
+          },
+          duration: 0,
+          url: objectUrl,
+          isLoading: true,
+        };
+
+        addToPlaylist(placeholder);
+
+        const { playlist } = useAudioStore.getState();
+        if (playlist.length === 1) {
+          setCurrentTrack(placeholder);
+        }
+
+        // Fast path: Try optimistic metadata lookup
+        const optimisticKey = computeOptimisticKey(file.name, file.size);
+        console.log(
+          "🚀 [OPTIMISTIC] Checking optimistic cache for key:",
+          optimisticKey,
+        );
+
         try {
-          const arrayBuffer = await file.arrayBuffer()
-          const hash = await hashArrayBuffer(arrayBuffer)
-          let metadata: AudioMetadata
-          let artwork: ArtworkSource | undefined
+          const optimisticResult =
+            await optimisticMetadataStore.getOptimisticMetadata(
+              file.name,
+              file.size,
+            );
 
-          // Try to get cached metadata from IndexedDB (legacy fallback)
+          if (optimisticResult.metadata && optimisticResult.trackIndex) {
+            const cacheHitTime = performance.now() - startTime;
+            console.log(
+              `⚡ [OPTIMISTIC] Cache hit in ${cacheHitTime.toFixed(2)}ms for key:`,
+              optimisticKey,
+            );
+
+            // Convert optimistic metadata to AudioMetadata format
+            const optimisticMetadata: AudioMetadata = {
+              title: optimisticResult.metadata.title,
+              artist: optimisticResult.metadata.artist,
+              album: optimisticResult.metadata.album,
+              year: optimisticResult.metadata.year,
+              genre: optimisticResult.metadata.genre,
+              duration: optimisticResult.metadata.duration,
+              bitrate: optimisticResult.metadata.bitrate,
+              sample_rate: optimisticResult.metadata.sample_rate,
+              channels: optimisticResult.metadata.channels,
+              bit_depth: optimisticResult.metadata.bit_depth,
+              format: optimisticResult.metadata.format,
+              album_art: optimisticResult.artwork?.data,
+              album_art_mime:
+                optimisticResult.artwork?.mime_type ||
+                optimisticResult.metadata.album_art_mime,
+            };
+
+            // Create artwork source if available
+            let artwork: ArtworkSource | undefined;
+            if (optimisticResult.artwork) {
+              artwork = {
+                type: "embedded",
+                data: optimisticResult.artwork.data,
+                mimeType: optimisticResult.artwork.mime_type,
+                confidence: optimisticResult.metadata.verified ? 1.0 : 0.8,
+                metadata: {
+                  artist: optimisticMetadata.artist,
+                  album: optimisticMetadata.album,
+                  title: optimisticMetadata.title,
+                },
+              };
+            }
+
+            // Update track with optimistic metadata immediately
+            useAudioStore.getState().updateTrack(id, {
+              metadata: optimisticMetadata,
+              duration: optimisticMetadata.duration || 0,
+              artwork,
+              isLoading: false,
+            });
+
+            // Show verification status if not verified
+            if (!optimisticResult.metadata.verified) {
+              conditionalToast.info(
+                `Loaded: ${optimisticMetadata.title} (verifying...)`,
+              );
+            } else {
+              conditionalToast.success(`Loaded: ${optimisticMetadata.title}`);
+            }
+
+            // Start background verification if not already verified
+            if (!optimisticResult.metadata.verified) {
+              startBackgroundVerification(file, optimisticKey, id);
+            }
+
+            return placeholder;
+          }
+        } catch (optimisticError) {
+          console.warn(
+            "⚠️ [OPTIMISTIC] Optimistic lookup failed, falling back to full extraction:",
+            optimisticError,
+          );
+        }
+
+        // Fallback: Full metadata extraction
+        console.log(
+          "🔍 [METADATA] No optimistic cache hit, performing full extraction...",
+        );
+        (async () => {
           try {
-            const cachedMetadata = await metadataStore.getMetadata(hash)
-            if (cachedMetadata) {
-              console.log('📦 [METADATA] Found cached metadata in IndexedDB')
-              
-              // Convert stored metadata back to AudioMetadata format
-              metadata = {
-                title: cachedMetadata.title,
-                artist: cachedMetadata.artist,
-                album: cachedMetadata.album,
-                year: cachedMetadata.year,
-                genre: cachedMetadata.genre || '',
-                duration: cachedMetadata.duration,
-                bitrate: cachedMetadata.bitrate,
-                sample_rate: cachedMetadata.sample_rate,
-                channels: cachedMetadata.channels,
-                bit_depth: cachedMetadata.bit_depth,
-                format: cachedMetadata.format,
-                album_art: undefined, // Will be loaded separately if needed
-                album_art_mime: cachedMetadata.album_art_mime
-              }
+            const arrayBuffer = await file.arrayBuffer();
+            const hash = await hashArrayBuffer(arrayBuffer);
+            let metadata: AudioMetadata;
+            let artwork: ArtworkSource | undefined;
 
-              // Load album art if available
-              if (cachedMetadata.album_art_hash) {
-                const albumArt = await metadataStore.getAlbumArt(cachedMetadata.album_art_hash)
-                if (albumArt) {
-                  metadata.album_art = albumArt.data
-                  metadata.album_art_mime = albumArt.mime_type
-                  
-                  // Create artwork source for UI
-                  artwork = {
-                    type: 'embedded',
-                    data: albumArt.data,
-                    mimeType: albumArt.mime_type,
-                    confidence: 1.0,
-                    metadata: {
-                      artist: metadata.artist,
-                      album: metadata.album,
-                      title: metadata.title
-                    }
+            // Try to get cached metadata from IndexedDB (legacy fallback)
+            try {
+              const cachedMetadata = await metadataStore.getMetadata(hash);
+              if (cachedMetadata) {
+                console.log("📦 [METADATA] Found cached metadata in IndexedDB");
+
+                // Convert stored metadata back to AudioMetadata format
+                metadata = {
+                  title: cachedMetadata.title,
+                  artist: cachedMetadata.artist,
+                  album: cachedMetadata.album,
+                  year: cachedMetadata.year,
+                  genre: cachedMetadata.genre || "",
+                  duration: cachedMetadata.duration,
+                  bitrate: cachedMetadata.bitrate,
+                  sample_rate: cachedMetadata.sample_rate,
+                  channels: cachedMetadata.channels,
+                  bit_depth: cachedMetadata.bit_depth,
+                  format: cachedMetadata.format,
+                  album_art: undefined, // Will be loaded separately if needed
+                  album_art_mime: cachedMetadata.album_art_mime,
+                };
+
+                // Load album art if available
+                if (cachedMetadata.album_art_hash) {
+                  const albumArt = await metadataStore.getAlbumArt(
+                    cachedMetadata.album_art_hash,
+                  );
+                  if (albumArt) {
+                    metadata.album_art = albumArt.data;
+                    metadata.album_art_mime = albumArt.mime_type;
+
+                    // Create artwork source for UI
+                    artwork = {
+                      type: "embedded",
+                      data: albumArt.data,
+                      mimeType: albumArt.mime_type,
+                      confidence: 1.0,
+                      metadata: {
+                        artist: metadata.artist,
+                        album: metadata.album,
+                        title: metadata.title,
+                      },
+                    };
                   }
                 }
-              }
-            } else {
-              // No cached metadata, extract it
-              console.log('🔍 [METADATA] No cached metadata found, extracting...')
-              metadata = await parseMetadata(file)
-              const artworkResult = await extractArtwork(metadata, file.name, arrayBuffer)
-              artwork = artworkResult.artwork
+              } else {
+                // No cached metadata, extract it
+                console.log(
+                  "🔍 [METADATA] No cached metadata found, extracting...",
+                );
+                metadata = await parseMetadata(file);
+                const artworkResult = await extractArtwork(
+                  metadata,
+                  file.name,
+                  arrayBuffer,
+                );
+                artwork = artworkResult.artwork;
 
-              // Store in both legacy and optimistic stores
+                // Store in both legacy and optimistic stores
+                try {
+                  console.log("💾 [METADATA] Storing metadata in IndexedDB...");
+                  const { metadataId, albumArtId } =
+                    await metadataStore.storeMetadata(
+                      file,
+                      metadata,
+                      arrayBuffer,
+                    );
+                  console.log("✅ [METADATA] Metadata stored successfully:", {
+                    metadataId,
+                    albumArtId,
+                  });
+
+                  // Also store in optimistic cache
+                  await optimisticMetadataStore.storeOptimisticMetadata(
+                    file.name,
+                    file.size,
+                    metadata,
+                    arrayBuffer,
+                  );
+                  console.log(
+                    "✅ [OPTIMISTIC] Metadata stored in optimistic cache",
+                  );
+                } catch (storeError) {
+                  console.error(
+                    "❌ [METADATA] Failed to store metadata:",
+                    storeError,
+                  );
+                  // Continue without storing - metadata is still available for this session
+                }
+              }
+            } catch (dbError) {
+              console.error(
+                "❌ [METADATA] IndexedDB error, falling back to extraction:",
+                dbError,
+              );
+              // Fallback to extraction if IndexedDB fails
+              metadata = await parseMetadata(file);
+              const artworkResult = await extractArtwork(
+                metadata,
+                file.name,
+                arrayBuffer,
+              );
+              artwork = artworkResult.artwork;
+
+              // Store in optimistic cache
               try {
-                console.log('💾 [METADATA] Storing metadata in IndexedDB...')
-                const { metadataId, albumArtId } = await metadataStore.storeMetadata(file, metadata, arrayBuffer)
-                console.log('✅ [METADATA] Metadata stored successfully:', { metadataId, albumArtId })
-                
-                // Also store in optimistic cache
-                await optimisticMetadataStore.storeOptimisticMetadata(file.name, file.size, metadata, arrayBuffer)
-                console.log('✅ [OPTIMISTIC] Metadata stored in optimistic cache')
-              } catch (storeError) {
-                console.error('❌ [METADATA] Failed to store metadata:', storeError)
-                // Continue without storing - metadata is still available for this session
+                await optimisticMetadataStore.storeOptimisticMetadata(
+                  file.name,
+                  file.size,
+                  metadata,
+                  arrayBuffer,
+                );
+              } catch (optimisticError) {
+                console.warn(
+                  "⚠️ [OPTIMISTIC] Failed to store in optimistic cache:",
+                  optimisticError,
+                );
               }
             }
-          } catch (dbError) {
-            console.error('❌ [METADATA] IndexedDB error, falling back to extraction:', dbError)
-            // Fallback to extraction if IndexedDB fails
-            metadata = await parseMetadata(file)
-            const artworkResult = await extractArtwork(metadata, file.name, arrayBuffer)
-            artwork = artworkResult.artwork
-            
-            // Store in optimistic cache
-            try {
-              await optimisticMetadataStore.storeOptimisticMetadata(file.name, file.size, metadata, arrayBuffer)
-            } catch (optimisticError) {
-              console.warn('⚠️ [OPTIMISTIC] Failed to store in optimistic cache:', optimisticError)
-            }
-          }
 
-          const audioData = await generateAmplitudeEnvelopeData(file, metadata, arrayBuffer)
+            const audioData = await generateAmplitudeEnvelopeData(
+              file,
+              metadata,
+              arrayBuffer,
+            );
 
-          useAudioStore.getState().updateTrack(id, {
-            metadata: {
-              title: metadata.title || file.name.replace(/\.[^/.]+$/, ''),
-              artist: metadata.artist || 'Unknown Artist',
-              album: metadata.album || 'Unknown Album',
-              year: metadata.year ? parseInt(metadata.year.toString()) : undefined,
-              genre: metadata.genre || '',
+            useAudioStore.getState().updateTrack(id, {
+              metadata: {
+                title: metadata.title || file.name.replace(/\.[^/.]+$/, ""),
+                artist: metadata.artist || "Unknown Artist",
+                album: metadata.album || "Unknown Album",
+                year: metadata.year
+                  ? parseInt(metadata.year.toString())
+                  : undefined,
+                genre: metadata.genre || "",
+                duration: metadata.duration || 0,
+                bitrate: metadata.bitrate || 0,
+                sample_rate: metadata.sample_rate || 0,
+                channels: metadata.channels || 0,
+                album_art: metadata.album_art,
+                album_art_mime: metadata.album_art_mime,
+              },
               duration: metadata.duration || 0,
-              bitrate: metadata.bitrate || 0,
-              sample_rate: metadata.sample_rate || 0,
-              channels: metadata.channels || 0,
-              album_art: metadata.album_art,
-              album_art_mime: metadata.album_art_mime,
-            },
-            duration: metadata.duration || 0,
-            audioData,
-            artwork,
-            isLoading: false,
-          })
-          
-          const totalTime = performance.now() - startTime
-          console.log(`✅ [METADATA] Full extraction completed in ${totalTime.toFixed(2)}ms`)
-          conditionalToast.success(`Loaded: ${metadata.title || file.name.replace(/\.[^/.]+$/, '')}`)
-        } catch (error) {
-          const errorMessage = error instanceof Error ? error.message : 'Failed to load audio file'
-          setError(errorMessage)
-          conditionalToast.error(errorMessage)
-          useAudioStore.getState().updateTrack(id, { isLoading: false })
-        }
-      })()
+              audioData,
+              artwork,
+              isLoading: false,
+            });
 
-      return placeholder
-    } catch (error) {
-      const errorMessage = error instanceof Error ? error.message : 'Failed to load audio file'
-      setError(errorMessage)
-      conditionalToast.error(errorMessage)
-      throw error
-    } finally {
-      setIsLoading(false)
-    }
-  }, [validateAudioFile, parseMetadata, generateAmplitudeEnvelopeData, addToPlaylist, setCurrentTrack, startBackgroundVerification])
+            const totalTime = performance.now() - startTime;
+            console.log(
+              `✅ [METADATA] Full extraction completed in ${totalTime.toFixed(2)}ms`,
+            );
+            conditionalToast.success(
+              `Loaded: ${metadata.title || file.name.replace(/\.[^/.]+$/, "")}`,
+            );
+          } catch (error) {
+            const errorMessage =
+              error instanceof Error
+                ? error.message
+                : "Failed to load audio file";
+            setError(errorMessage);
+            conditionalToast.error(errorMessage);
+            useAudioStore.getState().updateTrack(id, { isLoading: false });
+          }
+        })();
+
+        return placeholder;
+      } catch (error) {
+        const errorMessage =
+          error instanceof Error ? error.message : "Failed to load audio file";
+        setError(errorMessage);
+        conditionalToast.error(errorMessage);
+        throw error;
+      } finally {
+        setIsLoading(false);
+      }
+    },
+    [
+      validateAudioFile,
+      parseMetadata,
+      generateAmplitudeEnvelopeData,
+      addToPlaylist,
+      setCurrentTrack,
+      startBackgroundVerification,
+    ],
+  );
 
   // Load multiple audio files
-  const loadAudioFiles = useCallback(async (files: FileList | File[]): Promise<AudioTrack[]> => {
-    setIsLoading(true)
-    setError(null)
+  const loadAudioFiles = useCallback(
+    async (files: FileList | File[]): Promise<AudioTrack[]> => {
+      setIsLoading(true);
+      setError(null);
 
-    try {
-      const fileArray = Array.from(files)
-      const validFiles = fileArray.filter(validateAudioFile)
-      const invalidFiles = fileArray.filter(file => !validateAudioFile(file))
+      try {
+        const fileArray = Array.from(files);
+        const validFiles = fileArray.filter(validateAudioFile);
+        const invalidFiles = fileArray.filter(
+          (file) => !validateAudioFile(file),
+        );
 
-      if (validFiles.length === 0) {
-        throw new Error('No valid audio files found')
-      }
-
-      const results = await Promise.all(
-        validFiles.map(async (file) => {
-          try {
-            return await loadAudioFile(file)
-          } catch {
-            return null
-          }
-        })
-      )
-
-      const tracks = results.filter((t): t is AudioTrack => t !== null)
-
-      if (tracks.length > 0) {
-        const { currentTrack } = useAudioStore.getState()
-        if (!currentTrack) {
-          setCurrentTrack(tracks[0])
+        if (validFiles.length === 0) {
+          throw new Error("No valid audio files found");
         }
+
+        const results = await Promise.all(
+          validFiles.map(async (file) => {
+            try {
+              return await loadAudioFile(file);
+            } catch {
+              return null;
+            }
+          }),
+        );
+
+        const tracks = results.filter((t): t is AudioTrack => t !== null);
+
+        if (tracks.length > 0) {
+          const { currentTrack } = useAudioStore.getState();
+          if (!currentTrack) {
+            setCurrentTrack(tracks[0]);
+          }
+        }
+
+        const successMessage = `Loaded ${tracks.length} audio file${tracks.length > 1 ? "s" : ""}`;
+        if (invalidFiles.length > 0) {
+          conditionalToast.success(
+            `${successMessage} (${invalidFiles.length} skipped)`,
+          );
+        } else {
+          conditionalToast.success(successMessage);
+        }
+
+        return tracks;
+      } catch (error) {
+        const errorMessage =
+          error instanceof Error ? error.message : "Failed to load audio files";
+        setError(errorMessage);
+        conditionalToast.error(errorMessage);
+        throw error;
+      } finally {
+        setIsLoading(false);
       }
-
-      const successMessage = `Loaded ${tracks.length} audio file${tracks.length > 1 ? 's' : ''}`
-      if (invalidFiles.length > 0) {
-        conditionalToast.success(`${successMessage} (${invalidFiles.length} skipped)`)
-      } else {
-        conditionalToast.success(successMessage)
-      }
-
-      return tracks
-
-    } catch (error) {
-      const errorMessage = error instanceof Error ? error.message : 'Failed to load audio files'
-      setError(errorMessage)
-      conditionalToast.error(errorMessage)
-      throw error
-    } finally {
-      setIsLoading(false)
-    }
-  }, [validateAudioFile, loadAudioFile, setCurrentTrack])
+    },
+    [validateAudioFile, loadAudioFile, setCurrentTrack],
+  );
 
   // Play audio track
   const playTrack = useCallback(async (track: AudioTrack) => {
     try {
-      await audioPlayer.playTrack(track)
+      await audioPlayer.playTrack(track);
     } catch (error) {
-      conditionalToast.error('Failed to play audio track')
-      throw error
+      conditionalToast.error("Failed to play audio track");
+      throw error;
     }
-  }, [])
+  }, []);
 
   // Stop playback
   const stopPlayback = useCallback(() => {
-    audioPlayer.stopPlayback()
-  }, [])
+    audioPlayer.stopPlayback();
+  }, []);
 
   // Pause playback
   const pausePlayback = useCallback(() => {
-    audioPlayer.pausePlayback()
-  }, [])
+    audioPlayer.pausePlayback();
+  }, []);
 
   // Resume playback
   const resumePlayback = useCallback(() => {
-    audioPlayer.resumePlayback()
-  }, [])
+    audioPlayer.resumePlayback();
+  }, []);
 
   // Seek to position
   const seekTo = useCallback((time: number) => {
-    audioPlayer.seekTo(time)
-  }, [])
+    audioPlayer.seekTo(time);
+  }, []);
 
   // Set volume
   const setAudioVolume = useCallback((volume: number) => {
-    audioPlayer.setVolume(volume)
-  }, [])
+    audioPlayer.setVolume(volume);
+  }, []);
 
   // Toggle mute
   const toggleMute = useCallback(() => {
-    audioPlayer.toggleMute()
-  }, [])
+    audioPlayer.toggleMute();
+  }, []);
 
   // Get frequency data for spectrogram
   const getFrequencyData = useCallback(() => {
-    return audioPlayer.getFrequencyData()
-  }, [])
+    return audioPlayer.getFrequencyData();
+  }, []);
 
   // Get time domain data
   const getTimeData = useCallback(() => {
-    return audioPlayer.getTimeData()
-  }, [])
+    return audioPlayer.getTimeData();
+  }, []);
 
   // Initialize audio context
   const initAudioContext = useCallback(async () => {
-    return await audioPlayer.initAudioContext()
-  }, [])
+    return await audioPlayer.initAudioContext();
+  }, []);
 
   // Cleanup
   const cleanup = useCallback(() => {
     if (unsubscribeRef.current) {
-      unsubscribeRef.current()
+      unsubscribeRef.current();
     }
-    audioPlayer.cleanup()
-  }, [])
+    revokeAllObjectUrls();
+    audioPlayer.cleanup();
+  }, [revokeAllObjectUrls]);
 
   return {
     isLoading,
@@ -637,6 +819,6 @@ export const useAudioFile = () => {
     getTimeData,
     cleanup,
     initAudioContext,
-    startBackgroundVerification
-  }
-}
+    startBackgroundVerification,
+  };
+};


### PR DESCRIPTION
## Summary
- ensure object URLs are revoked on hook unmount or cleanup
- propagate array buffer and decode failures for audio data
- add unit tests for cleanup and error handling

## Testing
- `npm test` (fails: required_features_enabled)
- `npm run lint` (fails: Missing script "lint")
- `cd web/apps/mfe-spectrogram && npm test` (fails: Playwright Test did not expect test.describe())

------
https://chatgpt.com/codex/tasks/task_e_68a7887c7f70832bb8ef8bf7f60a4cd9