### PR TITLE
feat(shell): apply accent variable in design toggle

### DIFF
--- a/web/apps/shell/src/DesignToggle.test.tsx
+++ b/web/apps/shell/src/DesignToggle.test.tsx
@@ -48,6 +48,35 @@ describe("DesignToggle", () => {
     expect(document.documentElement.getAttribute("data-mode")).toBe("dark");
   });
 
+  /** Japanese Option B should expose the red accent colour in all modes. */
+  it.each(["light", "dark"] as const)(
+    "applies red accent for Option B in %s mode",
+    (mode) => {
+      const { getByTestId } = renderWithProvider();
+      fireEvent.change(getByTestId("design-select"), {
+        target: { value: "japanese-b" },
+      });
+      fireEvent.change(getByTestId("mode-select"), { target: { value: mode } });
+      const accent = rootStyles().getPropertyValue("--color-accent").trim();
+      expect(accent).toBe(PALETTES["japanese-b"][mode].accent);
+    },
+  );
+
+  /** Option A remains monochrome and must not adopt the red accent. */
+  it.each(["light", "dark"] as const)(
+    "keeps Option A monochrome in %s mode",
+    (mode) => {
+      const { getByTestId } = renderWithProvider();
+      fireEvent.change(getByTestId("design-select"), {
+        target: { value: "japanese-a" },
+      });
+      fireEvent.change(getByTestId("mode-select"), { target: { value: mode } });
+      const accent = rootStyles().getPropertyValue("--color-accent").trim();
+      expect(accent).toBe(PALETTES["japanese-a"][mode].accent);
+      expect(accent).not.toBe(PALETTES["japanese-b"][mode].accent);
+    },
+  );
+
   /**
    * Switching away from Bauhaus should remove secondary and tertiary colour
    * variables so that minimalist designs remain free of unused values.

--- a/web/apps/shell/src/DesignToggle.tsx
+++ b/web/apps/shell/src/DesignToggle.tsx
@@ -6,6 +6,9 @@ import { PALETTES } from "./designs";
 /** Consistent spacing for the toggle container. */
 const CONTROL_SPACING = "0.5rem" as const;
 
+/** CSS variable exposing the theme's primary accent colour. */
+const ACCENT_VAR = "var(--color-accent)" as const;
+
 /**
  * Lookup set of allowed design identifiers. Using a Set provides constant
  * time membership checks and avoids repeatedly allocating arrays on each
@@ -71,13 +74,20 @@ export function DesignToggle() {
   };
 
   return (
-    <div style={{ padding: CONTROL_SPACING, display: "flex", gap: CONTROL_SPACING }}>
+    <div
+      style={{
+        padding: CONTROL_SPACING,
+        display: "flex",
+        gap: CONTROL_SPACING,
+      }}
+    >
       <label>
         Design:
         <select
           value={design}
           onChange={handleDesignChange}
           data-testid="design-select"
+          style={{ color: ACCENT_VAR, borderColor: ACCENT_VAR }}
         >
           <option value="japanese-a">Japanese A</option>
           <option value="japanese-b">Japanese B</option>
@@ -90,6 +100,7 @@ export function DesignToggle() {
           value={mode}
           onChange={handleModeChange}
           data-testid="mode-select"
+          style={{ color: ACCENT_VAR, borderColor: ACCENT_VAR }}
         >
           <option value="light">Light</option>
           <option value="dark">Dark</option>


### PR DESCRIPTION
## Summary
- use var(--color-accent) for design and mode selects
- test Japanese Option B red accents and Option A monochrome behavior

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a7961ad204832bb970981f0371f281