### PR TITLE
refactor: validate palette and test malformed inputs

### DIFF
--- a/web/apps/shell/src/DesignContext.test.tsx
+++ b/web/apps/shell/src/DesignContext.test.tsx
@@ -91,9 +91,22 @@ describe("DesignProvider", () => {
   });
 
   it("throws on invalid palette", () => {
-    expect(() => applyPalette(undefined as unknown as any)).toThrow(
-      /valid palette/,
-    );
-    expect(() => applyPalette({} as any)).toThrow(/valid palette/);
+    /** Regular expression matching palette validation errors. */
+    const ERR_RE = /valid palette/;
+    /**
+     * Palettes intentionally missing required fields or providing
+     * incorrect types. Each entry exercises a separate validation path.
+     */
+    const badPalettes = [
+      undefined,
+      {},
+      { background: "#fff", text: "#000" },
+      { background: "#fff", accent: "#000" },
+      { text: "#000", accent: "#fff" },
+      { background: "#fff", text: "#000", accent: 123 },
+    ] as const;
+    for (const p of badPalettes) {
+      expect(() => applyPalette(p as any)).toThrow(ERR_RE);
+    }
   });
 });

--- a/web/apps/shell/src/DesignContext.tsx
+++ b/web/apps/shell/src/DesignContext.tsx
@@ -36,23 +36,25 @@ const VAR_SECONDARY = "--color-secondary" as const;
 /** Name of the CSS variable for tertiary accent colour. */
 const VAR_TERTIARY = "--color-tertiary" as const;
 
+/** Error thrown when palette validation fails. */
+const ERR_INVALID_PALETTE =
+  "applyPalette requires a valid palette with background, text, and accent properties" as const;
+
 /**
  * Apply a palette to the document root.
- * Fails fast when invoked without a palette and removes optional colours when
- * absent. Explicit removal prevents stale values from previous designs from
- * leaking into the current theme.
+ * Validates required fields and types, failing fast to avoid writing
+ * undefined CSS values. Optional colours are explicitly removed when absent
+ * to prevent stale values from leaking between designs.
  */
 export function applyPalette(palette: Palette): void {
   if (
     !palette ||
     typeof palette !== "object" ||
-    !("background" in palette) ||
-    !("text" in palette) ||
-    !("accent" in palette)
+    typeof (palette as any).background !== "string" ||
+    typeof (palette as any).text !== "string" ||
+    typeof (palette as any).accent !== "string"
   ) {
-    throw new Error(
-      "applyPalette requires a valid palette with background, text, and accent properties",
-    );
+    throw new Error(ERR_INVALID_PALETTE);
   }
   const root = document.documentElement;
   root.style.setProperty(VAR_BG, palette.background);


### PR DESCRIPTION
## Summary
- centralize palette validation into a single block with type checks
- add tests ensuring malformed palettes trigger validation errors

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a79e255688832bbed7c4b80a0c7e5c