### PR TITLE
Scope shell theme transitions to explicit class

### DIFF
--- a/web/apps/shell/src/themes/ThemeTransitions.test.tsx
+++ b/web/apps/shell/src/themes/ThemeTransitions.test.tsx
@@ -1,0 +1,71 @@
+import { describe, it, expect } from "vitest";
+import { render } from "@testing-library/react";
+import { readFileSync } from "fs";
+import { fileURLToPath } from "url";
+import { dirname, resolve } from "path";
+
+import { JapaneseLayout } from "./japanese/JapaneseLayout";
+import { BauhausLayout, Block, Line } from "./bauhaus/BauhausLayout";
+import { WHITE } from "./bauhaus/palette";
+import { THEME_TRANSITION_CLASS } from "../ui/ThemeTransitionClass";
+
+/** Resolve path to this test file for locating stylesheets. */
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+/**
+ * Load a theme stylesheet to verify presence of the transition rule.
+ * Using a helper avoids duplicating path resolution logic.
+ */
+function loadCss(relative: string): string {
+  const cssPath = resolve(__dirname, relative);
+  return readFileSync(cssPath, "utf8");
+}
+
+/** Placeholder element rendered in layout sections during tests. */
+const DUMMY = <div />;
+
+describe("theme transition class", () => {
+  it("is defined in Japanese theme CSS", () => {
+    const css = loadCss("./japanese.css");
+    expect(css).toMatch(/\.theme-transition\s*{[^}]*transition/);
+  });
+
+  it("is defined in Bauhaus theme CSS", () => {
+    const css = loadCss("./bauhaus.css");
+    expect(css).toMatch(/\.theme-transition\s*{[^}]*transition/);
+  });
+
+  it("applies to Japanese layout sections", () => {
+    const { container } = render(
+      <JapaneseLayout header={DUMMY} footer={DUMMY}>
+        {DUMMY}
+      </JapaneseLayout>,
+    );
+    const sections = container.querySelectorAll(`.${THEME_TRANSITION_CLASS}`);
+    expect(sections.length).toBe(3);
+  });
+
+  it("applies to Bauhaus layout primitives", () => {
+    const { container: layout } = render(
+      <BauhausLayout header={DUMMY} footer={DUMMY}>
+        {DUMMY}
+      </BauhausLayout>,
+    );
+    expect(layout.querySelectorAll(`.${THEME_TRANSITION_CLASS}`).length).toBe(3);
+
+    const { container: block } = render(
+      <Block color={WHITE} column={1} row={1} />,
+    );
+    expect(
+      block.firstElementChild?.classList.contains(THEME_TRANSITION_CLASS),
+    ).toBe(true);
+
+    const { container: line } = render(
+      <Line color={WHITE} orientation="horizontal" index={1} />,
+    );
+    expect(
+      line.firstElementChild?.classList.contains(THEME_TRANSITION_CLASS),
+    ).toBe(true);
+  });
+});

--- a/web/apps/shell/src/themes/bauhaus.css
+++ b/web/apps/shell/src/themes/bauhaus.css
@@ -23,7 +23,11 @@
   color: var(--color-text);
 }
 
-/* Transition behaviour emphasising motion. */
-:root[data-design="bauhaus"] * {
+/*
+  Transition behaviour emphasising motion. Targeting the dedicated
+  `theme-transition` class avoids the costly universal selector while
+  still animating transforms on explicitly marked elements.
+*/
+:root[data-design="bauhaus"] .theme-transition {
   transition: transform var(--anim-duration) ease-in-out;
 }

--- a/web/apps/shell/src/themes/bauhaus/BauhausLayout.tsx
+++ b/web/apps/shell/src/themes/bauhaus/BauhausLayout.tsx
@@ -2,6 +2,7 @@ import React, { CSSProperties, ReactNode, useMemo } from "react";
 import { useGridTransitions } from "./useGridTransitions";
 import { WHITE, BLACK, RED, BAUHAUS_BLUE, BAUHAUS_YELLOW } from "./palette";
 import { GRID_GAP_REM, LINE_THICKNESS_REM } from "../../ui/Spacing";
+import { THEME_TRANSITION_CLASS } from "../../ui/ThemeTransitionClass";
 
 /** Number of columns used in the Bauhaus grid. */
 export const GRID_COLUMNS = 12 as const;
@@ -67,7 +68,12 @@ export function Block({
     [color, column, columnSpan, row, rowSpan],
   );
 
-  return <div style={{ ...transitionStyle, ...style }} />;
+  return (
+    <div
+      className={THEME_TRANSITION_CLASS}
+      style={{ ...transitionStyle, ...style }}
+    />
+  );
 }
 
 /** Properties accepted by {@link Line}. */
@@ -92,6 +98,7 @@ export function Line({ color, orientation, index }: LineProps) {
   if (orientation === "horizontal") {
     return (
       <div
+        className={THEME_TRANSITION_CLASS}
         style={{
           ...transitionStyle,
           ...base,
@@ -105,6 +112,7 @@ export function Line({ color, orientation, index }: LineProps) {
 
   return (
     <div
+      className={THEME_TRANSITION_CLASS}
       style={{
         ...transitionStyle,
         ...base,
@@ -160,9 +168,24 @@ export function BauhausLayout({
 
   return (
     <div style={containerStyle}>
-      <header style={{ ...transitionStyle, ...spanning }}>{header}</header>
-      <main style={{ ...transitionStyle, ...spanning }}>{children}</main>
-      <footer style={{ ...transitionStyle, ...spanning }}>{footer}</footer>
+      <header
+        className={THEME_TRANSITION_CLASS}
+        style={{ ...transitionStyle, ...spanning }}
+      >
+        {header}
+      </header>
+      <main
+        className={THEME_TRANSITION_CLASS}
+        style={{ ...transitionStyle, ...spanning }}
+      >
+        {children}
+      </main>
+      <footer
+        className={THEME_TRANSITION_CLASS}
+        style={{ ...transitionStyle, ...spanning }}
+      >
+        {footer}
+      </footer>
     </div>
   );
 }

--- a/web/apps/shell/src/themes/japanese.css
+++ b/web/apps/shell/src/themes/japanese.css
@@ -25,9 +25,14 @@
   color: var(--color-text);
 }
 
-/* Transition behaviour for minimalist Japanese designs. */
-:root[data-design="japanese-a"] *,
-:root[data-design="japanese-b"] * {
+/*
+  Transition behaviour for minimalist Japanese designs. The rule targets the
+  shared `theme-transition` class rather than all elements to avoid expensive
+  universal selectors while still animating foreground and background colours
+  for marked components.
+*/
+:root[data-design="japanese-a"] .theme-transition,
+:root[data-design="japanese-b"] .theme-transition {
   transition:
     background-color var(--anim-duration) ease-in-out,
     color var(--anim-duration) ease-in-out;

--- a/web/apps/shell/src/themes/japanese/JapaneseLayout.tsx
+++ b/web/apps/shell/src/themes/japanese/JapaneseLayout.tsx
@@ -1,6 +1,7 @@
 import React, { CSSProperties, ReactNode, useMemo } from "react";
 import { useMinimalFades } from "./useMinimalFades";
 import { LAYOUT_GAP_REM } from "../../ui/Spacing";
+import { THEME_TRANSITION_CLASS } from "../../ui/ThemeTransitionClass";
 
 /** Height of the layout viewport ensuring full-screen coverage. */
 const FULL_HEIGHT = "100vh" as const;
@@ -49,9 +50,18 @@ export function JapaneseLayout({
 
   return (
     <div style={containerStyle}>
-      <header style={fadeStyle}>{header}</header>
-      <main style={{ ...mainStyle, ...fadeStyle }}>{children}</main>
-      <footer style={fadeStyle}>{footer}</footer>
+      <header className={THEME_TRANSITION_CLASS} style={fadeStyle}>
+        {header}
+      </header>
+      <main
+        className={THEME_TRANSITION_CLASS}
+        style={{ ...mainStyle, ...fadeStyle }}
+      >
+        {children}
+      </main>
+      <footer className={THEME_TRANSITION_CLASS} style={fadeStyle}>
+        {footer}
+      </footer>
     </div>
   );
 }

--- a/web/apps/shell/src/ui/ThemeTransitionClass.ts
+++ b/web/apps/shell/src/ui/ThemeTransitionClass.ts
@@ -1,0 +1,6 @@
+/**
+ * CSS class applied to elements requiring theme transitions.
+ * Centralising the name avoids magic strings and keeps usage consistent
+ * across components.
+ */
+export const THEME_TRANSITION_CLASS = "theme-transition" as const;


### PR DESCRIPTION
## Summary
- restrict Bauhaus and Japanese theme transitions to elements with a `theme-transition` class
- apply transition class across layouts and primitives via a shared constant
- test that theme styles and components expose the transition class

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a79e2957e4832bacef2830ee98c93d