### PR TITLE
feat(shell): add playwright e2e tests

### DIFF
--- a/web/apps/shell/e2e/design-mode.spec.ts
+++ b/web/apps/shell/e2e/design-mode.spec.ts
@@ -1,0 +1,68 @@
+import { test, expect } from '@playwright/test';
+import { PALETTES, Design, Mode } from '../src/designs';
+
+/** Selector for the HTML root element used to store attributes. */
+const ROOT_SELECTOR = 'html';
+/** Selector for the design dropdown control. */
+const DESIGN_SELECT = '[data-testid="design-select"]';
+/** Selector for the mode dropdown control. */
+const MODE_SELECT = '[data-testid="mode-select"]';
+
+/** CSS variable holding the background colour. */
+const VAR_BG = '--color-bg';
+/** CSS variable holding the default text colour. */
+const VAR_TEXT = '--color-text';
+/** CSS variable holding the primary accent colour. */
+const VAR_ACCENT = '--color-accent';
+/** CSS variable holding the secondary accent colour. */
+const VAR_SECONDARY = '--color-secondary';
+/** CSS variable holding the tertiary accent colour. */
+const VAR_TERTIARY = '--color-tertiary';
+
+/** Designs supported by the application under test. */
+const DESIGNS: readonly Design[] = ['japanese-a', 'japanese-b', 'bauhaus'];
+/** Colour modes toggled by the user. */
+const MODES: readonly Mode[] = ['light', 'dark'];
+
+/**
+ * Retrieve a computed CSS variable from the document root.
+ * @param page Playwright page instance.
+ * @param name Name of the CSS variable to read.
+ * @returns The trimmed value of the variable.
+ */
+async function readVar(page: any, name: string): Promise<string> {
+  return page.evaluate((n) => getComputedStyle(document.documentElement).getPropertyValue(n).trim(), name);
+}
+
+/**
+ * Cycle through all design and mode combinations, ensuring the DOM attributes
+ * and CSS variables reflect the expected palette values.
+ */
+test('design and mode toggling updates attributes and CSS variables', async ({ page }) => {
+  await page.goto('/');
+  for (const design of DESIGNS) {
+    await page.locator(DESIGN_SELECT).selectOption(design);
+    for (const mode of MODES) {
+      await page.locator(MODE_SELECT).selectOption(mode);
+      const root = page.locator(ROOT_SELECTOR);
+      await expect(root).toHaveAttribute('data-design', design);
+      await expect(root).toHaveAttribute('data-mode', mode);
+      const palette = PALETTES[design][mode];
+      expect(await readVar(page, VAR_BG)).toBe(palette.background);
+      expect(await readVar(page, VAR_TEXT)).toBe(palette.text);
+      expect(await readVar(page, VAR_ACCENT)).toBe(palette.accent);
+      const secondary = await readVar(page, VAR_SECONDARY);
+      if (palette.secondary) {
+        expect(secondary).toBe(palette.secondary);
+      } else {
+        expect(secondary).toBe('');
+      }
+      const tertiary = await readVar(page, VAR_TERTIARY);
+      if (palette.tertiary) {
+        expect(tertiary).toBe(palette.tertiary);
+      } else {
+        expect(tertiary).toBe('');
+      }
+    }
+  }
+});

--- a/web/apps/shell/e2e/global-setup.ts
+++ b/web/apps/shell/e2e/global-setup.ts
@@ -1,0 +1,17 @@
+import { chromium, FullConfig } from '@playwright/test';
+
+/**
+ * Ensure the development server is reachable before tests execute.
+ * The check fails fast so misconfigured environments surface quickly.
+ */
+export default async function globalSetup(config: FullConfig): Promise<void> {
+  const { baseURL } = config.projects[0].use;
+  const browser = await chromium.launch();
+  try {
+    const page = await browser.newPage();
+    await page.goto(baseURL, { waitUntil: 'domcontentloaded', timeout: 30000 });
+    await page.waitForSelector('#root', { timeout: 10000 });
+  } finally {
+    await browser.close();
+  }
+}

--- a/web/apps/shell/e2e/global-teardown.ts
+++ b/web/apps/shell/e2e/global-teardown.ts
@@ -1,0 +1,8 @@
+/**
+ * Global teardown hook mirrored from the spectrogram project.
+ * Currently no explicit cleanup is required but the hook is
+ * retained for symmetry and future extensibility.
+ */
+export default async function globalTeardown(): Promise<void> {
+  // No resources to release.
+}

--- a/web/apps/shell/package-lock.json
+++ b/web/apps/shell/package-lock.json
@@ -13,12 +13,14 @@
       },
       "devDependencies": {
         "@originjs/vite-plugin-federation": "^1.3.7",
+        "@playwright/test": "^1.42.1",
         "@testing-library/dom": "^10.4.1",
         "@testing-library/react": "^16.3.0",
         "@types/react": "^18.3.5",
         "@types/react-dom": "^18.3.0",
         "@vitejs/plugin-react": "^4.3.1",
         "@vitest/coverage-v8": "^3.2.4",
+        "allure-playwright": "^3.3.3",
         "jsdom": "^26.1.0",
         "typescript": "^5.5.4",
         "vite": "^5.4.2",
@@ -913,6 +915,22 @@
         "node": ">=14"
       }
     },
+    "node_modules/@playwright/test": {
+      "version": "1.55.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.55.0.tgz",
+      "integrity": "sha512-04IXzPwHrW69XusN/SIdDdKZBzMfOT9UNT/YiJit/xpy2VuAoB8NHc8Aplb96zsWDddLnbkPL3TsmrS04ZU2xQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.55.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@rolldown/pluginutils": {
       "version": "1.0.0-beta.27",
       "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-beta.27.tgz",
@@ -1532,6 +1550,37 @@
         "node": ">= 14"
       }
     },
+    "node_modules/allure-js-commons": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/allure-js-commons/-/allure-js-commons-3.3.3.tgz",
+      "integrity": "sha512-MLkPWrVtrt/2TdAvaExNSM8yTuY/lEo+MSLoM2DOUUsWzbzki8XIxHoX+mSdkatZAJargsU9JeO/dL5kQyR5IQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "md5": "^2.3.0"
+      },
+      "peerDependencies": {
+        "allure-playwright": "3.3.3"
+      },
+      "peerDependenciesMeta": {
+        "allure-playwright": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/allure-playwright": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/allure-playwright/-/allure-playwright-3.3.3.tgz",
+      "integrity": "sha512-f5+PsYJVBG9igcD2ldzRHOx4kMiuqyoezpneQd94R08I/S3lL/MvdMNmkT1vet8KYB8tsV1OuK17PZexnFaC+w==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "allure-js-commons": "3.3.3"
+      },
+      "peerDependencies": {
+        "@playwright/test": ">=1.36.0"
+      }
+    },
     "node_modules/ansi-regex": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
@@ -1690,6 +1739,16 @@
         "node": ">=18"
       }
     },
+    "node_modules/charenc": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/charenc/-/charenc-0.0.2.tgz",
+      "integrity": "sha512-yrLQ/yVUFXkzg7EDQsPieE/53+0RlaWTs+wBrvW36cyilJ2SaDWfl4Yj7MtLTXleV9uEKefbAGUPv2/iWSooRA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/check-error": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.1.tgz",
@@ -1739,6 +1798,16 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/crypt": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/crypt/-/crypt-0.0.2.tgz",
+      "integrity": "sha512-mCxBlsHFYh9C+HVpiEacem8FEBnMXgU9gy4zmNC+SXAZNB/1idgp/aulFJ4FgCi7GPEVbfyng092GqL2k2rmow==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/cssstyle": {
@@ -2082,6 +2151,13 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/is-buffer": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
+      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/is-fullwidth-code-point": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
@@ -2335,6 +2411,18 @@
         "node": ">=10"
       }
     },
+    "node_modules/md5": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/md5/-/md5-2.3.0.tgz",
+      "integrity": "sha512-T1GITYmFaKuO91vxyoQMFETst+O71VUPEU3ze5GNzDm0OWdP8v1ziTaAEPUr/3kLsY3Sftgz242A1SetQiDL7g==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "charenc": "0.0.2",
+        "crypt": "0.0.2",
+        "is-buffer": "~1.1.6"
+      }
+    },
     "node_modules/minimatch": {
       "version": "9.0.5",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
@@ -2486,6 +2574,53 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.55.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.55.0.tgz",
+      "integrity": "sha512-sdCWStblvV1YU909Xqx0DhOjPZE4/5lJsIS84IfN9dAZfcl/CIZ5O8l3o0j7hPMjDvqoTF8ZUcc+i/GL5erstA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.55.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.55.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.55.0.tgz",
+      "integrity": "sha512-GvZs4vU3U5ro2nZpeiwyb0zuFaqb9sUiAJuyrWpcGouD8y9/HLgGbNRjIph7zU9D3hnPaisMl9zG9CgFi/biIg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/postcss": {

--- a/web/apps/shell/package.json
+++ b/web/apps/shell/package.json
@@ -9,7 +9,14 @@
     "build": "npm run generate:css && vite build",
     "preview": "vite preview --port 5173",
     "pretest": "npm run generate:css",
-    "test": "vitest run --coverage"
+    "test": "vitest run --coverage --exclude \"e2e/**\"",
+    "test:e2e": "playwright test",
+    "test:e2e:ui": "playwright test --ui",
+    "test:e2e:headed": "playwright test --headed",
+    "test:e2e:debug": "playwright test --debug",
+    "test:e2e:report": "playwright show-report",
+    "test:e2e:install": "playwright install",
+    "test:e2e:install-deps": "playwright install-deps"
   },
   "dependencies": {
     "react": "^18.3.1",
@@ -26,6 +33,8 @@
     "jsdom": "^26.1.0",
     "typescript": "^5.5.4",
     "vite": "^5.4.2",
-    "vitest": "^3.2.4"
+    "vitest": "^3.2.4",
+    "@playwright/test": "^1.42.1",
+    "allure-playwright": "^3.3.3"
   }
 }

--- a/web/apps/shell/playwright.config.ts
+++ b/web/apps/shell/playwright.config.ts
@@ -1,0 +1,90 @@
+import { defineConfig, devices } from '@playwright/test';
+
+/**
+ * Playwright configuration for the shell application.
+ * Mirrors the spectrogram setup while adjusting the base URL
+ * and test directory for this app.
+ */
+export default defineConfig({
+  /** Directory containing end-to-end tests. */
+  testDir: './e2e',
+  /** Execute tests in parallel to reduce runtime. */
+  fullyParallel: true,
+  /** Prevent accidental commit of focused tests. */
+  forbidOnly: !!process.env.CI,
+  /** Retry failing tests on CI for increased stability. */
+  retries: process.env.CI ? 2 : 0,
+  /** Disable parallel workers on CI to limit resource usage. */
+  workers: process.env.CI ? 1 : undefined,
+  /** Reporters used to generate various test artifacts. */
+  reporter: [
+    ['html'],
+    ['json', { outputFile: 'test-results/results.json' }],
+    ['junit', { outputFile: 'test-results/results.xml' }],
+    ['allure-playwright', { outputFolder: 'test-results/allure-results' }]
+  ],
+  /** Shared context configuration for all tests. */
+  use: {
+    /** Base URL used by `page.goto('/')`. */
+    baseURL: 'http://localhost:5173',
+    /** Enable tracing on first retry to aid debugging. */
+    trace: 'on-first-retry',
+    /** Capture screenshots only on failure. */
+    screenshot: 'only-on-failure',
+    /** Record video artifacts when tests fail. */
+    video: 'retain-on-failure',
+    /** Timeout for individual user actions. */
+    actionTimeout: 10000,
+    /** Timeout for page navigation events. */
+    navigationTimeout: 30000,
+  },
+  /** Browsers and devices under test. */
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] },
+    },
+    {
+      name: 'firefox',
+      use: { ...devices['Desktop Firefox'] },
+    },
+    {
+      name: 'webkit',
+      use: { ...devices['Desktop Safari'] },
+    },
+    {
+      name: 'Mobile Chrome',
+      use: { ...devices['Pixel 5'] },
+    },
+    {
+      name: 'Mobile Safari',
+      use: { ...devices['iPhone 12'] },
+    },
+    // System-installed browsers such as Edge and Chrome are omitted to
+    // avoid dependence on external installations in test environments.
+  ],
+  /** Start the development server before running tests. */
+  webServer: {
+    command: 'npm run dev',
+    url: 'http://localhost:5173',
+    reuseExistingServer: !process.env.CI,
+    timeout: 120 * 1000,
+  },
+  /** Global lifecycle hooks for setup and teardown. */
+  globalSetup: './e2e/global-setup.ts',
+  globalTeardown: './e2e/global-teardown.ts',
+  /** Directory for artifacts produced during test runs. */
+  outputDir: 'test-results/',
+  /** Maximum allowed time for the entire test run. */
+  timeout: 300000,
+  /** Expectation timeout for each assertion. */
+  expect: {
+    timeout: 10000,
+  },
+  /** Metadata included in generated reports. */
+  metadata: {
+    name: 'Kofft Shell E2E Tests',
+    description: 'End-to-end tests for the Kofft Shell application',
+    version: '1.0.0',
+  },
+});


### PR DESCRIPTION
## Summary
- add Playwright configuration and global hooks for shell app
- cover design and mode toggling with new e2e spec
- wire up Playwright scripts and dependencies

## Testing
- `npm run test:e2e`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a79e2a9088832bb9c227b72403046a