### PR TITLE
feat(shell): add fade-in opacity for Japanese layout sections

### DIFF
--- a/web/apps/shell/src/themes/japanese/JapaneseLayout.test.tsx
+++ b/web/apps/shell/src/themes/japanese/JapaneseLayout.test.tsx
@@ -1,8 +1,14 @@
 import React from "react";
 import { describe, it, expect } from "vitest";
-import { render } from "@testing-library/react";
+import { render, waitFor } from "@testing-library/react";
 import { JapaneseLayout } from "./JapaneseLayout";
 import { LAYOUT_GAP_REM } from "../../ui/Spacing";
+
+/** Style opacity representing transparent state before fade-in. */
+const OPACITY_TRANSPARENT = "0" as const;
+
+/** Style opacity representing opaque state after fade-in. */
+const OPACITY_OPAQUE = "1" as const;
 
 /** Validate JapaneseLayout behaviour and structure. */
 describe("JapaneseLayout", () => {
@@ -18,6 +24,23 @@ describe("JapaneseLayout", () => {
     const root = container.firstChild as HTMLElement;
     expect(root.style.display).toBe("flex");
     expect(root.style.gap).toBe(`${LAYOUT_GAP_REM}rem`);
+  });
+
+  it("fades sections from transparent to opaque", async () => {
+    const { container } = render(
+      <JapaneseLayout header={<div>H</div>} footer={<div>F</div>}>
+        <p>C</p>
+      </JapaneseLayout>,
+    );
+    const [header, main, footer] = Array.from(
+      container.querySelectorAll("header, main, footer"),
+    ) as HTMLElement[];
+    expect(header.style.opacity).toBe(OPACITY_TRANSPARENT);
+    expect(main.style.opacity).toBe(OPACITY_TRANSPARENT);
+    expect(footer.style.opacity).toBe(OPACITY_TRANSPARENT);
+    await waitFor(() => expect(header.style.opacity).toBe(OPACITY_OPAQUE));
+    await waitFor(() => expect(main.style.opacity).toBe(OPACITY_OPAQUE));
+    await waitFor(() => expect(footer.style.opacity).toBe(OPACITY_OPAQUE));
   });
 
   it("throws on missing required props", () => {

--- a/web/apps/shell/src/themes/japanese/useMinimalFades.test.ts
+++ b/web/apps/shell/src/themes/japanese/useMinimalFades.test.ts
@@ -1,19 +1,32 @@
 import { describe, it, expect } from "vitest";
-import { renderHook } from "@testing-library/react";
+import { renderHook, waitFor } from "@testing-library/react";
 import { useMinimalFades } from "./useMinimalFades";
 import { FADE_DURATION_MS } from "../../ui/AnimationDurations";
 
+/** Style opacity representing transparency at mount. */
+const OPACITY_TRANSPARENT = 0 as const;
+
+/** Style opacity representing full visibility after fade completes. */
+const OPACITY_OPAQUE = 1 as const;
+
 /** Validate behaviour of the fade hook. */
 describe("useMinimalFades", () => {
-  it("returns transition style with configured duration", () => {
+  it("starts transparent, fades in and exposes configured transition", async () => {
     const { result } = renderHook(() => useMinimalFades());
+    expect(result.current.style.opacity).toBe(OPACITY_TRANSPARENT);
     expect(result.current.style.transition).toBe(
       `opacity ${FADE_DURATION_MS}ms ease-in-out`,
     );
+    await waitFor(() =>
+      expect(result.current.style.opacity).toBe(OPACITY_OPAQUE),
+    );
   });
 
-  it("memoises the style object to avoid allocations", () => {
+  it("memoises the style object after fade completion", async () => {
     const { result, rerender } = renderHook(() => useMinimalFades());
+    await waitFor(() =>
+      expect(result.current.style.opacity).toBe(OPACITY_OPAQUE),
+    );
     const first = result.current.style;
     rerender();
     expect(result.current.style).toBe(first);

--- a/web/apps/shell/src/themes/japanese/useMinimalFades.ts
+++ b/web/apps/shell/src/themes/japanese/useMinimalFades.ts
@@ -1,6 +1,14 @@
-import { useMemo } from "react";
-import { CSSProperties } from "react";
+import { CSSProperties, useEffect, useMemo, useState } from "react";
 import { FADE_DURATION_MS } from "../../ui/AnimationDurations";
+
+/** Opacity at component mount ensuring content is initially hidden. */
+const INITIAL_OPACITY = 0 as const;
+
+/** Target opacity reached after the fade-in completes. */
+const TARGET_OPACITY = 1 as const;
+
+/** Delay before the fade-in starts allowing the initial paint. */
+const FADE_DELAY_MS = 0 as const;
 
 /**
  * Hook producing memoised style props for minimal fade transitions.
@@ -9,9 +17,22 @@ import { FADE_DURATION_MS } from "../../ui/AnimationDurations";
  * garbage collection pressure during re-renders.
  */
 export function useMinimalFades(): { readonly style: CSSProperties } {
+  const [opacity, setOpacity] = useState<number>(INITIAL_OPACITY);
+
+  // Trigger a single fade-in once the component has mounted. The update is
+  // deferred to the next task to ensure callers observe the initial
+  // transparency before the transition begins.
+  useEffect(() => {
+    const handle = setTimeout(() => setOpacity(TARGET_OPACITY), FADE_DELAY_MS);
+    return () => clearTimeout(handle);
+  }, []);
+
   const style = useMemo<CSSProperties>(
-    () => ({ transition: `opacity ${FADE_DURATION_MS}ms ease-in-out` }),
-    [],
+    () => ({
+      opacity,
+      transition: `opacity ${FADE_DURATION_MS}ms ease-in-out`,
+    }),
+    [opacity],
   );
   return { style };
 }


### PR DESCRIPTION
## Summary
- add local opacity state with delayed fade-in to `useMinimalFades`
- verify layout sections start transparent then become opaque
- test `useMinimalFades` for initial transparency and memoization

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a79615eb00832b8de8992daf573123