### PR TITLE
docs: add testing instructions and RFFT validation comments

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -88,6 +88,8 @@ cargo xtask update-bench-readme
 
 ### Testing
 
+- See [TESTING.md](TESTING.md) for detailed commands to format, lint, test, run
+  specialized checks, and gather coverage.
 - Write unit tests for all new functionality
 - Include property-based tests for mathematical correctness
 - Test both `std` and `no_std` features

--- a/TESTING.md
+++ b/TESTING.md
@@ -1,0 +1,47 @@
+# Testing kofft
+
+This guide explains how to verify that the project builds, lints and passes all tests.
+
+## Formatting
+
+Format the entire workspace to keep code style consistent:
+
+```bash
+cargo fmt --all
+```
+
+## Linting
+
+Run Clippy across all targets and features to catch common mistakes:
+
+```bash
+cargo clippy --all-targets --all-features
+```
+
+## Running the test suite
+
+Execute all tests with every feature enabled:
+
+```bash
+cargo test --all-features
+```
+
+### Specialized tests
+
+Some tests require explicit invocation. For example, the spectrogram parity
+check compares the output of the `spectrogram` example with the `sanity-check`
+binary:
+
+```bash
+cargo test --test spectrogram_parity
+```
+
+## Coverage
+
+To measure test coverage, run Tarpaulin for the entire workspace:
+
+```bash
+cargo tarpaulin --all-features --workspace
+```
+
+Aim for at least **50% line coverage** when adding or modifying code.


### PR DESCRIPTION
## Summary
- add TESTING.md with explicit commands for formatting, linting, tests, specialized spectrogram parity check, and coverage expectations
- reference TESTING.md from CONTRIBUTING guidelines
- document RFFT validation tests and import cache-limit constant

## Testing
- `cargo fmt --all`
- `cargo clippy --all-targets --all-features` *(fails: cannot find type `Vec` in stft.rs, and trait `AsRef<Path>` for `Arc<PathBuf>`)*
- `cargo test --all-features` *(fails: cannot find type `Vec` in stft.rs and `AsRef<Path>` for `Arc<PathBuf>`)*
- `cargo tarpaulin --all-features --workspace` *(command not found; attempted installation but not available)*

------
https://chatgpt.com/codex/tasks/task_e_68a79e6fa590832bbac25487e98edea0