### PR TITLE
tests: name numeric constants

### DIFF
--- a/tests/planner_unsafecell.rs
+++ b/tests/planner_unsafecell.rs
@@ -1,10 +1,16 @@
 // Test intent: verifies planner unsafecell behavior including edge cases.
 use kofft::fft::{Complex32, FftImpl, ScalarFftImpl};
 
+/// Number of complex samples used to exercise sequential planner mutation.
+const SAMPLE_LEN: usize = 8;
+/// Permissible floating-point error tolerance for round-trip FFT comparisons.
+const FLOAT_EPSILON: f32 = 1e-5;
+
+/// Ensure the planner can mutate sequentially without incurring `RefCell` overhead.
 #[test]
 fn planner_allows_sequential_mutation_without_refcell_overhead() {
     let fft = ScalarFftImpl::<f32>::default();
-    let mut data: Vec<Complex32> = (0..8)
+    let mut data: Vec<Complex32> = (0..SAMPLE_LEN)
         .map(|i| Complex32::new(i as f32, -(i as f32)))
         .collect();
     let original = data.clone();
@@ -13,7 +19,7 @@ fn planner_allows_sequential_mutation_without_refcell_overhead() {
     fft.ifft(&mut data).unwrap();
 
     for (a, b) in data.iter().zip(original.iter()) {
-        assert!((a.re - b.re).abs() < 1e-5);
-        assert!((a.im - b.im).abs() < 1e-5);
+        assert!((a.re - b.re).abs() < FLOAT_EPSILON);
+        assert!((a.im - b.im).abs() < FLOAT_EPSILON);
     }
 }

--- a/tests/rfft_twiddles.rs
+++ b/tests/rfft_twiddles.rs
@@ -2,16 +2,25 @@
 use kofft::num::Complex32;
 use kofft::rfft::RfftPlanner;
 
+/// Number of twiddle factors requested for this test to exercise planner caching.
+const TWIDDLE_LEN: usize = 8;
+/// Permissible floating-point error tolerance when comparing twiddle values.
+/// Chosen to exceed expected single-precision rounding error.
+const FLOAT_EPSILON: f32 = 1e-6;
+/// Index of the first non-trivial twiddle factor to validate.
+const TWIDDLE_IDX: usize = 1;
+
+/// Verify that the planner caches and computes RFFT twiddle factors accurately.
 #[test]
 fn planner_twiddles_rfft_f32() {
     let mut planner = RfftPlanner::<f32>::new().unwrap();
-    let tw = planner.get_twiddles(8).unwrap();
-    assert_eq!(tw.len(), 8);
-    let expected = Complex32::expi(-std::f32::consts::PI / 8.0);
-    assert!((tw[1].re - expected.re).abs() < 1e-6);
-    assert!((tw[1].im - expected.im).abs() < 1e-6);
+    let tw = planner.get_twiddles(TWIDDLE_LEN).unwrap();
+    assert_eq!(tw.len(), TWIDDLE_LEN);
+    let expected = Complex32::expi(-std::f32::consts::PI / (TWIDDLE_LEN as f32));
+    assert!((tw[TWIDDLE_IDX].re - expected.re).abs() < FLOAT_EPSILON);
+    assert!((tw[TWIDDLE_IDX].im - expected.im).abs() < FLOAT_EPSILON);
     // Ensure cached reference is reused.
     let ptr1 = tw.as_ptr();
-    let ptr2 = planner.get_twiddles(8).unwrap().as_ptr();
+    let ptr2 = planner.get_twiddles(TWIDDLE_LEN).unwrap().as_ptr();
     assert_eq!(ptr1, ptr2);
 }


### PR DESCRIPTION
## Summary
- replace magic numbers in rfft_twiddles with named constants for length, epsilon, and index
- define and use documented constants for STFT parallel test parameters and call counting
- extract sample length and epsilon constants in planner_unsafecell test

## Testing
- `cargo fmt`
- `cargo clippy --tests --features parallel`
- `cargo test --features parallel` *(fails: wavelet_multi::haar_multi_roundtrip_even and related tests return InvalidLevels)*

------
https://chatgpt.com/codex/tasks/task_e_68a79e6bdbd8832bb64b99eee58cbfc1