### PR TITLE
Handle SpectrogramCanvas resize limits and context loss

### DIFF
--- a/web/apps/mfe-spectrogram/src/components/__tests__/SpectrogramCanvas.test.tsx
+++ b/web/apps/mfe-spectrogram/src/components/__tests__/SpectrogramCanvas.test.tsx
@@ -1,0 +1,59 @@
+import React, { createRef } from 'react'
+import { render, screen } from '@testing-library/react'
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import {
+  SpectrogramCanvas,
+  SpectrogramCanvasRef,
+  FALLBACK_MAX_CANVAS_SIZE
+} from '../spectrogram/SpectrogramCanvas'
+
+vi.mock('../../shared/stores/settingsStore', () => ({
+  useSettingsStore: () => ({
+    theme: 'japanese-a-light',
+    amplitudeScale: 'linear',
+    refreshRate: 60
+  })
+}))
+
+describe('SpectrogramCanvas', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks()
+    ;(global as any).requestAnimationFrame = (cb: FrameRequestCallback) => setTimeout(cb, 0)
+    ;(global as any).cancelAnimationFrame = (id: number) => clearTimeout(id)
+  })
+
+  it('clamps canvas size to device limit on resize', () => {
+    const ref = createRef<SpectrogramCanvasRef>()
+    render(<SpectrogramCanvas ref={ref} />)
+    const canvas = ref.current?.getCanvas() as HTMLCanvasElement
+    vi.spyOn(canvas, 'getBoundingClientRect').mockReturnValue({
+      width: FALLBACK_MAX_CANVAS_SIZE * 2,
+      height: FALLBACK_MAX_CANVAS_SIZE * 2,
+      top: 0,
+      left: 0,
+      bottom: 0,
+      right: 0
+    } as DOMRect)
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    ref.current?.resize()
+    expect(canvas.width).toBe(FALLBACK_MAX_CANVAS_SIZE)
+    expect(canvas.height).toBe(FALLBACK_MAX_CANVAS_SIZE)
+    expect(warnSpy).toHaveBeenCalled()
+  })
+
+  it('handles WebGL context loss and restoration', () => {
+    const getContextSpy = vi
+      .spyOn(HTMLCanvasElement.prototype, 'getContext')
+      .mockReturnValue(null)
+    const cancelSpy = vi.spyOn(global, 'cancelAnimationFrame')
+    render(<SpectrogramCanvas />)
+    const canvas = screen.getByTestId('spectrogram-canvas') as HTMLCanvasElement
+    const lost = new Event('webglcontextlost', { cancelable: true })
+    canvas.dispatchEvent(lost)
+    expect(lost.defaultPrevented).toBe(true)
+    expect(cancelSpy).toHaveBeenCalled()
+    const initialCalls = getContextSpy.mock.calls.length
+    canvas.dispatchEvent(new Event('webglcontextrestored'))
+    expect(getContextSpy.mock.calls.length).toBeGreaterThan(initialCalls)
+  })
+})

--- a/web/apps/mfe-spectrogram/src/components/spectrogram/SpectrogramCanvas.tsx
+++ b/web/apps/mfe-spectrogram/src/components/spectrogram/SpectrogramCanvas.tsx
@@ -2,6 +2,19 @@ import React, { forwardRef, useEffect, useRef, useImperativeHandle, useCallback 
 import { useSettingsStore } from '@/shared/stores/settingsStore'
 import type { Theme } from '@/shared/types'
 
+/**
+ * Default maximum canvas dimension in pixels used when the device does not
+ * expose its WebGL limits. This conservative value prevents allocating
+ * excessively large buffers on constrained devices.
+ */
+export const FALLBACK_MAX_CANVAS_SIZE = 4096
+
+/**
+ * Duration in seconds that the spectrogram keeps in its scrolling history.
+ * This replaces previously inlined magic numbers to clarify intent.
+ */
+const TIME_WINDOW_SECONDS = 15
+
 interface SpectrogramCanvasProps {
   onMouseMove?: (event: React.MouseEvent<HTMLCanvasElement>) => void
   onMouseLeave?: () => void
@@ -27,12 +40,16 @@ export const SpectrogramCanvas = forwardRef<SpectrogramCanvasRef, SpectrogramCan
     const bufferRef = useRef<WebGLBuffer | null>(null)
     const animationFrameRef = useRef<number | null>(null)
     const webglSupportedRef = useRef(false)
+    // Tracks the maximum supported canvas dimension. Defaults to a safe value
+    // until a WebGL context reveals the precise device limit.
+    const maxTextureSizeRef = useRef<number>(FALLBACK_MAX_CANVAS_SIZE)
     
     const { theme, amplitudeScale, refreshRate } = useSettingsStore()
 
     // Spectrogram data storage
     const spectrogramDataRef = useRef<Uint8Array[]>([])
-    const maxFramesRef = useRef(15 * refreshRate) // 15 second time window
+    // Maximum number of frames maintained to cover TIME_WINDOW_SECONDS.
+    const maxFramesRef = useRef(TIME_WINDOW_SECONDS * refreshRate)
     const currentFrameRef = useRef(0)
 
     // Color maps for different themes
@@ -144,6 +161,9 @@ export const SpectrogramCanvas = forwardRef<SpectrogramCanvasRef, SpectrogramCan
 
       glRef.current = gl
       webglSupportedRef.current = true
+      // Record the device's maximum supported texture size to avoid exceeding
+      // hardware limits during future resizes.
+      maxTextureSizeRef.current = gl.getParameter(gl.MAX_TEXTURE_SIZE) || FALLBACK_MAX_CANVAS_SIZE
 
       // Create shaders
       const vertexShaderSource = `
@@ -273,6 +293,12 @@ export const SpectrogramCanvas = forwardRef<SpectrogramCanvasRef, SpectrogramCan
     }, [checkWebGLSupport])
 
     // Resize canvas
+    /**
+     * Resizes the backing canvas buffer to match its on-screen dimensions while
+     * respecting hardware-imposed limits. The function fails fast on invalid
+     * metrics and clamps oversized requests to the maximum supported texture
+     * size to avoid costly allocations or WebGL errors.
+     */
     const resizeCanvas = useCallback(() => {
       const canvas = canvasRef.current
       if (!canvas) return
@@ -280,8 +306,23 @@ export const SpectrogramCanvas = forwardRef<SpectrogramCanvasRef, SpectrogramCan
       const rect = canvas.getBoundingClientRect()
       const pixelRatio = window.devicePixelRatio || 1
 
-      canvas.width = rect.width * pixelRatio
-      canvas.height = rect.height * pixelRatio
+      let targetWidth = rect.width * pixelRatio
+      let targetHeight = rect.height * pixelRatio
+
+      if (!isFinite(targetWidth) || !isFinite(targetHeight) || targetWidth <= 0 || targetHeight <= 0) {
+        console.warn('SpectrogramCanvas: invalid canvas size computed during resize')
+        return
+      }
+
+      const maxSize = maxTextureSizeRef.current
+      if (targetWidth > maxSize || targetHeight > maxSize) {
+        console.warn(`SpectrogramCanvas: clamping canvas to device limit ${maxSize}`)
+        targetWidth = Math.min(targetWidth, maxSize)
+        targetHeight = Math.min(targetHeight, maxSize)
+      }
+
+      canvas.width = targetWidth
+      canvas.height = targetHeight
       canvas.style.width = rect.width + 'px'
       canvas.style.height = rect.height + 'px'
 
@@ -406,6 +447,40 @@ export const SpectrogramCanvas = forwardRef<SpectrogramCanvasRef, SpectrogramCan
       }
     }, [initWebGL, resizeCanvas, animate])
 
+    /**
+     * Reacts to WebGL context loss events by halting rendering and attempts to
+     * reinitialise the pipeline once the context is restored. This guards
+     * against driver resets and resource exhaustion on unstable devices.
+     */
+    useEffect(() => {
+      const canvas = canvasRef.current
+      if (!canvas) return
+
+      const handleContextLost = (event: Event) => {
+        event.preventDefault()
+        if (animationFrameRef.current !== null) {
+          cancelAnimationFrame(animationFrameRef.current)
+          animationFrameRef.current = null
+        }
+        webglSupportedRef.current = false
+      }
+
+      const handleContextRestored = () => {
+        if (initWebGL()) {
+          resizeCanvas()
+        }
+        animate()
+      }
+
+      canvas.addEventListener('webglcontextlost', handleContextLost as EventListener)
+      canvas.addEventListener('webglcontextrestored', handleContextRestored as EventListener)
+
+      return () => {
+        canvas.removeEventListener('webglcontextlost', handleContextLost as EventListener)
+        canvas.removeEventListener('webglcontextrestored', handleContextRestored as EventListener)
+      }
+    }, [initWebGL, resizeCanvas, animate])
+
     // Handle window resize
     useEffect(() => {
       const handleResize = () => {
@@ -418,7 +493,7 @@ export const SpectrogramCanvas = forwardRef<SpectrogramCanvasRef, SpectrogramCan
 
     // Update max frames when refresh rate changes
     useEffect(() => {
-      maxFramesRef.current = 15 * refreshRate // 15 second time window
+      maxFramesRef.current = TIME_WINDOW_SECONDS * refreshRate
       
       // Trim data if needed
       if (spectrogramDataRef.current.length > maxFramesRef.current) {

--- a/web/apps/mfe-spectrogram/src/components/spectrogram/SpectrogramCanvas.tsx
+++ b/web/apps/mfe-spectrogram/src/components/spectrogram/SpectrogramCanvas.tsx
@@ -469,7 +469,11 @@ export const SpectrogramCanvas = forwardRef<SpectrogramCanvasRef, SpectrogramCan
         if (initWebGL()) {
           resizeCanvas()
         }
-        animate()
+          animate()
+        } else {
+          // Fallback: just start animation loop for non-WebGL environments
+          animate()
+        }
       }
 
       canvas.addEventListener('webglcontextlost', handleContextLost as EventListener)


### PR DESCRIPTION
## Summary
- clamp canvas dimensions to device WebGL limits and sanitize invalid sizes
- restart rendering when WebGL context is lost and restored
- add regression tests for oversize resize events and context loss

## Testing
- `npm test` *(fails: requestAnimationFrame is not defined; multiple existing test failures)*
- `npm run lint` *(fails: Missing script: "lint")*

------
https://chatgpt.com/codex/tasks/task_e_68a7884cd3e8832b883321dd64e59dc0