### PR TITLE
Use shared spacing constants in DesignToggle

### DIFF
--- a/web/apps/shell/src/DesignToggle.test.tsx
+++ b/web/apps/shell/src/DesignToggle.test.tsx
@@ -5,6 +5,7 @@ import { DesignProvider } from "./DesignContext";
 import { DesignToggle, applyDesign, applyMode, parseDesign, parseMode } from "./DesignToggle";
 import type { Design, Mode } from "./designs";
 import { PALETTES } from "./designs";
+import { LAYOUT_GAP_REM, GRID_GAP_REM } from "./ui/Spacing";
 
 /**
  * Convenience helper rendering the toggle within its provider. The wrapper
@@ -40,6 +41,18 @@ describe("DesignToggle", () => {
       expect(document.documentElement.getAttribute("data-design")).toBe(design);
     },
   );
+
+  /**
+   * The wrapper element should reflect shared spacing constants so layouts stay
+   * in sync. The numeric values are converted to `rem` units in the component.
+   */
+  it("applies shared padding and gap", () => {
+    const { container } = renderWithProvider();
+    const wrapper = container.firstElementChild as HTMLElement;
+    expect(wrapper.style.padding).toBe(`${LAYOUT_GAP_REM}rem`);
+    expect(wrapper.style.gap).toBe(`${GRID_GAP_REM}rem`);
+    expect(wrapper.style.display).toBe("flex");
+  });
 
   /** Ensure colour mode changes propagate to the root element. */
   it("switches mode", () => {

--- a/web/apps/shell/src/DesignToggle.tsx
+++ b/web/apps/shell/src/DesignToggle.tsx
@@ -1,9 +1,20 @@
 import React from "react";
 import { useDesign } from "./DesignContext";
 import type { Design, Mode } from "./designs";
+import { LAYOUT_GAP_REM, GRID_GAP_REM } from "./ui/Spacing";
 
-/** Consistent spacing for the toggle container. */
-const CONTROL_SPACING = "0.5rem" as const;
+/**
+ * Padding applied around the toggle controls using the shared layout spacing
+ * constant. Converting to `rem` at the call site avoids repeated string
+ * concatenation and keeps the numeric source of truth in `Spacing.ts`.
+ */
+const CONTROL_PADDING = `${LAYOUT_GAP_REM}rem` as const;
+
+/**
+ * Gap between control elements leveraging the grid spacing constant to ensure
+ * consistent rhythm with other UI components.
+ */
+const CONTROL_GAP = `${GRID_GAP_REM}rem` as const;
 
 /** CSS variable exposing the theme's primary accent colour. */
 const ACCENT_VAR = "var(--color-accent)" as const;
@@ -84,9 +95,10 @@ export function DesignToggle() {
   return (
     <div
       style={{
-        padding: CONTROL_SPACING,
+        /** Apply shared spacing constants for consistent layout rhythm. */
+        padding: CONTROL_PADDING,
         display: "flex",
-        gap: CONTROL_SPACING,
+        gap: CONTROL_GAP,
       }}
     >
       <label>


### PR DESCRIPTION
## Summary
- replace hard-coded spacing in `DesignToggle` with shared `LAYOUT_GAP_REM` and `GRID_GAP_REM` values
- add regression test ensuring rendered padding and gap follow the shared constants

## Testing
- `npm --prefix web/apps/shell test`

------
https://chatgpt.com/codex/tasks/task_e_68a79e287798832bab2bd0b56274527d